### PR TITLE
chore: rename GLM-5 to GLM-5.1

### DIFF
--- a/.env.miner.example
+++ b/.env.miner.example
@@ -47,9 +47,9 @@ CLAWBENCH_LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
 # LLM model for evaluation (provider/model format)
 # The prefix must match a provider defined in config/openclaw.json.template.
 # Examples:
-#   zhipu/glm-5                            (Zhipu AI, default)
-#   chutes/zai-org/GLM-5-TEE               (Chutes GLM-5, alternative)
-CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5
+#   zhipu/glm-5.1                            (Zhipu AI, default)
+#   chutes/zai-org/GLM-5.1-TEE               (Chutes GLM-5.1, alternative)
+CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5.1
 
 # --- S3-compatible upload (default mode, unless PACK_URL is set) ---
 # Works with AWS S3, GCS (HMAC keys), MinIO, Cloudflare R2.

--- a/.env.validator.example
+++ b/.env.validator.example
@@ -24,10 +24,10 @@ CLAWBENCH_LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
 # LLM model for evaluation (provider/model format)
 # The prefix must match a provider defined in config/openclaw.json.template.
 # Examples:
-#   zhipu/glm-5                            (Zhipu AI, default)
-#   chutes/zai-org/GLM-5-TEE               (Chutes GLM-5, alternative)
-#   openrouter/zhipu/glm-5                 (OpenRouter, multi-provider)
-CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5
+#   zhipu/glm-5.1                            (Zhipu AI, default)
+#   chutes/zai-org/GLM-5.1-TEE               (Chutes GLM-5.1, alternative)
+#   openrouter/zhipu/glm-5.1                 (OpenRouter, multi-provider)
+CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5.1
 
 # =============================================================================
 # Bittensor

--- a/INCENTIVE_MECHANISM.md
+++ b/INCENTIVE_MECHANISM.md
@@ -12,7 +12,7 @@
 
 TrajectoryRL rewards miners who submit **policy packs** (PolicyBundles) that complete AI agent tasks at the **lowest cost** while passing all safety and correctness checks.
 
-The default evaluation model is **GLM-5** (via OpenAI-compatible API). The incentive is simple: **pass the gate, then compete on cost**.
+The default evaluation model is **GLM-5.1** (via OpenAI-compatible API). The incentive is simple: **pass the gate, then compete on cost**.
 
 1. **Pack integrity gate**: LLM-as-judge static analysis detects hardcoded responses, instruction overrides, and gaming attempts before any episode runs
 2. **Qualification gate**: LLM-as-judge evaluates the full agent trajectory — every safety and correctness criterion must pass, and all claims must be **grounded** in data the agent actually retrieved via tool calls
@@ -55,7 +55,7 @@ Stage 1 — Prompt optimization (AGENTS.md tuning):
 Stage 2 — Hybrid routing (AGENTS.md + injected skills):
   Multi-LLM dynamic routing:               $900/month  (93% reduction)
     ├─ Qwen 3.5 (Alibaba) handles 40% of sub-tasks (tool calls, lookups)
-    ├─ GLM-5 (Z.ai) handles 25% (structured extraction, formatting)
+    ├─ GLM-5.1 (Z.ai) handles 25% (structured extraction, formatting)
     ├─ Gemini 3 Flash (Google) handles 20% (search, summarization)
     ├─ GPT-5.2 (OpenAI) handles 10% (reasoning, drafting)
     └─ Claude Opus 4.6 (Anthropic) handles 5% (complex judgment calls)
@@ -171,7 +171,7 @@ cost_usd = Σ  rate(model_i, token_type) × token_count(model_i, token_type)
            i
 ```
 
-Cost is captured from the LLM provider's usage data after each episode. It includes all tokens consumed during the agent's tool-calling loop across **all models used** — a pack that routes sub-tasks to multiple models (e.g., GLM-5, Qwen 3.5, Gemini 3 Flash) accumulates cost from each model at its respective rate.
+Cost is captured from the LLM provider's usage data after each episode. It includes all tokens consumed during the agent's tool-calling loop across **all models used** — a pack that routes sub-tasks to multiple models (e.g., GLM-5.1, Qwen 3.5, Gemini 3 Flash) accumulates cost from each model at its respective rate.
 
 **Note**: The judge's own LLM cost is borne by the validator and is **not** counted toward the miner's episode cost.
 

--- a/MINER_OPERATIONS.md
+++ b/MINER_OPERATIONS.md
@@ -137,7 +137,7 @@ cp .env.miner.example .env.miner
 | `NETWORK` | yes | `finney` | Bittensor network |
 | `CLAWBENCH_LLM_API_KEY` | default mode | — | API key for AGENTS.md generation |
 | `CLAWBENCH_LLM_BASE_URL` | no | `https://open.bigmodel.cn/api/paas/v4` | OpenAI-compatible API base URL |
-| `CLAWBENCH_DEFAULT_MODEL` | no | `glm-5` | Model for AGENTS.md generation |
+| `CLAWBENCH_DEFAULT_MODEL` | no | `glm-5.1` | Model for AGENTS.md generation |
 | `S3_BUCKET` | default mode* | — | S3-compatible bucket name |
 | `S3_ENDPOINT_URL` | no | — | Custom endpoint for GCS/R2/MinIO |
 | `S3_REGION` | no | `us-east-1` | Bucket region |
@@ -233,7 +233,7 @@ result = judge.evaluate(scenario_config, tool_calls, agent_response)
 print(f"Score: {result.overall_score}, Gate: {result.qualification_gate}")
 ```
 
-> **Important**: The judge model must produce output in the `content` field. Reasoning models like GLM-5-TEE put output in `reasoning_content` which the judge parser cannot read. Use a standard chat model (e.g., `deepseek-ai/DeepSeek-V3`) for the judge.
+> **Important**: The judge model must produce output in the `content` field. Reasoning models like GLM-5.1-TEE put output in `reasoning_content` which the judge parser cannot read. Use a standard chat model (e.g., `deepseek-ai/DeepSeek-V3`) for the judge.
 
 > **Note on score variation**: Validators choose their own judge model via `JUDGE_MODEL` env var. Different judge models may score the same trajectory differently, and misconfigured judges (e.g., reasoning models without the `thinkingFormat` fix) may score everything as 0. Your local scores may not match validator scores. See [issue #98](https://github.com/trajectoryRL/trajectoryRL/issues/98) for discussion.
 
@@ -297,14 +297,14 @@ python scripts/run_episode.py --scenario inbox_triage --workspace /tmp/workspace
 
 > **Note**: The regex checks from `run_episode.py --json` are useful for debugging tool usage but **do not reflect your actual validator score** — see "How Scoring Works" above.
 
-### Known Issues with GLM-5-TEE (Reasoning Models)
+### Known Issues with GLM-5.1-TEE (Reasoning Models)
 
-GLM-5 / GLM-5-TEE is a reasoning model that puts all output in `reasoning_content` instead of `content`. This affects two areas:
+GLM-5.1 / GLM-5.1-TEE is a reasoning model that puts all output in `reasoning_content` instead of `content`. This affects two areas:
 
 **1. Agent responses (OpenClaw gateway):** If you're getting empty agent responses (0 correctness checks passed, but tool calls are happening), add to the model definition in `config/openclaw.json.template`:
    ```json
    {
-     "id": "zai-org/GLM-5-TEE",
+     "id": "zai-org/GLM-5.1-TEE",
      "reasoning": true,
      "maxTokens": 32768,
      "compat": {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See [INCENTIVE_MECHANISM.md](INCENTIVE_MECHANISM.md) for full scoring, rewards, 
 ### Example ROI (1,000 tasks/day)
 
 ```
-Unoptimized GLM-5:                       $12,300/month
+Unoptimized GLM-5.1:                       $12,300/month
 
 Stage 1 — Prompt optimization (AGENTS.md tuning):
   Optimized prompts + stop rules:         $3,300/month  (73% reduction)
@@ -55,7 +55,7 @@ Stage 1 — Prompt optimization (AGENTS.md tuning):
 Stage 2 — Hybrid routing (AGENTS.md + injected skills):
   Multi-LLM dynamic routing:               $900/month  (93% reduction)
     ├─ Qwen 3.5 (Alibaba) handles 40% of sub-tasks (tool calls, lookups)
-    ├─ GLM-5 (Z.ai) handles 25% (structured extraction, formatting)
+    ├─ GLM-5.1 (Z.ai) handles 25% (structured extraction, formatting)
     ├─ Gemini 3 Flash (Google) handles 20% (search, summarization)
     ├─ GPT-5.2 (OpenAI) handles 10% (reasoning, drafting)
     └─ Claude Opus 4.6 (Anthropic) handles 5% (complex judgment calls)
@@ -93,7 +93,7 @@ NETUID=11
 NETWORK=finney
 CLAWBENCH_LLM_API_KEY=your-api-key
 CLAWBENCH_LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4/
-CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5
+CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5.1
 EOF
 ```
 
@@ -101,9 +101,9 @@ EOF
 
 | Provider | `CLAWBENCH_LLM_BASE_URL` | `CLAWBENCH_DEFAULT_MODEL` |
 |----------|--------------------------|---------------------------|
-| [Zhipu AI](https://bigmodel.cn) (default) | `https://open.bigmodel.cn/api/paas/v4` | `zhipu/glm-5` |
-| [Chutes](https://chutes.ai) | `https://llm.chutes.ai/v1` | `chutes/zai-org/GLM-5-TEE` |
-| [OpenRouter](https://openrouter.ai) | `https://openrouter.ai/api/v1` | `openrouter/zhipu/glm-5` |
+| [Zhipu AI](https://bigmodel.cn) (default) | `https://open.bigmodel.cn/api/paas/v4` | `zhipu/glm-5.1` |
+| [Chutes](https://chutes.ai) | `https://llm.chutes.ai/v1` | `chutes/zai-org/GLM-5.1-TEE` |
+| [OpenRouter](https://openrouter.ai) | `https://openrouter.ai/api/v1` | `openrouter/zhipu/glm-5.1` |
 
 | Variable | Required | Description |
 |----------|:--------:|-------------|
@@ -113,7 +113,7 @@ EOF
 | `NETWORK` | Yes | `finney`, `test`, or `local` |
 | `CLAWBENCH_LLM_API_KEY` | Yes | API key for the LLM provider (e.g. [Zhipu AI](https://bigmodel.cn), [Chutes](https://chutes.ai), [OpenRouter](https://openrouter.ai)) |
 | `CLAWBENCH_LLM_BASE_URL` | Yes | Base URL for the OpenAI-compatible API |
-| `CLAWBENCH_DEFAULT_MODEL` | Yes | LLM model for evaluation (default: `zhipu/glm-5`) |
+| `CLAWBENCH_DEFAULT_MODEL` | Yes | LLM model for evaluation (default: `zhipu/glm-5.1`) |
 | `JUDGE_MODEL` | No | LLM model for judge (defaults to `CLAWBENCH_DEFAULT_MODEL`) |
 | `JUDGE_API_KEY` | No | API key for judge (defaults to `CLAWBENCH_LLM_API_KEY`) |
 | `JUDGE_BASE_URL` | No | Base URL for judge (defaults to `CLAWBENCH_LLM_BASE_URL`) |
@@ -163,11 +163,11 @@ NETUID=11
 NETWORK=finney
 LLM_API_KEY=your-api-key
 LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4/
-LLM_MODEL=zhipu/glm-5
+LLM_MODEL=zhipu/glm-5.1
 EOF
 ```
 
-> **Tip:** Any OpenAI-compatible provider works. For OpenRouter, use `LLM_BASE_URL=https://openrouter.ai/api/v1` and `LLM_MODEL=zhipu/glm-5`.
+> **Tip:** Any OpenAI-compatible provider works. For OpenRouter, use `LLM_BASE_URL=https://openrouter.ai/api/v1` and `LLM_MODEL=zhipu/glm-5.1`.
 
 #### 3. Start mining
 
@@ -201,9 +201,9 @@ python neurons/miner.py status
 cd clawbench
 pip install -e .
 # Set CLAWBENCH_LLM_API_KEY, CLAWBENCH_LLM_BASE_URL, CLAWBENCH_DEFAULT_MODEL in .env
-# Example Zhipu:      CLAWBENCH_LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4/, CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5
-# Example Chutes:     CLAWBENCH_LLM_BASE_URL=https://llm.chutes.ai/v1,              CLAWBENCH_DEFAULT_MODEL=chutes/zai-org/GLM-5-TEE
-# Example OpenRouter: CLAWBENCH_LLM_BASE_URL=https://openrouter.ai/api/v1,           CLAWBENCH_DEFAULT_MODEL=openrouter/zhipu/glm-5
+# Example Zhipu:      CLAWBENCH_LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4/, CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5.1
+# Example Chutes:     CLAWBENCH_LLM_BASE_URL=https://llm.chutes.ai/v1,              CLAWBENCH_DEFAULT_MODEL=chutes/zai-org/GLM-5.1-TEE
+# Example OpenRouter: CLAWBENCH_LLM_BASE_URL=https://openrouter.ai/api/v1,           CLAWBENCH_DEFAULT_MODEL=openrouter/zhipu/glm-5.1
 
 # Test a single scenario
 python scripts/run_episode.py --scenario inbox_triage --variant optimized --json

--- a/VALIDATOR_OPERATIONS.md
+++ b/VALIDATOR_OPERATIONS.md
@@ -31,7 +31,7 @@ Agents typically make 2–8 LLM calls per episode depending on scenario complexi
 
 ## Daily Cost Projections
 
-Designated model: `GLM-5` via OpenAI-compatible API. Cost per episode ≈ **$0.08** (observed median).
+Designated model: `GLM-5.1` via OpenAI-compatible API. Cost per episode ≈ **$0.08** (observed median).
 
 **All validators must use the designated model.** This is a consensus requirement: if validators use different models, agents produce different tool-call sequences, leading to different rubric outcomes and validator disagreement on scores. Using the wrong model puts your validator out of consensus and risks down-weighting by Yuma.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -32,7 +32,7 @@ NETUID=11
 NETWORK=finney
 CLAWBENCH_LLM_API_KEY=...
 CLAWBENCH_LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
-CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5
+CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5.1
 
 # Optional
 LOG_LEVEL=INFO                    # DEBUG for development

--- a/docker/docker-compose.validator.yml
+++ b/docker/docker-compose.validator.yml
@@ -15,7 +15,7 @@
 #   NETWORK=finney
 #   CLAWBENCH_LLM_API_KEY=...
 #   CLAWBENCH_LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
-#   CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5
+#   CLAWBENCH_DEFAULT_MODEL=zhipu/glm-5.1
 
 services:
   validator:

--- a/scripts/eval_miners.py
+++ b/scripts/eval_miners.py
@@ -37,7 +37,7 @@ Environment variables (also read from .env.validator):
     WALLET_HOTKEY             Hotkey name                  (default: default)
     NETUID                    Subnet UID                   (default: 11)
     NETWORK                   Subtensor network            (default: finney)
-    CLAWBENCH_DEFAULT_MODEL   LLM model                   (default: zhipu/glm-5)
+    CLAWBENCH_DEFAULT_MODEL   LLM model                   (default: zhipu/glm-5.1)
     CLAWBENCH_LLM_API_KEY     API key
     CLAWBENCH_LLM_BASE_URL    Base URL
     CLAWBENCH_PATH            Path to clawbench directory
@@ -305,7 +305,7 @@ async def run_evaluation(args):
 
     # --- 3. Prepare ClawBench harness ---
     clawbench_path = Path(args.clawbench_path)
-    model = args.model or os.getenv("CLAWBENCH_DEFAULT_MODEL", "zhipu/glm-5")
+    model = args.model or os.getenv("CLAWBENCH_DEFAULT_MODEL", "zhipu/glm-5.1")
     api_key = args.api_key or os.getenv("CLAWBENCH_LLM_API_KEY", "")
     base_url = args.base_url or os.getenv(
         "CLAWBENCH_LLM_BASE_URL", "https://open.bigmodel.cn/api/paas/v4"
@@ -468,7 +468,7 @@ def main():
     parser.add_argument("--timeout", type=int, default=120, help="Timeout per scenario in seconds (default: 120)")
 
     # LLM config
-    parser.add_argument("--model", type=str, default=None, help="LLM model (e.g. zhipu/glm-5)")
+    parser.add_argument("--model", type=str, default=None, help="LLM model (e.g. zhipu/glm-5.1)")
     parser.add_argument("--api-key", type=str, default=None, help="API key for the LLM provider")
     parser.add_argument("--base-url", type=str, default=None, help="Base URL for the LLM API")
 

--- a/scripts/eval_pack.py
+++ b/scripts/eval_pack.py
@@ -31,7 +31,7 @@ Usage:
     python scripts/eval_pack.py --pack pack.json -v -o results.json
 
 Environment variables:
-    CLAWBENCH_DEFAULT_MODEL   LLM model           (default: zhipu/glm-5)
+    CLAWBENCH_DEFAULT_MODEL   LLM model           (default: zhipu/glm-5.1)
     CLAWBENCH_LLM_API_KEY     API key for LLM
     CLAWBENCH_LLM_BASE_URL    LLM base URL        (default: https://open.bigmodel.cn/api/paas/v4)
 """
@@ -172,7 +172,7 @@ async def run(args) -> int:
 
     # ── 4. ClawBench harness ──────────────────────────────────────────────
     clawbench_path = Path(args.clawbench_path)
-    model = args.model or os.getenv("CLAWBENCH_DEFAULT_MODEL", "zhipu/glm-5")
+    model = args.model or os.getenv("CLAWBENCH_DEFAULT_MODEL", "zhipu/glm-5.1")
     api_key = args.api_key or os.getenv("CLAWBENCH_LLM_API_KEY", "")
     base_url = args.base_url or os.getenv(
         "CLAWBENCH_LLM_BASE_URL", "https://open.bigmodel.cn/api/paas/v4",

--- a/scripts/test_llm_judge.py
+++ b/scripts/test_llm_judge.py
@@ -276,7 +276,7 @@ Auth migration is blocked waiting on Redis provisioning.
 
 
 def _strip_provider_prefix(model: str) -> str:
-    """Strip provider prefix from model name (e.g. 'zhipu/glm-5' -> 'glm-5')."""
+    """Strip provider prefix from model name (e.g. 'zhipu/glm-5.1' -> 'glm-5.1')."""
     if "/" in model:
         model = model.split("/", 1)[1]
     return model

--- a/seasons/self_learning_s1.md
+++ b/seasons/self_learning_s1.md
@@ -602,7 +602,7 @@ At the midpoint estimate, Season 1 costs ~$174/epoch with 50 miners (~$706 at 20
 **Cost mitigation strategies:**
 
 - **Harness-aware cost caps.** The validator sets a per-episode token/dollar cap. The agent harness is killed if the cap is exceeded (episode scored as-is with whatever was completed). This bounds worst-case cost.
-- **Cheap default model.** The default evaluation model is GLM-5 (cheapest qualified model). Season 1 scores on quality, not cost.
+- **Cheap default model.** The default evaluation model is GLM-5.1 (cheapest qualified model). Season 1 scores on quality, not cost.
 - **Lightweight containers.** Sandbox containers are lightweight (mock services only). Harness containers use official agent images. Both are ephemeral, created per-eval and destroyed after.
 
 **Mitigation for time:** 17h is within the 24h epoch with margin. Scale to 15–20 containers if miner count exceeds 200.

--- a/tests/test_default_mode.py
+++ b/tests/test_default_mode.py
@@ -52,7 +52,7 @@ def _make_config(**overrides):
         log_level="WARNING",
         llm_api_key="sk-test-key",
         llm_base_url="https://open.bigmodel.cn/api/paas/v4",
-        llm_model="glm-5",
+        llm_model="glm-5.1",
         pack_url="",
     )
     defaults.update(overrides)

--- a/trajectoryrl/utils/clawbench.py
+++ b/trajectoryrl/utils/clawbench.py
@@ -63,7 +63,7 @@ class ClawBenchHarness:
         clawbench_path: Path,
         timeout: int = 120,
         workspace_path: Optional[Path] = None,
-        clawbench_default_model: str = "zhipu/glm-5",
+        clawbench_default_model: str = "zhipu/glm-5.1",
         clawbench_api_key: str = "",
         clawbench_base_url: str = "https://open.bigmodel.cn/api/paas/v4",
     ):
@@ -74,7 +74,7 @@ class ClawBenchHarness:
             timeout: Timeout in seconds for each scenario
             workspace_path: Shared workspace directory that OpenClaw reads from.
                 If None, uses WORKSPACE_PATH env var or clawbench_path/workspace.
-            clawbench_default_model: Model in ``provider/model`` format (e.g. ``zhipu/glm-5``).
+            clawbench_default_model: Model in ``provider/model`` format (e.g. ``zhipu/glm-5.1``).
             clawbench_api_key: API key for the LLM provider.
             clawbench_base_url: Base URL for the OpenAI-compatible API.
         """

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -9,7 +9,7 @@ from typing import List, Optional
 logger = logging.getLogger(__name__)
 
 DEFAULT_LLM_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
-DEFAULT_LLM_MODEL = "glm-5"
+DEFAULT_LLM_MODEL = "glm-5.1"
 DEFAULT_CLAWBENCH_MODEL = f"zhipu/{DEFAULT_LLM_MODEL}"
 
 
@@ -251,7 +251,7 @@ class MinerConfig:
         log_level: Logging level
         llm_api_key: API key for the OpenAI-compatible LLM endpoint
         llm_base_url: Base URL for the OpenAI-compatible LLM endpoint
-        llm_model: Model name for AGENTS.md generation (e.g. glm-5)
+        llm_model: Model name for AGENTS.md generation (e.g. glm-5.1)
         pack_url: Pre-set pack URL (skips S3 upload if set)
     """
 

--- a/trajectoryrl/utils/llm_client.py
+++ b/trajectoryrl/utils/llm_client.py
@@ -5,7 +5,7 @@ Configure via environment variables:
 
   CLAWBENCH_LLM_API_KEY      API key for the provider
   CLAWBENCH_LLM_BASE_URL     Base URL (e.g. https://open.bigmodel.cn/api/paas/v4)
-  CLAWBENCH_DEFAULT_MODEL        Model name (e.g. glm-5)
+  CLAWBENCH_DEFAULT_MODEL        Model name (e.g. glm-5.1)
 
 For Anthropic models, the native SDK is used instead of the OpenAI
 compatibility layer.
@@ -56,7 +56,7 @@ def _generate(
     Prefer ``async_generate`` in async contexts — this function blocks
     the calling thread until the HTTP request completes.
     """
-    model = model or os.environ.get("CLAWBENCH_DEFAULT_MODEL", "glm-5")
+    model = model or os.environ.get("CLAWBENCH_DEFAULT_MODEL", "glm-5.1")
     if "/" in model:
         model = model.split("/", 1)[1]
     key = resolve_api_key(api_key)

--- a/trajectoryrl/utils/pack_generator.py
+++ b/trajectoryrl/utils/pack_generator.py
@@ -6,7 +6,7 @@ types, producing a generic policy that scores well across all five scenarios.
 
 Uses an OpenAI-compatible endpoint configured via ``CLAWBENCH_LLM_API_KEY``,
 ``CLAWBENCH_LLM_BASE_URL``, and ``CLAWBENCH_DEFAULT_MODEL`` environment variables.
-Default provider is Zhipu (https://open.bigmodel.cn/api/paas/v4) with GLM-5.
+Default provider is Zhipu (https://open.bigmodel.cn/api/paas/v4) with GLM-5.1.
 """
 
 import logging
@@ -123,7 +123,7 @@ Do NOT wrap the output in code fences.
 
 
 def generate_agents_md(
-    model: str = "zai-org/GLM-5-TEE",
+    model: str = "zai-org/GLM-5.1-TEE",
     api_key: str = "",
     base_url: str = "",
     previous_agents_md: Optional[str] = None,
@@ -132,7 +132,7 @@ def generate_agents_md(
     """Generate an AGENTS.md policy document via the unified LLM client.
 
     Args:
-        model: Model name (e.g. ``glm-5``).
+        model: Model name (e.g. ``glm-5.1``).
         api_key: Explicit API key (optional; auto-resolved from env if empty).
         base_url: Explicit base URL (optional; auto-resolved from env if empty).
         previous_agents_md: If provided, improve this existing policy


### PR DESCRIPTION
## Summary
- Rename all references of `glm-5` / `GLM-5` to `glm-5.1` / `GLM-5.1` across config, scripts, docs, env examples, and docker files (18 files total)

## Test plan
- [ ] Verify no remaining bare `glm-5` references (without `.1`) in the codebase
- [ ] Confirm validator and miner env examples point to correct model
- [ ] Spot-check that `clawbench` submodule ref is updated

Made with [Cursor](https://cursor.com)