### PR TITLE
[coding-agent] fix: pull sandbox image before startup aggregation

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -1056,6 +1056,30 @@ class TrajectoryValidator:
             f"(~{self.config.weight_interval_blocks * 12 // 60}min)"
         )
 
+        # Pull sandbox image early so SCORING_VERSION is correct for
+        # startup aggregation (otherwise it stays at the default=1).
+        if self.config.full_cycle_on_startup or self.config.aggregate_when_start:
+            try:
+                await self._sandbox_harness.pull_latest()
+                _consensus_mod.SCORING_VERSION = (
+                    self._sandbox_harness.scoring_version
+                )
+                logger.info(
+                    "scoring_version=%d (bench_version=%s) — set before "
+                    "startup aggregation",
+                    self._sandbox_harness.scoring_version,
+                    self._sandbox_harness.sandbox_version,
+                )
+                # Reload: __init__ loaded with stale SCORING_VERSION=1,
+                # which invalidated the saved state. Now that the real
+                # version is known, reload to recover _eval_pack_hash etc.
+                self._load_eval_state()
+            except Exception as e:
+                logger.warning(
+                    "Failed to pull sandbox image before startup aggregation: "
+                    "%s — scoring_version may be stale", e,
+                )
+
         if self.config.full_cycle_on_startup:
             try:
                 await self._full_cycle_on_startup()


### PR DESCRIPTION
Startup aggregation was always failing because SCORING_VERSION remained at its default value (1) when _aggregate_on_startup ran. The image pull that sets the real scoring_version (e.g. 3) only happened later inside _run_evaluation_cycle. This caused all chain commitments to be filtered out with "scoring_version mismatch", making aggregation a no-op.

Fix: pull the sandbox image and update SCORING_VERSION before running startup aggregation or full_cycle_on_startup. Then reload eval state so that _eval_pack_hash is recovered (it was discarded in __init__ due to the stale scoring_version mismatch), preventing unnecessary re-evaluation of miners whose pack_hash hasn't changed.

Made-with: Cursor