### PR TITLE
fix(s1): hermes container permissions + restore LLM API key env vars

### DIFF
--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -230,12 +230,18 @@ def _docker_run_json(client: docker.DockerClient, image: str,
 
 def _put_file(
     container: Container, path: str, content: str | bytes,
-    mode: int = 0o644,
+    mode: int = 0o644, uid: int = 0, gid: int = 0,
 ) -> None:
     """Write a file into a container via tar archive.
 
     Works on containers that are created but not yet started (no exec_run
-    required). Sets file mode via tar header.
+    required). Sets file mode + ownership via tar header.
+
+    The uid/gid parameters matter when the container's runtime user is
+    not root (e.g. the Hermes image drops privileges to uid 10000 via
+    gosu). A file dropped with the default uid=0,mode=0o600 is
+    unreadable by a non-root runtime user — callers must pass the
+    target container's uid/gid.
     """
     import posixpath
     dir_name = posixpath.dirname(path)
@@ -246,6 +252,8 @@ def _put_file(
         info = tarfile.TarInfo(name=file_name)
         info.size = len(data)
         info.mode = mode
+        info.uid = uid
+        info.gid = gid
         tar.addfile(info, io.BytesIO(data))
     buf.seek(0)
     container.put_archive(dir_name, buf)
@@ -266,6 +274,24 @@ def _generate_keypair() -> tuple[str, str]:
         private_key = open(key_path).read()
         public_key = open(f"{key_path}.pub").read().strip()
     return private_key, public_key
+
+
+# Hermes image runtime user. The image's ENTRYPOINT gosu-drops to this
+# uid before running the agent command, so any file we put_archive into
+# the container must be owned by (or readable by) this uid.
+_HERMES_UID = 10000
+
+# Pre-entrypoint wrapper for Hermes containers: executed as root before
+# the image's own entrypoint gosu-drops to the hermes user. Chowns
+# /workspace so the judge can write /workspace/evaluation.json (Docker
+# creates working_dir= paths as root:root). Then exec's the image's
+# original entrypoint with the original command args intact.
+_HERMES_PREENTRY = (
+    "chown -R hermes:hermes /workspace 2>/dev/null; "
+    "chmod 0755 /workspace 2>/dev/null; "
+    "exec /opt/hermes/docker/entrypoint.sh \"$@\""
+)
+_HERMES_ENTRYPOINT = ["/bin/sh", "-c", _HERMES_PREENTRY, "--"]
 
 
 _PROVIDER_PREFIXES = ("openrouter/", "chutes/")
@@ -642,6 +668,7 @@ class TrajectorySandboxHarness:
 
             harness = self.client.containers.create(
                 self._harness_image,
+                entrypoint=_HERMES_ENTRYPOINT,
                 command=["chat", "-q", harness_prompt,
                          "-m", self._llm_model,
                          "-t", "terminal,file,code_execution,memory",
@@ -649,6 +676,12 @@ class TrajectorySandboxHarness:
                 name=harness_name,
                 environment={
                     "HERMES_BUNDLED_SKILLS": "/nonexistent",
+                    # Hermes' "custom" provider resolves the API key from
+                    # env, not from config.yaml's api_key: field. Provide
+                    # both common names so whichever routing path the
+                    # resolver takes can authenticate.
+                    "OPENROUTER_API_KEY": self._llm_api_key,
+                    "OPENAI_API_KEY":     self._llm_api_key,
                 },
                 mem_limit="4g", cpu_quota=200000,
                 labels={"trajectoryrl.role": "testee",
@@ -660,23 +693,21 @@ class TrajectorySandboxHarness:
             # Attach eval network so testee can reach sandbox via SSH
             network.connect(harness)
 
-            # Install SSH private key into testee container (mode 0600
-            # so ssh client accepts it).
-            _put_file(harness, "/tmp/id_ed25519", private_key, mode=0o600)
+            # Install SSH private key into testee container. Owned by the
+            # hermes uid so the non-root agent can read it (mode 0600 is
+            # required by the ssh client for private keys).
+            _put_file(harness, "/tmp/id_ed25519", private_key,
+                      mode=0o600, uid=_HERMES_UID, gid=_HERMES_UID)
 
             # Pin hermes to the configured OpenAI-compatible endpoint.
             # Without this, hermes' --provider auto routes by model name
             # (e.g. zai-org/* → openrouter) and ignores LLM_BASE_URL env.
-            # mode 0644 (not 0600) — put_archive writes as root:root, but the
-            # container runs as the hermes user. Image's entrypoint only
-            # chowns $HERMES_HOME when its own owner is wrong, and /opt/data
-            # is already hermes:hermes, so files we drop in stay root-owned.
             _put_file(
                 harness, "/opt/data/config.yaml",
                 _hermes_custom_config(
                     self._llm_model, self._llm_api_url, self._llm_api_key,
                 ),
-                mode=0o644,
+                mode=0o644, uid=_HERMES_UID, gid=_HERMES_UID,
             )
 
             harness.start()
@@ -772,6 +803,7 @@ class TrajectorySandboxHarness:
         try:
             judge = self.client.containers.create(
                 self._harness_image,
+                entrypoint=_HERMES_ENTRYPOINT,
                 command=["chat", "-q",
                          "Read /workspace/JUDGE.md for your evaluation protocol. "
                          "Read /workspace/JUDGE_TASK.md for this episode's evidence. "
@@ -789,6 +821,10 @@ class TrajectorySandboxHarness:
                 working_dir="/workspace",
                 environment={
                     "HERMES_BUNDLED_SKILLS": "/nonexistent",
+                    # See testee container: Hermes' "custom" provider reads
+                    # the API key from env, not from config.yaml.
+                    "OPENROUTER_API_KEY": self._llm_api_key,
+                    "OPENAI_API_KEY":     self._llm_api_key,
                 },
                 mem_limit="4g", cpu_quota=200000,
                 labels={"trajectoryrl.role": "judge",
@@ -798,15 +834,18 @@ class TrajectorySandboxHarness:
             )
 
             network.connect(judge)
-            _put_file(judge, "/workspace/JUDGE.md", judge_skill)
-            _put_file(judge, "/workspace/JUDGE_TASK.md", judge_instruction)
-            _put_file(judge, "/tmp/id_ed25519", private_key, mode=0o600)
+            _put_file(judge, "/workspace/JUDGE.md", judge_skill,
+                      uid=_HERMES_UID, gid=_HERMES_UID)
+            _put_file(judge, "/workspace/JUDGE_TASK.md", judge_instruction,
+                      uid=_HERMES_UID, gid=_HERMES_UID)
+            _put_file(judge, "/tmp/id_ed25519", private_key,
+                      mode=0o600, uid=_HERMES_UID, gid=_HERMES_UID)
             _put_file(
                 judge, "/opt/data/config.yaml",
                 _hermes_custom_config(
                     self._llm_model, self._llm_api_url, self._llm_api_key,
                 ),
-                mode=0o600,
+                mode=0o644, uid=_HERMES_UID, gid=_HERMES_UID,
             )
             judge.start()
 


### PR DESCRIPTION
Five related bugs prevent every S1 evaluation from producing a non-zero score against ghcr.io/trajectoryrl/hermes-agent:latest:

1. `_put_file` writes tar entries with uid=0,gid=0 (root:root). The Hermes image's ENTRYPOINT drops privileges to user `hermes` (uid 10000) via gosu before running the agent, so root-owned mode-0600 files (/tmp/id_ed25519) become unreadable — SSH into the sandbox fails for both testee and judge.

2. The judge container is created with working_dir="/workspace", which Docker creates as root:root. The hermes user can't write /workspace/evaluation.json, so the judge produces no output and quality defaults to 0.0.

3. Commit f287c27 changed only the testee's /opt/data/config.yaml to mode 0644; the judge's copy was left at 0600 — still unreadable by the hermes user.

4. Commit dd8e6fc moved LLM credentials from env vars into /opt/data/config.yaml under `provider: "custom"`. But Hermes' `custom` provider is designed for local servers that ignore auth — it does NOT read api_key: from the YAML. It falls back to OPENROUTER_API_KEY / OPENAI_API_KEY in the container env, which dd8e6fc stripped out. Result: "Provider resolver returned an empty API key" on startup.

5. (Follow-on of 4) Same problem on the judge.

Fix:

- Extend `_put_file` with uid/gid params (default 0,0 for back-compat).
- Pass uid=gid=10000 on all 6 _put_file calls targeting hermes containers so the files are owned by the runtime user.
- Wrap the hermes container entrypoint with a root-phase chown of /workspace so Docker-created working_dir paths become writable by the hermes user (evaluation.json + any agent-produced files).
- Bump the judge's /opt/data/config.yaml mode from 0600 to 0644, matching what f287c27 did for the testee.
- Restore OPENROUTER_API_KEY + OPENAI_API_KEY env vars on both testee and judge containers so Hermes' provider resolver has a credential source.

Verified: with upstream main (HEAD=f287c27) and no patch, S1 evaluation returns quality=0.0 on every episode (testee SSH fails, judge cannot write evaluation.json, provider resolver returns empty API key). With this commit applied, it gets scored successfully.