### PR TITLE
feat: add window_shift operational knob for window alignment

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -212,6 +212,7 @@ class TrajectoryValidator:
             global_anchor=config.global_anchor_block,
             publish_pct=config.window_publish_pct,
             aggregate_pct=config.window_aggregate_pct,
+            window_shift=config.window_shift,
         )
         # Which window's aggregation has completed (persisted in eval state).
         # Guards one-shot aggregation per window — survives restarts.
@@ -927,7 +928,7 @@ class TrajectoryValidator:
 
         synthetic_window = EvaluationWindow(
             window_number=target_window,
-            window_start=self._window_config.global_anchor
+            window_start=self._window_config.effective_anchor
             + target_window * self._window_config.window_length,
             block_offset=self._window_config.window_length - 1,
             phase=WindowPhase.AGGREGATION,
@@ -1059,6 +1060,7 @@ class TrajectoryValidator:
             f"Eval window: {self._window_config.window_length} blocks "
             f"(~{self._window_config.window_length * 12 // 3600:.0f}h), "
             f"anchor={self._window_config.global_anchor}, "
+            f"shift={self._window_config.window_shift}, "
             f"publish={self._window_config.publish_pct:.0%}, "
             f"aggregate={self._window_config.aggregate_pct:.0%}"
         )

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -52,6 +52,7 @@ class ValidatorConfig:
     global_anchor_block: int = 0     # anchor block for window alignment
     window_publish_pct: float = 0.80  # T_publish: 80% of window for evaluation
     window_aggregate_pct: float = 0.90  # T_aggregate: 90% (10% propagation interval)
+    window_shift: int = 0             # additive offset applied to window start (env: WINDOW_SHIFT)
 
     # Scoring config
     delta_threshold: float = 0.05
@@ -201,6 +202,8 @@ class ValidatorConfig:
             aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "0") == "1",
             full_cycle_on_startup=os.getenv("FULL_CYCLE_ON_STARTUP", "0") == "1",
             disable_winner_protection=os.getenv("DISABLE_WINNER_PROTECTION", "0") == "1",
+            # --- Window shift (operational knob; must match across validators) ---
+            window_shift=int(os.getenv("WINDOW_SHIFT", "0")),
             # --- IM parameters are hardcoded (dataclass defaults) ---
             # Do NOT load from env: score_delta,
             # rho_reliability, consensus_epsilon, bootstrap_threshold,

--- a/trajectoryrl/utils/eval_window.py
+++ b/trajectoryrl/utils/eval_window.py
@@ -34,6 +34,7 @@ class WindowConfig:
     global_anchor: int = 0          # anchor block for window alignment
     publish_pct: float = 0.80       # T_publish as fraction of window
     aggregate_pct: float = 0.90     # T_aggregate as fraction of window
+    window_shift: int = 0           # additive offset applied to window start
 
     @property
     def publish_block(self) -> int:
@@ -42,6 +43,10 @@ class WindowConfig:
     @property
     def aggregate_block(self) -> int:
         return int(self.window_length * self.aggregate_pct)
+
+    @property
+    def effective_anchor(self) -> int:
+        return self.global_anchor + self.window_shift
 
 
 @dataclass(frozen=True)
@@ -73,14 +78,15 @@ def compute_window(current_block: int, config: WindowConfig) -> EvaluationWindow
     Pure function -- deterministic for any given (current_block, config) pair.
     Every validator calling this with the same inputs gets the same result.
     """
-    if current_block < config.global_anchor:
-        effective_block = config.global_anchor
+    anchor = config.effective_anchor
+    if current_block < anchor:
+        effective_block = anchor
     else:
         effective_block = current_block
 
-    blocks_since_anchor = effective_block - config.global_anchor
+    blocks_since_anchor = effective_block - anchor
     window_number = blocks_since_anchor // config.window_length
-    window_start = config.global_anchor + window_number * config.window_length
+    window_start = anchor + window_number * config.window_length
     block_offset = effective_block - window_start
 
     publish_block = config.publish_block


### PR DESCRIPTION
Adds an additive offset to window start, controllable via WINDOW_SHIFT env var, on top of the existing fixed global_anchor. Useful to shift the evaluation window boundary without changing the anchor constant.