### PR TITLE
[coding-agent] gate eval start at block 7986780 (2026-04-17 08:00 UTC)

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -76,7 +76,7 @@ logger = logging.getLogger(__name__)
 
 OWNER_UID = 74
 BURN_FRACTION = 0.50  # 50% of miner emissions burned via owner UID
-EVAL_START_BLOCK = 0
+EVAL_START_BLOCK = 7986780  # 2026-04-17 08:00 UTC (ref: block 7986030 @ 05:30:09 UTC, ~12s/block)
 
 _METAGRAPH_SYNC_RETRIES = 3
 _METAGRAPH_SYNC_DELAY = 10  # seconds between retries


### PR DESCRIPTION
Combined with the existing _should_start_evaluation check, eval only runs once block >= EVAL_START_BLOCK AND window.phase == EVALUATION. Pre-launch path continues to set fallback weights only.