### PR TITLE
Fix single-validator gaming by requiring multi-validator consensus (#…

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2537,6 +2537,7 @@ class TestConsensusAggregation:
         )
 
     def test_single_validator(self):
+        """With only 1 validator total, min_validators gate relaxes to 1."""
         subs = [self._make_validated("v1", 100.0, {"m1": 3.0, "m2": 5.0})]
         costs, quals = compute_consensus_costs(subs)
         assert costs["m1"] == pytest.approx(3.0)
@@ -2566,7 +2567,7 @@ class TestConsensusAggregation:
             self._make_validated("v1", 100.0, {"m1": 2.0, "m2": 4.0}),
             self._make_validated("v2", 100.0, {"m1": 6.0}),
         ]
-        costs, _ = compute_consensus_costs(subs)
+        costs, _ = compute_consensus_costs(subs, min_validators_qualified=1)
         assert costs["m1"] == pytest.approx(4.0)
         assert costs["m2"] == pytest.approx(4.0)
 
@@ -2593,7 +2594,7 @@ class TestConsensusAggregation:
             self._make_validated("v1", 300.0, {"m1": 2.0}, {"m1": True}),
             self._make_validated("v2", 100.0, {"m1": 3.0}, {"m1": False}),
         ]
-        _, quals = compute_consensus_costs(subs)
+        _, quals = compute_consensus_costs(subs, min_validators_qualified=1)
         assert quals["m1"] is True  # 300/(300+100) = 0.75 > 0.5
 
     def test_qualification_minority_stake_cannot_disqualify(self):
@@ -2622,11 +2623,14 @@ class TestConsensusAggregation:
             self._make_validated("v1", 200.0, {"m1": 2.0}, {"m1": True}),
             self._make_validated("v2", 100.0, {"m1": 3.0}, {"m1": False}),
         ]
-        # 200/300 ≈ 0.667 > 0.5 → qualified with default threshold
-        _, quals_default = compute_consensus_costs(subs)
+        # 200/300 ≈ 0.667 > 0.5 → stake ok, but only 1 validator qualified
+        # With min_validators=1, test pure stake threshold behavior
+        _, quals_default = compute_consensus_costs(subs, min_validators_qualified=1)
         assert quals_default["m1"] is True
         # 200/300 ≈ 0.667, NOT > 0.67 → disqualified with 2/3 threshold
-        _, quals_super = compute_consensus_costs(subs, qualification_stake_threshold=0.67)
+        _, quals_super = compute_consensus_costs(
+            subs, qualification_stake_threshold=0.67, min_validators_qualified=1,
+        )
         assert quals_super["m1"] is False
 
     def test_empty_submissions(self):
@@ -2652,7 +2656,7 @@ class TestConsensusAggregation:
             self._make_validated("v1", 200.0, {"m1": 0.02}, {"m1": False}),
             self._make_validated("v2", 300.0, {"m1": 0.05}, {"m1": True}),
         ]
-        costs, quals = compute_consensus_costs(subs)
+        costs, quals = compute_consensus_costs(subs, min_validators_qualified=1)
         assert quals["m1"] is True  # 300/500 = 0.6 > 0.5
         assert costs["m1"] == pytest.approx(0.05)  # only v2's cost
 
@@ -2678,6 +2682,30 @@ class TestConsensusAggregation:
         costs, quals = compute_consensus_costs(subs)
         assert quals["m1"] is False
         assert costs["m1"] == pytest.approx(0.0)
+
+    def test_min_validators_qualified_gate(self):
+        """Miner passing only one dominant-stake validator is disqualified.
+
+        This prevents gaming where a miner targets a single high-stake
+        validator and ignores the rest (issue #149).
+        """
+        subs = [
+            self._make_validated("v_dominant", 600.0, {"m1": 2.0}, {"m1": True}),
+            self._make_validated("v2", 100.0, {"m1": 3.0}, {"m1": False}),
+            self._make_validated("v3", 100.0, {"m1": 4.0}, {"m1": False}),
+        ]
+        # Stake majority: 600/800 = 0.75 > 0.5, but only 1 validator qualified
+        _, quals = compute_consensus_costs(subs)
+        assert quals["m1"] is False
+
+        # Same scenario with 2 validators qualified → passes
+        subs_ok = [
+            self._make_validated("v1", 300.0, {"m1": 2.0}, {"m1": True}),
+            self._make_validated("v2", 300.0, {"m1": 3.0}, {"m1": True}),
+            self._make_validated("v3", 100.0, {"m1": 4.0}, {"m1": False}),
+        ]
+        _, quals_ok = compute_consensus_costs(subs_ok)
+        assert quals_ok["m1"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -949,6 +949,7 @@ class TrajectoryValidator:
         consensus_costs, consensus_qualified = compute_consensus_costs(
             validated,
             qualification_stake_threshold=self.config.qualification_stake_threshold,
+            min_validators_qualified=self.config.min_validators_qualified,
         )
 
         self._consensus_window = window.window_number

--- a/trajectoryrl/scoring/__init__.py
+++ b/trajectoryrl/scoring/__init__.py
@@ -527,11 +527,16 @@ class TrajectoryScorer:
 def compute_consensus_costs(
     validated_submissions: List[ValidatedSubmission],
     qualification_stake_threshold: float = 0.5,
+    min_validators_qualified: int = 2,
 ) -> Tuple[Dict[str, float], Dict[str, bool]]:
     """Compute stake-weighted consensus costs and qualification across validators.
 
     Qualification uses stake-weighted majority across ALL reporting validators:
         qual_ratio = qualified_stake / total_reporting_stake > threshold
+
+    Additionally, a miner must be reported as qualified by at least
+    ``min_validators_qualified`` distinct validators.  This prevents gaming
+    where a miner passes only a single dominant-stake validator.
 
     Consensus cost uses ONLY votes where the validator reported qualified=True:
         consensus_cost[miner] = Σ(stake_i × cost_i) / Σ(stake_i)
@@ -546,6 +551,11 @@ def compute_consensus_costs(
         qualification_stake_threshold: Fraction of reporting stake that must
             vote qualified=True for a miner to be considered qualified.
             Default 0.5 (simple majority by stake weight).
+        min_validators_qualified: Minimum number of distinct validators that
+            must report qualified=True for a miner to qualify.  Default 2.
+            When fewer than ``min_validators_qualified`` validators submitted
+            results overall, this gate is relaxed to the total validator count
+            so that small networks are not deadlocked.
 
     Returns:
         Tuple of (consensus_costs, consensus_qualified):
@@ -559,6 +569,7 @@ def compute_consensus_costs(
     miner_qualified_stake: Dict[str, float] = {}
     miner_qual_weighted_cost: Dict[str, float] = {}
     miner_qual_cost_stake: Dict[str, float] = {}
+    miner_qual_validator_count: Dict[str, int] = {}
 
     for sub in validated_submissions:
         stake = sub.validator_stake
@@ -576,6 +587,7 @@ def compute_consensus_costs(
                 miner_qualified_stake[miner_hk] = 0.0
                 miner_qual_weighted_cost[miner_hk] = 0.0
                 miner_qual_cost_stake[miner_hk] = 0.0
+                miner_qual_validator_count[miner_hk] = 0
 
             miner_total_stake[miner_hk] += stake
 
@@ -584,6 +596,12 @@ def compute_consensus_costs(
                 miner_qualified_stake[miner_hk] += stake
                 miner_qual_weighted_cost[miner_hk] += stake * cost
                 miner_qual_cost_stake[miner_hk] += stake
+                miner_qual_validator_count[miner_hk] += 1
+
+    # When the network has fewer validators than the minimum, relax the gate
+    # to the actual validator count so small networks are not deadlocked.
+    total_validators = len([s for s in validated_submissions if s.validator_stake > 0])
+    effective_min_validators = min(min_validators_qualified, total_validators)
 
     consensus_costs: Dict[str, float] = {}
     miner_qualified: Dict[str, bool] = {}
@@ -591,9 +609,14 @@ def compute_consensus_costs(
         total_stake = miner_total_stake[miner_hk]
         if total_stake > 0:
             qual_ratio = miner_qualified_stake[miner_hk] / total_stake
-            miner_qualified[miner_hk] = qual_ratio > qualification_stake_threshold
+            stake_ok = qual_ratio > qualification_stake_threshold
         else:
-            miner_qualified[miner_hk] = False
+            stake_ok = False
+
+        validator_count_ok = (
+            miner_qual_validator_count.get(miner_hk, 0) >= effective_min_validators
+        )
+        miner_qualified[miner_hk] = stake_ok and validator_count_ok
 
         qual_cost_stake = miner_qual_cost_stake[miner_hk]
         if qual_cost_stake > 0:
@@ -604,9 +627,11 @@ def compute_consensus_costs(
             consensus_costs[miner_hk] = 0.0
 
     logger.info(
-        "Consensus computed: %d miners, %d validators, qual_threshold=%.2f",
+        "Consensus computed: %d miners, %d validators, qual_threshold=%.2f, "
+        "min_validators=%d (effective=%d)",
         len(consensus_costs), len(validated_submissions),
-        qualification_stake_threshold,
+        qualification_stake_threshold, min_validators_qualified,
+        effective_min_validators,
     )
 
     return consensus_costs, miner_qualified

--- a/trajectoryrl/scoring/__init__.py
+++ b/trajectoryrl/scoring/__init__.py
@@ -600,7 +600,7 @@ def compute_consensus_costs(
 
     # When the network has fewer validators than the minimum, relax the gate
     # to the actual validator count so small networks are not deadlocked.
-    total_validators = len([s for s in validated_submissions if s.validator_stake > 0])
+    total_validators = len({s.payload.validator_hotkey for s in validated_submissions if s.validator_stake > 0})
     effective_min_validators = min(min_validators_qualified, total_validators)
 
     consensus_costs: Dict[str, float] = {}

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -93,6 +93,7 @@ class ValidatorConfig:
     consensus_epsilon: float = 0.02
     consensus_protocol_version: int = 1
     qualification_stake_threshold: float = 0.5  # stake-weighted majority for qualification
+    min_validators_qualified: int = 2  # minimum distinct validators that must report qualified
 
     # Consensus CAS: IPFS primary, trajrl.com API fallback
     ipfs_api_url: str = "http://ipfs.metahash73.com:5001/api/v0"


### PR DESCRIPTION
## Summary
- Add `min_validators_qualified` gate (default: 2) to `compute_consensus_costs` — miners must be reported qualified by at least 2 distinct validators, not just pass a stake-weighted majority
- Prevents gaming where miners target a single dominant-stake validator and ignore the rest
- Gate relaxes to actual validator count when fewer than 2 validators exist, avoiding deadlock in small networks

Closes #149

## Test plan
- [x] New `test_min_validators_qualified_gate` covers the core scenario
- [x] All 16 existing consensus aggregation tests pass
- [ ] Verify on testnet that miners qualifying via single dominant validator are correctly rejected
