### PR TITLE
fix: enable disable_winner_protection and aggregate_when_start by def…

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -198,9 +198,9 @@ class ValidatorConfig:
             sandbox_timeout_per_episode=int(os.getenv("SANDBOX_TIMEOUT_PER_EPISODE", "180")),
             sandbox_num_episodes=int(os.getenv("SANDBOX_NUM_EPISODES", "4")),
             # --- Startup aggregation ---
-            aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "0") == "1",
+            aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "1") == "1",
             full_cycle_on_startup=os.getenv("FULL_CYCLE_ON_STARTUP", "0") == "1",
-            disable_winner_protection=os.getenv("DISABLE_WINNER_PROTECTION", "0") == "1",
+            disable_winner_protection=os.getenv("DISABLE_WINNER_PROTECTION", "1") == "1",
             # --- IM parameters are hardcoded (dataclass defaults) ---
             # Do NOT load from env: score_delta,
             # rho_reliability, consensus_epsilon, bootstrap_threshold,


### PR DESCRIPTION
…ault

Flip env defaults for DISABLE_WINNER_PROTECTION and AGGREGATE_WHEN_START from "0" to "1" so validators converge on the lowest-cost winner and run consensus aggregation on startup without needing explicit opt-in.