### PR TITLE
feat: add parallel scenario evaluation

### DIFF
--- a/docker/Dockerfile.validator
+++ b/docker/Dockerfile.validator
@@ -62,6 +62,7 @@ COPY trajectoryrl/ trajectoryrl/
 COPY neurons/ neurons/
 COPY scripts/ scripts/
 COPY clawbench/ clawbench/
+COPY eval_parallel_test.py ./
 
 RUN pip install --no-cache-dir -e . && \
     pip install --no-cache-dir -r clawbench/requirements.txt && \
@@ -95,5 +96,7 @@ ENV OPENCLAW_URL=http://localhost:18789
 ENV MOCK_TOOLS_URL=http://localhost:3001
 ENV FIXTURES_PATH=/app/clawbench/fixtures
 ENV SCENARIO=client_escalation
+# Parallel evaluation (set PARALLEL_SCENARIOS=1 to enable)
+ENV PARALLEL_SCENARIOS=0
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/docker-compose.parallel-test.yml
+++ b/docker/docker-compose.parallel-test.yml
@@ -1,0 +1,48 @@
+# TrajectoryRL — Parallel Evaluation Test
+#
+# Tests parallel scenario evaluation using the same all-in-one image.
+# Uses PARALLEL_SCENARIOS=1 to skip single-instance service startup
+# and let ParallelClawBenchHarness manage N service slots.
+#
+# Usage:
+#   # Build and run with a pack file:
+#   docker compose -f docker/docker-compose.parallel-test.yml --env-file .env up --build
+#
+#   # View logs:
+#   docker compose -f docker/docker-compose.parallel-test.yml logs -f
+#
+#   # Clean up:
+#   docker compose -f docker/docker-compose.parallel-test.yml down
+
+services:
+  parallel-test:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.validator
+    container_name: trajectoryrl_parallel_test
+    network_mode: host
+    env_file:
+      - ../.env
+    environment:
+      # Enable parallel evaluation
+      - PARALLEL_SCENARIOS=1
+      - OPENCLAW_BIN=/app/openclaw
+      # Run the test script instead of the full validator
+      - VALIDATOR_SCRIPT=/app/eval_parallel_test.py
+      # ClawBench config
+      - CLAWBENCH_PATH=/app/clawbench
+      - CLAWBENCH_DEFAULT_MODEL=${CLAWBENCH_DEFAULT_MODEL:-zhipu/glm-5}
+      - CLAWBENCH_LLM_BASE_URL=${CLAWBENCH_LLM_BASE_URL:-https://open.bigmodel.cn/api/paas/v4}
+      - CLAWBENCH_LLM_API_KEY=${CLAWBENCH_LLM_API_KEY:-}
+      # Logging
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    volumes:
+      # Mount pack file (place your pack.json in the repo root)
+      - ../pack.json:/pack.json:ro
+    # Pass pack path as argument (forwarded by entrypoint via $@)
+    command: ["/pack.json"]
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/docker/entrypoint-validator.sh
+++ b/docker/entrypoint-validator.sh
@@ -7,6 +7,11 @@
 #   3. validator    (Python, foreground — PID 1 via exec)
 #
 # On startup, runs init_workspace.py once to set up fixtures + config.
+#
+# Parallel mode (PARALLEL_SCENARIOS=1):
+#   Steps 3-5 (init workspace, mock-tools, OpenClaw) are SKIPPED.
+#   The ParallelClawBenchHarness in the validator Python code manages
+#   N independent service slots, each with its own ports + workspace.
 
 set -euo pipefail
 
@@ -54,6 +59,21 @@ else
     echo "[entrypoint] Pulling latest ClawBench..."
     (cd /app/clawbench && git pull --ff-only origin "$CLAWBENCH_BRANCH") || \
         echo "[entrypoint] WARNING: ClawBench pull failed — using current version"
+fi
+
+# ── Parallel mode check ──────────────────────────────────────────
+# When PARALLEL_SCENARIOS=1, the Python ParallelClawBenchHarness manages
+# its own mock-tools + OpenClaw instances (one per scenario, on different
+# ports). Skip the single-instance startup below.
+PARALLEL_SCENARIOS="${PARALLEL_SCENARIOS:-0}"
+# Configurable main script (default: neurons/validator.py)
+VALIDATOR_SCRIPT="${VALIDATOR_SCRIPT:-neurons/validator.py}"
+
+if [ "$PARALLEL_SCENARIOS" = "1" ]; then
+    echo "[entrypoint] Parallel mode: skipping single-instance service startup"
+    echo "[entrypoint] ParallelClawBenchHarness will start N service slots"
+    echo "[entrypoint] Starting: $VALIDATOR_SCRIPT (parallel mode)..."
+    exec python -u "$VALIDATOR_SCRIPT" "$@"
 fi
 
 # ── 3. Init workspace (one-shot) ────────────────────────────────
@@ -109,5 +129,5 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 # ── 7. Start validator (foreground) ─────────────────────────────
-echo "[entrypoint] Starting validator..."
-exec python -u neurons/validator.py "$@"
+echo "[entrypoint] Starting: $VALIDATOR_SCRIPT..."
+exec python -u "$VALIDATOR_SCRIPT" "$@"

--- a/eval_parallel_test.py
+++ b/eval_parallel_test.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""
+Parallel evaluation test — mimics the validator's _evaluate_miner() flow
+with parallel scenario evaluation.
+
+Replicates the exact same environment and code paths as the production
+validator, but evaluates a single pack (from a JSON file) instead of
+fetching from on-chain commitments.
+
+Usage (inside the all-in-one Docker container):
+    python eval_parallel_test.py /pack.json
+    python eval_parallel_test.py /pack.json --sequential  # compare with serial
+"""
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Any
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger("eval_parallel_test")
+
+from trajectoryrl.utils.config import ValidatorConfig
+from trajectoryrl.utils.clawbench import ClawBenchHarness, EvaluationResult
+from trajectoryrl.utils.parallel_clawbench import ParallelClawBenchHarness
+from trajectoryrl.utils.epoch_context import generate_epoch_context, render_context_preamble
+from trajectoryrl.utils.llm_judge import TrajectoryJudge
+
+
+def compute_epoch_seed(epoch: int, netuid: int = 11) -> int:
+    raw = f"trajectoryrl-{netuid}-epoch-{epoch}".encode()
+    return int(hashlib.sha256(raw).hexdigest()[:8], 16)
+
+
+def process_scenario_result(
+    trajectory_judge: TrajectoryJudge,
+    scenarios: Dict[str, dict],
+    miner_uid: int,
+    scenario_name: str,
+    result: EvaluationResult,
+    scenario_costs: Dict[str, float],
+    scenario_qualified: Dict[str, bool],
+    scenario_token_usage: Dict[str, Dict[str, int]],
+    scenario_model_usage: Dict[str, List[Dict[str, Any]]],
+    scenario_judge_details: Dict[str, Dict[str, Any]],
+) -> None:
+    """Process a single scenario result — identical to validator._process_scenario_result."""
+    if result.error:
+        logger.warning(
+            f"Miner {miner_uid}: {scenario_name} episode error: {result.error}"
+        )
+        scenario_qualified[scenario_name] = False
+        return
+
+    if result.cost_usd is not None:
+        scenario_costs[scenario_name] = result.cost_usd
+    if result.token_usage:
+        scenario_token_usage[scenario_name] = result.token_usage
+    if result.model_usage:
+        scenario_model_usage[scenario_name] = result.model_usage
+
+    # Phase 2: LLM trajectory judge
+    scenario_config = scenarios.get(scenario_name, {})
+    trajectory = result.trajectory or []
+    judge_result = trajectory_judge.evaluate(
+        scenario_config=scenario_config,
+        trajectory=trajectory,
+        agent_response=result.response,
+    )
+
+    qualified = judge_result.qualification_gate
+    scenario_qualified[scenario_name] = qualified
+
+    _criteria = judge_result.criteria_results
+    _n = len(_criteria)
+    _passed = sum(1 for cr in _criteria if cr.verdict == "PASS")
+    _grounded = sum(1 for cr in _criteria if cr.grounded)
+    scenario_judge_details[scenario_name] = {
+        "overall_score": round(judge_result.overall_score, 4),
+        "safety_passed": judge_result.safety_passed,
+        "correctness_passed": judge_result.correctness_passed,
+        "qualification_gate": qualified,
+        "verdict": f"{_passed}/{_n}",
+        "grounded": f"{_grounded}/{_n}",
+        "error": judge_result.error,
+    }
+
+    cost_str = f", cost=${result.cost_usd:.4f}" if result.cost_usd is not None else ""
+    gate_str = "PASS" if qualified else "FAIL"
+    logger.info(
+        f"Miner {miner_uid}: {scenario_name} -> "
+        f"judge={judge_result.overall_score:.3f}{cost_str}, "
+        f"gate={gate_str}, tool_calls={result.tool_calls}"
+    )
+
+    if judge_result.error:
+        logger.warning(f"Miner {miner_uid}: {scenario_name} judge error: {judge_result.error}")
+
+    for cr in judge_result.criteria_results:
+        if cr.verdict != "PASS":
+            logger.info(f"  FAIL {cr.id}: {cr.justification}")
+
+
+async def run_parallel(
+    pack: dict,
+    config: ValidatorConfig,
+    scenarios: Dict[str, dict],
+    eval_scenarios: List[str],
+    epoch_seed: int,
+    context_preamble: str,
+    trajectory_judge: "TrajectoryJudge",
+    user_context: Optional[Dict] = None,
+) -> Dict[str, Any]:
+    """Run all scenarios in parallel — episode + judge per scenario.
+
+    Each scenario runs its episode then immediately runs the LLM judge,
+    all in parallel. No scenario waits for others.
+    """
+    logger.info("=" * 60)
+    logger.info("PARALLEL EVALUATION (episode + judge per slot)")
+    logger.info("=" * 60)
+
+    num_slots = len(eval_scenarios)
+    logger.info(f"Starting {num_slots} parallel service slots...")
+
+    harness = ParallelClawBenchHarness(
+        num_slots=num_slots,
+        clawbench_path=config.clawbench_path,
+        scenario_names=eval_scenarios,
+        timeout=config.timeout_per_scenario,
+        openclaw_bin=config.openclaw_bin,
+        clawbench_default_model=config.clawbench_default_model,
+        clawbench_api_key=config.clawbench_api_key,
+        clawbench_base_url=config.clawbench_base_url,
+    )
+
+    start_time = time.time()
+    await harness.start()
+    startup_time = time.time() - start_time
+    logger.info(f"All {num_slots} slots started in {startup_time:.1f}s")
+
+    # Shared result dicts (populated by each parallel task)
+    scenario_costs: Dict[str, float] = {}
+    scenario_qualified: Dict[str, bool] = {}
+    scenario_token_usage: Dict[str, Dict[str, int]] = {}
+    scenario_model_usage: Dict[str, List[Dict[str, Any]]] = {}
+    scenario_judge_details: Dict[str, Dict[str, Any]] = {}
+
+    try:
+        eval_start = time.time()
+
+        async def _eval_and_judge(scenario_name: str) -> None:
+            result = await harness.evaluate_scenario(
+                pack=pack,
+                scenario_name=scenario_name,
+                seed=epoch_seed,
+                context_preamble=context_preamble,
+                user_context=user_context,
+            )
+            # Run blocking judge call in a thread so it doesn't block
+            # the event loop (other scenarios' episodes keep running)
+            await asyncio.to_thread(
+                process_scenario_result,
+                trajectory_judge=trajectory_judge,
+                scenarios=scenarios,
+                miner_uid=0,
+                scenario_name=scenario_name,
+                result=result,
+                scenario_costs=scenario_costs,
+                scenario_qualified=scenario_qualified,
+                scenario_token_usage=scenario_token_usage,
+                scenario_model_usage=scenario_model_usage,
+                scenario_judge_details=scenario_judge_details,
+            )
+
+        await asyncio.gather(*[_eval_and_judge(s) for s in eval_scenarios])
+
+        eval_time = time.time() - eval_start
+        logger.info(f"Parallel evaluation completed in {eval_time:.1f}s")
+
+        return {
+            "scenario_costs": scenario_costs,
+            "scenario_qualified": scenario_qualified,
+            "scenario_judge_details": scenario_judge_details,
+            "eval_time": eval_time,
+            "startup_time": startup_time,
+        }
+    finally:
+        await harness.stop()
+
+
+async def run_sequential(
+    pack: dict,
+    config: ValidatorConfig,
+    scenarios: Dict[str, dict],
+    eval_scenarios: List[str],
+    epoch_seed: int,
+    context_preamble: str,
+    user_context: Optional[Dict] = None,
+) -> Dict[str, Any]:
+    """Run scenarios sequentially — exactly like the current validator."""
+    logger.info("=" * 60)
+    logger.info("SEQUENTIAL EVALUATION")
+    logger.info("=" * 60)
+
+    harness = ClawBenchHarness(
+        clawbench_path=config.clawbench_path,
+        timeout=config.timeout_per_scenario,
+        clawbench_default_model=config.clawbench_default_model,
+        clawbench_api_key=config.clawbench_api_key,
+        clawbench_base_url=config.clawbench_base_url,
+    )
+
+    results: Dict[str, EvaluationResult] = {}
+    eval_start = time.time()
+
+    for idx, scenario_name in enumerate(eval_scenarios, 1):
+        logger.info(f"Scenario [{idx}/{len(eval_scenarios)}] {scenario_name}...")
+        result = await harness.evaluate_pack(
+            pack=pack,
+            scenario_name=scenario_name,
+            seed=epoch_seed,
+            context_preamble=context_preamble,
+            user_context=user_context,
+        )
+        results[scenario_name] = result
+
+    eval_time = time.time() - eval_start
+    logger.info(f"Sequential evaluation completed in {eval_time:.1f}s")
+
+    return {
+        "results": results,
+        "eval_time": eval_time,
+        "startup_time": 0.0,
+    }
+
+
+async def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Parallel evaluation test")
+    parser.add_argument("pack_path", nargs="?", default="/pack.json",
+                        help="Path to pack JSON file")
+    parser.add_argument("--sequential", action="store_true",
+                        help="Run sequentially instead of parallel (for comparison)")
+    args = parser.parse_args()
+
+    # Load pack
+    with open(args.pack_path) as f:
+        pack = json.load(f)
+    logger.info(f"Loaded pack from {args.pack_path}")
+
+    # --- Exactly what TrajectoryValidator.__init__ does ---
+    config = ValidatorConfig.from_env()
+    # Force parallel mode
+    config.parallel_scenarios = True
+
+    logger.info(f"Model:     {config.clawbench_default_model}")
+    logger.info(f"Base URL:  {config.clawbench_base_url}")
+    logger.info(f"API key:   {config.clawbench_api_key[:8]}..." if config.clawbench_api_key else "API key:   (not set)")
+    logger.info(f"Clawbench: {config.clawbench_path}")
+    logger.info(f"Scenarios: {config.scenarios}")
+
+    # Load scenario configs (same as validator._load_scenarios)
+    import yaml
+    scenarios: Dict[str, dict] = {}
+    for scenario_name in config.scenarios:
+        scenario_path = config.scenarios_path / f"{scenario_name}.yaml"
+        if scenario_path.exists():
+            with open(scenario_path) as f:
+                scenarios[scenario_name] = yaml.safe_load(f)
+    logger.info(f"Loaded {len(scenarios)} scenarios")
+
+    # Initialize LLM judge (same as validator)
+    judge_model = config.judge_model or config.clawbench_default_model
+    judge_api_key = config.judge_api_key or config.clawbench_api_key
+    judge_base_url = config.judge_base_url or config.clawbench_base_url
+    trajectory_judge = TrajectoryJudge(
+        model=judge_model,
+        api_key=judge_api_key,
+        base_url=judge_base_url,
+    )
+
+    # Epoch context (same as validator._run_evaluation_cycle)
+    current_block = 0
+    epoch = current_block // config.eval_interval_blocks
+    epoch_seed = compute_epoch_seed(epoch, config.netuid)
+    epoch_ctx = generate_epoch_context(epoch_seed)
+    context_preamble = render_context_preamble(epoch_ctx)
+    user_context = epoch_ctx.to_user_context()
+
+    logger.info(f"Epoch context (seed={epoch_seed}):")
+    logger.info(f"  Date:     {epoch_ctx.weekday}, {epoch_ctx.date_str}")
+    logger.info(f"  Identity: {epoch_ctx.user_name} / {epoch_ctx.user_role} @ {epoch_ctx.company}")
+
+    eval_scenarios = sorted(config.scenarios)
+
+    # Run evaluation
+    if args.sequential:
+        eval_data = await run_sequential(
+            pack, config, scenarios, eval_scenarios,
+            epoch_seed, context_preamble, user_context,
+        )
+        # Sequential: judge runs after all episodes (existing behavior)
+        scenario_costs: Dict[str, float] = {}
+        scenario_qualified: Dict[str, bool] = {}
+        scenario_token_usage: Dict[str, Dict[str, int]] = {}
+        scenario_model_usage: Dict[str, List[Dict[str, Any]]] = {}
+        scenario_judge_details: Dict[str, Dict[str, Any]] = {}
+        for scenario_name, result in eval_data["results"].items():
+            process_scenario_result(
+                trajectory_judge=trajectory_judge,
+                scenarios=scenarios,
+                miner_uid=0,
+                scenario_name=scenario_name,
+                result=result,
+                scenario_costs=scenario_costs,
+                scenario_qualified=scenario_qualified,
+                scenario_token_usage=scenario_token_usage,
+                scenario_model_usage=scenario_model_usage,
+                scenario_judge_details=scenario_judge_details,
+            )
+    else:
+        eval_data = await run_parallel(
+            pack, config, scenarios, eval_scenarios,
+            epoch_seed, context_preamble, trajectory_judge,
+            user_context,
+        )
+        # Parallel: judge already ran inside each parallel task
+        scenario_costs = eval_data["scenario_costs"]
+        scenario_qualified = eval_data["scenario_qualified"]
+        scenario_judge_details = eval_data["scenario_judge_details"]
+
+    # --- Summary ---
+    mode = "SEQUENTIAL" if args.sequential else "PARALLEL"
+    print(f"\n{'='*60}")
+    print(f"  {mode} EVALUATION RESULTS")
+    print(f"{'='*60}")
+    print(f"  {'Scenario':<25} {'Gate':>4}  {'Cost':>8}  {'Judge':>6}")
+    print(f"  {'-'*25} {'-'*4}  {'-'*8}  {'-'*6}")
+    for s in eval_scenarios:
+        gate = "PASS" if scenario_qualified.get(s) else "FAIL"
+        cost = f"${scenario_costs[s]:.4f}" if s in scenario_costs else "n/a"
+        jd = scenario_judge_details.get(s, {})
+        judge_score = f"{jd.get('overall_score', 0):.3f}" if jd else "n/a"
+        print(f"  {s:<25} {gate:>4}  {cost:>8}  {judge_score:>6}")
+    print(f"  {'-'*25} {'-'*4}  {'-'*8}  {'-'*6}")
+
+    total_cost = sum(scenario_costs.values())
+    passed = sum(1 for v in scenario_qualified.values() if v)
+    total = len(scenario_qualified)
+    print(f"  Qualification: {passed}/{total} scenarios passed")
+    print(f"  Total cost:    ${total_cost:.4f}")
+    print(f"  Eval time:     {eval_data['eval_time']:.1f}s")
+    if eval_data.get("startup_time"):
+        print(f"  Startup time:  {eval_data['startup_time']:.1f}s")
+    print(f"  Total time:    {eval_data['eval_time'] + eval_data.get('startup_time', 0):.1f}s")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -34,6 +34,7 @@ import bittensor as bt
 from ..utils.opp_schema import validate_opp_schema
 from ..utils.config import ValidatorConfig
 from ..utils.clawbench import ClawBenchHarness, EvaluationResult
+from ..utils.parallel_clawbench import ParallelClawBenchHarness
 from ..scoring import TrajectoryScorer
 from ..utils.github import PackFetcher
 from ..utils.epoch_context import generate_epoch_context, render_context_preamble
@@ -128,6 +129,24 @@ class TrajectoryValidator:
             api_key=judge_api_key,
             base_url=judge_base_url,
         )
+
+        # Parallel evaluation harness (v4.1): spins up N service slots
+        self.parallel_harness: Optional[ParallelClawBenchHarness] = None
+        if config.parallel_scenarios:
+            num_slots = len(config.scenarios)
+            logger.info(
+                "Initializing parallel ClawBench harness (%d slots)...", num_slots
+            )
+            self.parallel_harness = ParallelClawBenchHarness(
+                num_slots=num_slots,
+                clawbench_path=config.clawbench_path,
+                scenario_names=sorted(config.scenarios),
+                timeout=config.timeout_per_scenario,
+                openclaw_bin=config.openclaw_bin,
+                clawbench_default_model=config.clawbench_default_model,
+                clawbench_api_key=config.clawbench_api_key,
+                clawbench_base_url=config.clawbench_base_url,
+            )
 
         logger.info("Initializing pack fetcher...")
         self.pack_fetcher = PackFetcher(
@@ -1100,6 +1119,110 @@ class TrajectoryValidator:
             )
 
     # ------------------------------------------------------------------
+    # Scenario result processing (used by parallel path)
+    # ------------------------------------------------------------------
+
+    def _process_scenario_result(
+        self,
+        miner_uid: int,
+        scenario_name: str,
+        result: EvaluationResult,
+        scenario_costs: Dict[str, float],
+        scenario_qualified: Dict[str, bool],
+        scenario_token_usage: Dict[str, Dict[str, int]],
+        scenario_model_usage: Dict[str, List[Dict[str, Any]]],
+        scenario_judge_details: Dict[str, Dict[str, Any]],
+    ) -> None:
+        """Process a single scenario's EvaluationResult through the LLM judge.
+
+        Populates the mutable dicts with costs, qualification, token/model usage,
+        and judge details for this scenario.
+        """
+        if result.error:
+            logger.warning(
+                f"Miner {miner_uid}: {scenario_name} episode error: "
+                f"{result.error}"
+            )
+            scenario_qualified[scenario_name] = False
+            return
+
+        if result.cost_usd is not None:
+            scenario_costs[scenario_name] = result.cost_usd
+        if result.token_usage:
+            scenario_token_usage[scenario_name] = result.token_usage
+        if result.model_usage:
+            scenario_model_usage[scenario_name] = result.model_usage
+
+        # Phase 2: LLM trajectory judge
+        scenario_config = self.scenarios.get(scenario_name, {})
+        trajectory = result.trajectory or []
+        judge_result = self.trajectory_judge.evaluate(
+            scenario_config=scenario_config,
+            trajectory=trajectory,
+            agent_response=result.response,
+        )
+
+        qualified = judge_result.qualification_gate
+        scenario_qualified[scenario_name] = qualified
+
+        # Store full judge details for dashboard reporting
+        _criteria = judge_result.criteria_results
+        _n = len(_criteria)
+        _passed = sum(1 for cr in _criteria if cr.verdict == "PASS")
+        _grounded = sum(1 for cr in _criteria if cr.grounded)
+        scenario_judge_details[scenario_name] = {
+            "overall_score": round(judge_result.overall_score, 4),
+            "safety_passed": judge_result.safety_passed,
+            "correctness_passed": judge_result.correctness_passed,
+            "qualification_gate": qualified,
+            "verdict": f"{_passed}/{_n}",
+            "grounded": f"{_grounded}/{_n}",
+            "error": judge_result.error,
+        }
+
+        cost_str = (
+            f", cost=${result.cost_usd:.4f}"
+            if result.cost_usd is not None
+            else ""
+        )
+        gate_str = "PASS" if qualified else "FAIL"
+        logger.info(
+            f"Miner {miner_uid}: {scenario_name} -> "
+            f"judge={judge_result.overall_score:.3f}{cost_str}, "
+            f"gate={gate_str}, tool_calls={result.tool_calls}"
+        )
+        if result.token_usage:
+            tu = result.token_usage
+            logger.info(
+                f"Miner {miner_uid}: {scenario_name}   "
+                f"tokens: input={tu.get('input_tokens', 0)}, "
+                f"output={tu.get('output_tokens', 0)}, "
+                f"cache_read={tu.get('cache_read_tokens', 0)}, "
+                f"cache_write={tu.get('cache_write_tokens', 0)}"
+            )
+
+        if judge_result.error:
+            logger.warning(
+                f"Miner {miner_uid}: {scenario_name} judge error: "
+                f"{judge_result.error}"
+            )
+
+        # Log per-criterion details
+        for cr in judge_result.criteria_results:
+            if cr.verdict != "PASS":
+                logger.info(
+                    f"  FAIL {cr.id}: {cr.justification}"
+                )
+        if result.model_usage:
+            for m in result.model_usage:
+                logger.info(
+                    f"Miner {miner_uid}: {scenario_name}   "
+                    f"{m.get('model', '?')}: "
+                    f"${m.get('cost_usd', 0):.4f} "
+                    f"({m.get('count', 0)} calls)"
+                )
+
+    # ------------------------------------------------------------------
     # Miner evaluation
     # ------------------------------------------------------------------
 
@@ -1206,141 +1329,178 @@ class TrajectoryValidator:
         scenario_model_usage: Dict[str, List[Dict[str, Any]]] = {}
         scenario_judge_details: Dict[str, Dict[str, Any]] = {}
 
-        total_scenarios = len(eval_scenarios)
-        for scenario_idx, scenario_name in enumerate(eval_scenarios, 1):
+        if self.parallel_harness is not None:
+            # ── Parallel evaluation: episode + judge per scenario ──
+            # Each scenario runs its episode then immediately runs the LLM
+            # judge, all in parallel. No scenario waits for others.
             logger.info(
-                f"Miner {miner_uid}: scenario [{scenario_idx}/{total_scenarios}] "
-                f"{scenario_name} ..."
+                f"Miner {miner_uid}: running {len(eval_scenarios)} scenarios "
+                f"in parallel (episode + judge per slot)..."
             )
-            try:
-                # Single episode per scenario (no consensus voting in v4.0)
-                result = await self.harness.evaluate_pack(
+
+            async def _eval_and_judge(scenario_name: str) -> None:
+                result = await self.parallel_harness.evaluate_scenario(
                     pack=pack,
                     scenario_name=scenario_name,
                     seed=epoch_seed,
                     context_preamble=context_preamble,
                     user_context=user_context,
                 )
+                # Run blocking judge call in a thread so it doesn't block
+                # the event loop (other scenarios' episodes keep running)
+                await asyncio.to_thread(
+                    self._process_scenario_result,
+                    miner_uid=miner_uid,
+                    scenario_name=scenario_name,
+                    result=result,
+                    scenario_costs=scenario_costs,
+                    scenario_qualified=scenario_qualified,
+                    scenario_token_usage=scenario_token_usage,
+                    scenario_model_usage=scenario_model_usage,
+                    scenario_judge_details=scenario_judge_details,
+                )
 
-                if result.error:
-                    logger.warning(
-                        f"Miner {miner_uid}: {scenario_name} episode error: "
-                        f"{result.error}"
+            await asyncio.gather(
+                *[_eval_and_judge(s) for s in eval_scenarios]
+            )
+
+        else:
+            # ── Sequential evaluation: fail-fast on first failure ──
+            total_scenarios = len(eval_scenarios)
+            for scenario_idx, scenario_name in enumerate(eval_scenarios, 1):
+                logger.info(
+                    f"Miner {miner_uid}: scenario [{scenario_idx}/{total_scenarios}] "
+                    f"{scenario_name} ..."
+                )
+                try:
+                    # Single episode per scenario (no consensus voting in v4.0)
+                    result = await self.harness.evaluate_pack(
+                        pack=pack,
+                        scenario_name=scenario_name,
+                        seed=epoch_seed,
+                        context_preamble=context_preamble,
+                        user_context=user_context,
+                    )
+
+                    if result.error:
+                        logger.warning(
+                            f"Miner {miner_uid}: {scenario_name} episode error: "
+                            f"{result.error}"
+                        )
+                        scenario_qualified[scenario_name] = False
+                        remaining = [s for s in eval_scenarios if s not in scenario_qualified]
+                        if remaining:
+                            logger.info(
+                                f"Miner {miner_uid}: fail-fast, "
+                                f"skipping {len(remaining)} remaining scenarios"
+                            )
+                            for s in remaining:
+                                scenario_qualified[s] = False
+                        break
+
+                    if result.cost_usd is not None:
+                        scenario_costs[scenario_name] = result.cost_usd
+                    if result.token_usage:
+                        scenario_token_usage[scenario_name] = result.token_usage
+                    if result.model_usage:
+                        scenario_model_usage[scenario_name] = result.model_usage
+
+                    # Phase 2: LLM trajectory judge
+                    scenario_config = self.scenarios.get(scenario_name, {})
+                    trajectory = result.trajectory or []
+                    judge_result = self.trajectory_judge.evaluate(
+                        scenario_config=scenario_config,
+                        trajectory=trajectory,
+                        agent_response=result.response,
+                    )
+
+                    qualified = judge_result.qualification_gate
+                    scenario_qualified[scenario_name] = qualified
+
+                    # Store full judge details for dashboard reporting
+                    _criteria = judge_result.criteria_results
+                    _n = len(_criteria)
+                    _passed = sum(1 for cr in _criteria if cr.verdict == "PASS")
+                    _grounded = sum(1 for cr in _criteria if cr.grounded)
+                    scenario_judge_details[scenario_name] = {
+                        "overall_score": round(judge_result.overall_score, 4),
+                        "safety_passed": judge_result.safety_passed,
+                        "correctness_passed": judge_result.correctness_passed,
+                        "qualification_gate": qualified,
+                        "verdict": f"{_passed}/{_n}",
+                        "grounded": f"{_grounded}/{_n}",
+                        "error": judge_result.error,
+                    }
+
+                    cost_str = (
+                        f", cost=${result.cost_usd:.4f}"
+                        if result.cost_usd is not None
+                        else ""
+                    )
+                    gate_str = "PASS" if qualified else "FAIL"
+                    logger.info(
+                        f"Miner {miner_uid}: {scenario_name} -> "
+                        f"judge={judge_result.overall_score:.3f}{cost_str}, "
+                        f"gate={gate_str}, tool_calls={result.tool_calls}"
+                    )
+                    if result.token_usage:
+                        tu = result.token_usage
+                        logger.info(
+                            f"Miner {miner_uid}: {scenario_name}   "
+                            f"tokens: input={tu.get('input_tokens', 0)}, "
+                            f"output={tu.get('output_tokens', 0)}, "
+                            f"cache_read={tu.get('cache_read_tokens', 0)}, "
+                            f"cache_write={tu.get('cache_write_tokens', 0)}"
+                        )
+
+                    if judge_result.error:
+                        logger.warning(
+                            f"Miner {miner_uid}: {scenario_name} judge error: "
+                            f"{judge_result.error}"
+                        )
+
+                    # Log per-criterion details
+                    for cr in judge_result.criteria_results:
+                        if cr.verdict != "PASS":
+                            logger.info(
+                                f"  FAIL {cr.id}: {cr.justification}"
+                            )
+                    if result.model_usage:
+                        for m in result.model_usage:
+                            logger.info(
+                                f"Miner {miner_uid}: {scenario_name}   "
+                                f"{m.get('model', '?')}: "
+                                f"${m.get('cost_usd', 0):.4f} "
+                                f"({m.get('count', 0)} calls)"
+                            )
+
+                    # Fail fast: any scenario failure → skip remaining
+                    if not qualified:
+                        remaining = [s for s in eval_scenarios if s not in scenario_qualified]
+                        if remaining:
+                            logger.info(
+                                f"Miner {miner_uid}: fail-fast on {scenario_name}, "
+                                f"skipping {len(remaining)} remaining scenarios"
+                            )
+                            for s in remaining:
+                                scenario_qualified[s] = False
+                        break
+
+                except Exception as e:
+                    logger.error(
+                        f"Miner {miner_uid}: {scenario_name} failed: {e}",
+                        exc_info=True,
                     )
                     scenario_qualified[scenario_name] = False
                     remaining = [s for s in eval_scenarios if s not in scenario_qualified]
                     if remaining:
                         logger.info(
-                            f"Miner {miner_uid}: fail-fast, "
+                            f"Miner {miner_uid}: fail-fast on {scenario_name} exception, "
                             f"skipping {len(remaining)} remaining scenarios"
                         )
                         for s in remaining:
                             scenario_qualified[s] = False
                     break
-
-                if result.cost_usd is not None:
-                    scenario_costs[scenario_name] = result.cost_usd
-                if result.token_usage:
-                    scenario_token_usage[scenario_name] = result.token_usage
-                if result.model_usage:
-                    scenario_model_usage[scenario_name] = result.model_usage
-
-                # Phase 2: LLM trajectory judge
-                scenario_config = self.scenarios.get(scenario_name, {})
-                trajectory = result.trajectory or []
-                judge_result = self.trajectory_judge.evaluate(
-                    scenario_config=scenario_config,
-                    trajectory=trajectory,
-                    agent_response=result.response,
-                )
-
-                qualified = judge_result.qualification_gate
-                scenario_qualified[scenario_name] = qualified
-
-                # Store full judge details for dashboard reporting
-                _criteria = judge_result.criteria_results
-                _n = len(_criteria)
-                _passed = sum(1 for cr in _criteria if cr.verdict == "PASS")
-                _grounded = sum(1 for cr in _criteria if cr.grounded)
-                scenario_judge_details[scenario_name] = {
-                    "overall_score": round(judge_result.overall_score, 4),
-                    "safety_passed": judge_result.safety_passed,
-                    "correctness_passed": judge_result.correctness_passed,
-                    "qualification_gate": qualified,
-                    "verdict": f"{_passed}/{_n}",
-                    "grounded": f"{_grounded}/{_n}",
-                    "error": judge_result.error,
-                }
-
-                cost_str = (
-                    f", cost=${result.cost_usd:.4f}"
-                    if result.cost_usd is not None
-                    else ""
-                )
-                gate_str = "PASS" if qualified else "FAIL"
-                logger.info(
-                    f"Miner {miner_uid}: {scenario_name} -> "
-                    f"judge={judge_result.overall_score:.3f}{cost_str}, "
-                    f"gate={gate_str}, tool_calls={result.tool_calls}"
-                )
-                if result.token_usage:
-                    tu = result.token_usage
-                    logger.info(
-                        f"Miner {miner_uid}: {scenario_name}   "
-                        f"tokens: input={tu.get('input_tokens', 0)}, "
-                        f"output={tu.get('output_tokens', 0)}, "
-                        f"cache_read={tu.get('cache_read_tokens', 0)}, "
-                        f"cache_write={tu.get('cache_write_tokens', 0)}"
-                    )
-
-                if judge_result.error:
-                    logger.warning(
-                        f"Miner {miner_uid}: {scenario_name} judge error: "
-                        f"{judge_result.error}"
-                    )
-
-                # Log per-criterion details
-                for cr in judge_result.criteria_results:
-                    if cr.verdict != "PASS":
-                        logger.info(
-                            f"  FAIL {cr.id}: {cr.justification}"
-                        )
-                if result.model_usage:
-                    for m in result.model_usage:
-                        logger.info(
-                            f"Miner {miner_uid}: {scenario_name}   "
-                            f"{m.get('model', '?')}: "
-                            f"${m.get('cost_usd', 0):.4f} "
-                            f"({m.get('count', 0)} calls)"
-                        )
-
-                # Fail fast: any scenario failure → skip remaining
-                if not qualified:
-                    remaining = [s for s in eval_scenarios if s not in scenario_qualified]
-                    if remaining:
-                        logger.info(
-                            f"Miner {miner_uid}: fail-fast on {scenario_name}, "
-                            f"skipping {len(remaining)} remaining scenarios"
-                        )
-                        for s in remaining:
-                            scenario_qualified[s] = False
-                    break
-
-            except Exception as e:
-                logger.error(
-                    f"Miner {miner_uid}: {scenario_name} failed: {e}",
-                    exc_info=True,
-                )
-                scenario_qualified[scenario_name] = False
-                remaining = [s for s in eval_scenarios if s not in scenario_qualified]
-                if remaining:
-                    logger.info(
-                        f"Miner {miner_uid}: fail-fast on {scenario_name} exception, "
-                        f"skipping {len(remaining)} remaining scenarios"
-                    )
-                    for s in remaining:
-                        scenario_qualified[s] = False
-                break
 
         if not scenario_qualified:
             logger.warning(f"Miner {miner_uid}: No scenario results!")

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -70,7 +70,7 @@ class ValidatorConfig:
     # Evaluation config
     seeds_per_task: int = 1
     eval_interval_blocks: int = 7200  # ~24 hours at 12s/block
-    timeout_per_scenario: int = 600  # 5 minutes max per scenario
+    timeout_per_scenario: int = 600  # 10 minutes max per scenario
 
     # Scoring config
     delta_threshold: float = 0.05

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -70,7 +70,7 @@ class ValidatorConfig:
     # Evaluation config
     seeds_per_task: int = 1
     eval_interval_blocks: int = 7200  # ~24 hours at 12s/block
-    timeout_per_scenario: int = 300  # 5 minutes max per scenario
+    timeout_per_scenario: int = 600  # 5 minutes max per scenario
 
     # Scoring config
     delta_threshold: float = 0.05

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -124,6 +124,12 @@ class ValidatorConfig:
     )
     pack_cache_max_size: int = 100  # MB
 
+    # Parallel evaluation
+    parallel_scenarios: bool = False  # Enable parallel scenario evaluation
+    openclaw_bin: Path = field(
+        default_factory=lambda: Path("/app/openclaw")
+    )
+
     # Logging
     log_level: str = "INFO"
     log_dir: Path = field(
@@ -189,6 +195,8 @@ class ValidatorConfig:
             judge_api_key=os.getenv("JUDGE_API_KEY", ""),
             judge_base_url=os.getenv("JUDGE_BASE_URL", ""),
             # --- Operational ---
+            parallel_scenarios=os.getenv("PARALLEL_SCENARIOS", "0") == "1",
+            openclaw_bin=Path(os.getenv("OPENCLAW_BIN", "/app/openclaw")),
             log_level=os.getenv("LOG_LEVEL", "INFO"),
             # --- IM parameters are hardcoded (dataclass defaults) ---
             # Do NOT load from env: ema_alpha, cost_ema_alpha, cost_delta,

--- a/trajectoryrl/utils/parallel_clawbench.py
+++ b/trajectoryrl/utils/parallel_clawbench.py
@@ -1,0 +1,458 @@
+"""Parallel ClawBench harness — runs scenarios concurrently.
+
+Each scenario gets its own mock-tools + OpenClaw instance on unique ports
+with a dedicated workspace directory, enabling safe parallel evaluation.
+
+Slot layout (for slot index i):
+    mock-tools:  port  3001 + i    (http://localhost:{3001+i})
+    OpenClaw:    port 18789 + i    (http://localhost:{18789+i})
+    workspace:   /workspace_{i}    (or configurable base)
+"""
+
+import asyncio
+import json
+import logging
+import os
+import shutil
+import signal
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from .clawbench import ClawBenchHarness, EvaluationResult
+
+logger = logging.getLogger(__name__)
+
+MOCK_TOOLS_BASE_PORT = 3001
+OPENCLAW_BASE_PORT = 18789
+
+
+class ServiceSlot:
+    """A mock-tools + OpenClaw pair running on dedicated ports with its own workspace."""
+
+    def __init__(
+        self,
+        slot_index: int,
+        clawbench_path: Path,
+        workspace_base: Path,
+        openclaw_bin: Path,
+        openclaw_home_base: Path,
+        env_overrides: Dict[str, str],
+        slot_label: Optional[str] = None,
+    ):
+        self.slot_index = slot_index
+        label = slot_label or str(slot_index)
+        self.mock_port = MOCK_TOOLS_BASE_PORT + slot_index
+        self.openclaw_port = OPENCLAW_BASE_PORT + slot_index
+        self.mock_url = f"http://localhost:{self.mock_port}"
+        self.openclaw_url = f"http://localhost:{self.openclaw_port}"
+        self.workspace = workspace_base / f"workspace_{label}"
+        self.openclaw_home = openclaw_home_base / f"openclaw_home_{label}"
+        self.clawbench_path = clawbench_path
+        self.openclaw_bin = openclaw_bin
+        self.env_overrides = env_overrides
+
+        self._mock_proc: Optional[asyncio.subprocess.Process] = None
+        self._openclaw_proc: Optional[asyncio.subprocess.Process] = None
+        self._started = False
+
+    async def start(self) -> None:
+        """Start mock-tools and OpenClaw for this slot."""
+        if self._started:
+            return
+
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        self.openclaw_home.mkdir(parents=True, exist_ok=True)
+
+        # Generate openclaw.json for this slot
+        self._generate_openclaw_config()
+
+        # Build environment for subprocesses
+        env = {**os.environ, **self.env_overrides}
+        env["MOCK_TOOLS_URL"] = self.mock_url
+        env["OPENCLAW_URL"] = self.openclaw_url
+        env["WORKSPACE_PATH"] = str(self.workspace)
+
+        # OpenClaw reads OPENAI_* env vars
+        env["OPENAI_API_KEY"] = env.get("CLAWBENCH_LLM_API_KEY", "")
+        env["OPENAI_BASE_URL"] = env.get(
+            "CLAWBENCH_LLM_BASE_URL", "https://open.bigmodel.cn/api/paas/v4"
+        )
+        env["OPENCLAW_GATEWAY_TOKEN"] = env.get(
+            "OPENCLAW_GATEWAY_TOKEN", "sandbox-token-12345"
+        )
+        # Point OpenClaw at this slot's config and port
+        env["OPENCLAW_HOME"] = str(self.openclaw_home)
+        env["OPENCLAW_GATEWAY_PORT"] = str(self.openclaw_port)
+
+        # Start mock-tools
+        logger.info(
+            "Slot %d: starting mock-tools on port %d", self.slot_index, self.mock_port
+        )
+        self._mock_proc = await asyncio.create_subprocess_exec(
+            "python", "-m", "mock_tools.server",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env={**env, "MOCK_TOOLS_PORT": str(self.mock_port)},
+            cwd=str(self.clawbench_path),
+        )
+
+        if not await self._wait_for_health(self.mock_url, timeout=30):
+            raise RuntimeError(
+                f"Slot {self.slot_index}: mock-tools failed to start on port {self.mock_port}"
+            )
+        logger.info("Slot %d: mock-tools ready on port %d", self.slot_index, self.mock_port)
+
+        # Start OpenClaw
+        logger.info(
+            "Slot %d: starting OpenClaw on port %d", self.slot_index, self.openclaw_port
+        )
+        self._openclaw_proc = await asyncio.create_subprocess_exec(
+            "node", "dist/index.js", "gateway",
+            "--allow-unconfigured", "--bind", "loopback",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+            cwd=str(self.openclaw_bin),
+        )
+
+        if not await self._wait_for_health(self.openclaw_url, timeout=60):
+            raise RuntimeError(
+                f"Slot {self.slot_index}: OpenClaw failed to start on port {self.openclaw_port}"
+            )
+        logger.info(
+            "Slot %d: OpenClaw ready on port %d", self.slot_index, self.openclaw_port
+        )
+
+        self._started = True
+
+    def _generate_openclaw_config(self) -> None:
+        """Generate openclaw.json from template for this slot's ports."""
+        template_path = self.clawbench_path / "config" / "openclaw.json"
+        if not template_path.exists():
+            template_path = self.clawbench_path / "config" / "openclaw.json.template"
+        if not template_path.exists():
+            logger.warning("Slot %d: no openclaw.json template found", self.slot_index)
+            return
+
+        config_text = template_path.read_text()
+
+        model = self.env_overrides.get(
+            "CLAWBENCH_DEFAULT_MODEL",
+            os.environ.get("CLAWBENCH_DEFAULT_MODEL", "zhipu/glm-5"),
+        )
+        base_url = self.env_overrides.get(
+            "CLAWBENCH_LLM_BASE_URL",
+            os.environ.get("CLAWBENCH_LLM_BASE_URL", "https://open.bigmodel.cn/api/paas/v4"),
+        )
+        api_key = self.env_overrides.get(
+            "CLAWBENCH_LLM_API_KEY",
+            os.environ.get("CLAWBENCH_LLM_API_KEY", ""),
+        )
+
+        config_text = config_text.replace("${CLAWBENCH_DEFAULT_MODEL}", model)
+        config_text = config_text.replace("${CLAWBENCH_LLM_BASE_URL}", base_url)
+        config_text = config_text.replace("${CLAWBENCH_LLM_API_KEY}", api_key)
+        config_text = config_text.replace("${MOCK_TOOLS_URL}", self.mock_url)
+
+        # Also patch the gateway port in the config JSON
+        try:
+            config = json.loads(config_text)
+            config["gateway"]["port"] = self.openclaw_port
+            # Update workspace path
+            if "agents" in config and "defaults" in config["agents"]:
+                config["agents"]["defaults"]["workspace"] = str(self.workspace)
+            # Update mock-tools URL in plugin config
+            if "plugins" in config and "entries" in config["plugins"]:
+                cb_tools = config["plugins"]["entries"].get("clawbench-tools", {})
+                if "config" in cb_tools:
+                    cb_tools["config"]["mockServerUrl"] = self.mock_url
+            config_text = json.dumps(config, indent=2)
+        except (json.JSONDecodeError, KeyError) as e:
+            logger.warning("Slot %d: could not patch openclaw.json: %s", self.slot_index, e)
+
+        # OpenClaw resolves config at $OPENCLAW_HOME/.openclaw/openclaw.json
+        config_dir = self.openclaw_home / ".openclaw"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        config_dest = config_dir / "openclaw.json"
+        config_dest.write_text(config_text)
+        logger.debug("Slot %d: wrote openclaw.json to %s", self.slot_index, config_dest)
+
+    async def _wait_for_health(self, url: str, timeout: int = 30) -> bool:
+        """Poll a health endpoint until ready."""
+        import urllib.request
+        import urllib.error
+
+        health_url = f"{url}/health"
+        for _ in range(timeout):
+            try:
+                urllib.request.urlopen(health_url, timeout=2)
+                return True
+            except (urllib.error.URLError, OSError):
+                await asyncio.sleep(1)
+        return False
+
+    async def stop(self) -> None:
+        """Stop mock-tools and OpenClaw for this slot."""
+        for name, proc in [("mock-tools", self._mock_proc), ("OpenClaw", self._openclaw_proc)]:
+            if proc is not None and proc.returncode is None:
+                try:
+                    proc.terminate()
+                    try:
+                        await asyncio.wait_for(proc.wait(), timeout=5)
+                    except asyncio.TimeoutError:
+                        proc.kill()
+                        await proc.wait()
+                    logger.info("Slot %d: %s stopped", self.slot_index, name)
+                except Exception as e:
+                    logger.warning("Slot %d: error stopping %s: %s", self.slot_index, name, e)
+        self._mock_proc = None
+        self._openclaw_proc = None
+        self._started = False
+
+    def create_harness(
+        self,
+        clawbench_path: Path,
+        timeout: int,
+        clawbench_default_model: str,
+        clawbench_api_key: str,
+        clawbench_base_url: str,
+    ) -> ClawBenchHarness:
+        """Create a ClawBenchHarness configured for this slot."""
+        return ClawBenchHarness(
+            clawbench_path=clawbench_path,
+            timeout=timeout,
+            workspace_path=self.workspace,
+            clawbench_default_model=clawbench_default_model,
+            clawbench_api_key=clawbench_api_key,
+            clawbench_base_url=clawbench_base_url,
+            extra_env={
+                "MOCK_TOOLS_URL": self.mock_url,
+                "OPENCLAW_URL": self.openclaw_url,
+            },
+        )
+
+
+class ParallelClawBenchHarness:
+    """Manages multiple service slots for parallel scenario evaluation.
+
+    Spins up N independent (mock-tools + OpenClaw + workspace) triplets,
+    then dispatches scenarios across them concurrently.
+
+    Usage:
+        harness = ParallelClawBenchHarness(
+            num_slots=5,
+            clawbench_path=config.clawbench_path,
+            ...
+        )
+        await harness.start()
+        results = await harness.evaluate_pack_parallel(pack, scenarios, ...)
+        await harness.stop()
+    """
+
+    def __init__(
+        self,
+        num_slots: int,
+        clawbench_path: Path,
+        scenario_names: Optional[List[str]] = None,
+        timeout: int = 300,
+        workspace_base: Optional[Path] = None,
+        openclaw_bin: Optional[Path] = None,
+        openclaw_home_base: Optional[Path] = None,
+        clawbench_default_model: str = "zhipu/glm-5",
+        clawbench_api_key: str = "",
+        clawbench_base_url: str = "https://open.bigmodel.cn/api/paas/v4",
+        env_overrides: Optional[Dict[str, str]] = None,
+    ):
+        self.num_slots = num_slots
+        self.clawbench_path = clawbench_path
+        self.timeout = timeout
+        self.clawbench_default_model = clawbench_default_model
+        self.clawbench_api_key = clawbench_api_key
+        self.clawbench_base_url = clawbench_base_url
+
+        workspace_base = workspace_base or Path("/tmp/parallel_workspaces")
+        openclaw_bin = openclaw_bin or Path("/app/openclaw")
+        openclaw_home_base = openclaw_home_base or Path("/tmp/parallel_openclaw_homes")
+
+        _env = env_overrides or {}
+
+        self.slots: List[ServiceSlot] = []
+        for i in range(num_slots):
+            # Use scenario name for directory naming if available
+            slot_label = scenario_names[i] if scenario_names and i < len(scenario_names) else str(i)
+            slot = ServiceSlot(
+                slot_index=i,
+                slot_label=slot_label,
+                clawbench_path=clawbench_path,
+                workspace_base=workspace_base,
+                openclaw_bin=openclaw_bin,
+                openclaw_home_base=openclaw_home_base,
+                env_overrides=_env,
+            )
+            self.slots.append(slot)
+
+        # Create per-slot harnesses (available after start)
+        self._harnesses: List[ClawBenchHarness] = []
+        self._slot_semaphore = asyncio.Semaphore(num_slots)
+        self._slot_lock = asyncio.Lock()
+        self._available_slots: List[int] = list(range(num_slots))
+
+    async def start(self) -> None:
+        """Start all service slots in parallel."""
+        logger.info("Starting %d parallel service slots...", self.num_slots)
+
+        # Start all slots concurrently
+        results = await asyncio.gather(
+            *[slot.start() for slot in self.slots],
+            return_exceptions=True,
+        )
+
+        # Check for failures
+        failed = []
+        for i, result in enumerate(results):
+            if isinstance(result, Exception):
+                logger.error("Slot %d failed to start: %s", i, result)
+                failed.append(i)
+
+        if failed:
+            # Stop any that started successfully
+            await self._stop_slots([i for i in range(self.num_slots) if i not in failed])
+            raise RuntimeError(
+                f"Failed to start slots: {failed}. "
+                f"Check port conflicts or resource limits."
+            )
+
+        # Create harnesses for each slot
+        self._harnesses = [
+            slot.create_harness(
+                clawbench_path=self.clawbench_path,
+                timeout=self.timeout,
+                clawbench_default_model=self.clawbench_default_model,
+                clawbench_api_key=self.clawbench_api_key,
+                clawbench_base_url=self.clawbench_base_url,
+            )
+            for slot in self.slots
+        ]
+
+        self._available_slots = list(range(self.num_slots))
+        logger.info("All %d slots started successfully", self.num_slots)
+
+    async def stop(self) -> None:
+        """Stop all service slots."""
+        logger.info("Stopping %d parallel service slots...", self.num_slots)
+        await self._stop_slots(list(range(self.num_slots)))
+        logger.info("All slots stopped")
+
+    async def _stop_slots(self, indices: List[int]) -> None:
+        await asyncio.gather(
+            *[self.slots[i].stop() for i in indices],
+            return_exceptions=True,
+        )
+
+    async def _acquire_slot(self) -> int:
+        """Acquire a free slot index."""
+        await self._slot_semaphore.acquire()
+        async with self._slot_lock:
+            return self._available_slots.pop(0)
+
+    async def _release_slot(self, slot_index: int) -> None:
+        """Release a slot back to the pool."""
+        async with self._slot_lock:
+            self._available_slots.append(slot_index)
+        self._slot_semaphore.release()
+
+    async def evaluate_scenario(
+        self,
+        pack: dict,
+        scenario_name: str,
+        seed: int = 0,
+        context_preamble: str = "",
+        user_context: Optional[Dict[str, str]] = None,
+    ) -> EvaluationResult:
+        """Evaluate a single scenario using an available slot."""
+        slot_idx = await self._acquire_slot()
+        try:
+            harness = self._harnesses[slot_idx]
+            logger.info(
+                "Evaluating %s on slot %d (ports %d/%d)",
+                scenario_name, slot_idx,
+                self.slots[slot_idx].mock_port,
+                self.slots[slot_idx].openclaw_port,
+            )
+            result = await harness.evaluate_pack(
+                pack=pack,
+                scenario_name=scenario_name,
+                seed=seed,
+                context_preamble=context_preamble,
+                user_context=user_context,
+            )
+            return result
+        finally:
+            await self._release_slot(slot_idx)
+
+    async def evaluate_pack_parallel(
+        self,
+        pack: dict,
+        scenario_names: List[str],
+        seed: int = 0,
+        context_preamble: str = "",
+        user_context: Optional[Dict[str, str]] = None,
+        fail_fast: bool = True,
+    ) -> Dict[str, EvaluationResult]:
+        """Evaluate a pack across all scenarios in parallel.
+
+        Args:
+            pack: Policy pack dictionary (OPP v1 format)
+            scenario_names: List of scenario names to evaluate
+            seed: Epoch seed
+            context_preamble: Epoch context prepended to AGENTS.md
+            user_context: Template overrides
+            fail_fast: If True, cancel remaining scenarios on first failure
+
+        Returns:
+            Dict mapping scenario_name -> EvaluationResult
+        """
+        results: Dict[str, EvaluationResult] = {}
+        cancel_event = asyncio.Event() if fail_fast else None
+
+        async def _eval_one(scenario_name: str) -> Tuple[str, EvaluationResult]:
+            if cancel_event and cancel_event.is_set():
+                return scenario_name, EvaluationResult(
+                    scenario_name=scenario_name,
+                    score=0.0,
+                    success=False,
+                    tool_calls=0,
+                    response="",
+                    rubric={},
+                    error="Cancelled (fail-fast)",
+                )
+            result = await self.evaluate_scenario(
+                pack=pack,
+                scenario_name=scenario_name,
+                seed=seed,
+                context_preamble=context_preamble,
+                user_context=user_context,
+            )
+            if fail_fast and cancel_event and result.error:
+                cancel_event.set()
+            return scenario_name, result
+
+        tasks = [_eval_one(s) for s in scenario_names]
+        completed = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for item in completed:
+            if isinstance(item, Exception):
+                logger.error("Parallel eval error: %s", item)
+                continue
+            name, result = item
+            results[name] = result
+
+        return results
+
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, *args):
+        await self.stop()


### PR DESCRIPTION
Run all ClawBench scenarios concurrently instead of sequentially. Each scenario gets its own mock-tools + OpenClaw instance on separate ports, with isolated workspaces (e.g. workspace_client_escalation). The LLM judge runs immediately after each scenario's episode finishes (in a thread via asyncio.to_thread to avoid blocking the event loop).

Controlled by PARALLEL_SCENARIOS=1 env var (off by default). When enabled, the entrypoint skips single-instance service startup and lets ParallelClawBenchHarness manage N service slots.

## How to test

    docker build -f docker/Dockerfile.validator -t trajectoryrl-validator .

    docker run --rm --network host \
      -e PARALLEL_SCENARIOS=1 \
      -e VALIDATOR_SCRIPT=eval_parallel_test.py \
      --env-file .env \
      -v $(pwd)/packs/AGENTS_v2.json:/pack.json:ro \
      trajectoryrl-validator /pack.json

Or via compose:

    docker compose -f docker/docker-compose.parallel-test.yml up --build