### PR TITLE
[coding-agent] sandbox cleanup + idle-timeout watchdog

### DIFF
--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -6,6 +6,7 @@ without requiring Docker or real LLM API calls.
 
 import pytest
 from dataclasses import dataclass, field
+from unittest.mock import MagicMock
 
 from trajectoryrl.utils.config import ValidatorConfig
 from trajectoryrl.utils.sandbox_harness import (
@@ -13,6 +14,7 @@ from trajectoryrl.utils.sandbox_harness import (
     SandboxEvaluationResult,
     _SessionResult,
     _EpisodeResult,
+    _EMPTY_TRANSCRIPT_THRESHOLD,
 )
 
 
@@ -125,10 +127,81 @@ class TestConfigWiring:
         assert hasattr(ValidatorConfig, "harness_image")
         assert hasattr(ValidatorConfig, "sandbox_timeout_per_episode")
         assert hasattr(ValidatorConfig, "sandbox_num_episodes")
+        assert hasattr(ValidatorConfig, "sandbox_idle_timeout")
 
     def test_season1_defaults(self):
         assert ValidatorConfig.sandbox_num_episodes == 4
         assert ValidatorConfig.sandbox_timeout_per_episode == 180
+        assert ValidatorConfig.sandbox_idle_timeout == 45
+
+
+# ---------------------------------------------------------------------------
+# Tests: Empty-transcript judge skip
+# ---------------------------------------------------------------------------
+
+class TestEmptyTranscriptThreshold:
+    def test_threshold_is_reasonable(self):
+        # Hermes startup boilerplate is ~130 chars; a working agent
+        # always produces multi-kB transcripts. The threshold sits
+        # between those two regimes.
+        assert 130 < _EMPTY_TRANSCRIPT_THRESHOLD < 1000
+
+
+# ---------------------------------------------------------------------------
+# Tests: Orphan container cleanup
+# ---------------------------------------------------------------------------
+
+class TestOrphanCleanup:
+    def _make_harness(self, tmp_path) -> TrajectorySandboxHarness:
+        cfg = ValidatorConfig(
+            pack_cache_dir=tmp_path / "packs",
+            log_dir=tmp_path / "logs",
+            eval_state_path=tmp_path / "eval_state.json",
+            winner_state_path=tmp_path / "winner_state.json",
+        )
+        h = TrajectorySandboxHarness(cfg)
+        h._docker_client = MagicMock()
+        return h
+
+    def test_cleanup_removes_labeled_containers_and_networks(self, tmp_path):
+        h = self._make_harness(tmp_path)
+        c1 = MagicMock(); c1.name = "sandbox_abc"
+        c2 = MagicMock(); c2.name = "testee_abc_ep0"
+        n1 = MagicMock(); n1.name = "eval_abc"
+        h.client.containers.list.return_value = [c1, c2]
+        h.client.networks.list.return_value = [n1]
+
+        h._cleanup_orphan_containers()
+
+        h.client.containers.list.assert_called_once_with(
+            all=True, filters={"label": "trajectoryrl.role"},
+        )
+        h.client.networks.list.assert_called_once_with(
+            filters={"label": "trajectoryrl.role"},
+        )
+        c1.remove.assert_called_once_with(force=True)
+        c2.remove.assert_called_once_with(force=True)
+        n1.remove.assert_called_once_with()
+
+    def test_cleanup_swallows_per_item_failures(self, tmp_path):
+        h = self._make_harness(tmp_path)
+        bad = MagicMock(); bad.name = "bad"; bad.remove.side_effect = RuntimeError("nope")
+        good = MagicMock(); good.name = "good"
+        h.client.containers.list.return_value = [bad, good]
+        h.client.networks.list.return_value = []
+
+        # Must not raise even when one container removal fails.
+        h._cleanup_orphan_containers()
+
+        good.remove.assert_called_once_with(force=True)
+
+    def test_cleanup_swallows_list_failure(self, tmp_path):
+        h = self._make_harness(tmp_path)
+        h.client.containers.list.side_effect = RuntimeError("docker down")
+        h.client.networks.list.side_effect = RuntimeError("docker down")
+
+        # Must not raise even if Docker is entirely unreachable.
+        h._cleanup_orphan_containers()
 
 
 # ---------------------------------------------------------------------------

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -117,6 +117,10 @@ class ValidatorConfig:
     harness_image: str = "ghcr.io/trajectoryrl/hermes-agent:latest"
     sandbox_timeout_per_episode: int = 180  # 3 min per episode
     sandbox_num_episodes: int = 4
+    # Kill testee early if no transcript growth for this many seconds.
+    # An idle Hermes agent (only initialization output) wastes the full
+    # per-episode timeout otherwise; capped at sandbox_timeout_per_episode.
+    sandbox_idle_timeout: int = 45
 
     # Evaluation state persistence
     eval_state_path: Path = field(
@@ -197,6 +201,7 @@ class ValidatorConfig:
             harness_image=os.getenv("HARNESS_IMAGE", "ghcr.io/trajectoryrl/hermes-agent:latest"),
             sandbox_timeout_per_episode=int(os.getenv("SANDBOX_TIMEOUT_PER_EPISODE", "180")),
             sandbox_num_episodes=int(os.getenv("SANDBOX_NUM_EPISODES", "4")),
+            sandbox_idle_timeout=int(os.getenv("SANDBOX_IDLE_TIMEOUT", "45")),
             # --- Startup aggregation ---
             aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "1") == "1",
             full_cycle_on_startup=os.getenv("FULL_CYCLE_ON_STARTUP", "0") == "1",

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -281,6 +281,15 @@ def _generate_keypair() -> tuple[str, str]:
 # the container must be owned by (or readable by) this uid.
 _HERMES_UID = 10000
 
+# Transcripts shorter than this are considered "agent never woke up"
+# (only Hermes startup boilerplate, no LLM calls were made). Skipping
+# the judge for these episodes saves 1-3 minutes each — a real working
+# agent always produces multi-kB transcripts.
+_EMPTY_TRANSCRIPT_THRESHOLD = 200
+
+# Polling cadence for the testee idle-timeout watchdog.
+_TESTEE_POLL_INTERVAL = 5.0
+
 # Pre-entrypoint wrapper for Hermes containers: executed as root before
 # the image's own entrypoint gosu-drops to the hermes user. Chowns
 # /workspace so the judge can write /workspace/evaluation.json (Docker
@@ -402,7 +411,62 @@ class TrajectorySandboxHarness:
         except Exception as e:
             logger.warning("Failed to pull latest images: %s (using cached)", e)
 
+    def _cleanup_orphan_containers(self) -> None:
+        """Remove leftover sandbox/testee/judge containers and networks.
+
+        When the validator process is killed (OOM, docker stop, host
+        reboot), the per-eval `finally` blocks never run, so containers
+        and networks tagged with `trajectoryrl.role` keep running
+        forever. This routine reaps any such orphans before the next
+        eval cycle. Best-effort: failures are logged but never raise.
+        """
+        try:
+            orphans = self.client.containers.list(
+                all=True, filters={"label": "trajectoryrl.role"},
+            )
+        except Exception as e:
+            logger.warning("Orphan cleanup: failed to list containers: %s", e)
+            orphans = []
+
+        removed = 0
+        for c in orphans:
+            try:
+                c.remove(force=True)
+                removed += 1
+            except Exception as e:
+                logger.warning(
+                    "Orphan cleanup: failed to remove container %s: %s",
+                    getattr(c, "name", "?"), e,
+                )
+
+        try:
+            stale_nets = self.client.networks.list(
+                filters={"label": "trajectoryrl.role"},
+            )
+        except Exception as e:
+            logger.warning("Orphan cleanup: failed to list networks: %s", e)
+            stale_nets = []
+
+        nets_removed = 0
+        for n in stale_nets:
+            try:
+                n.remove()
+                nets_removed += 1
+            except Exception as e:
+                logger.warning(
+                    "Orphan cleanup: failed to remove network %s: %s",
+                    getattr(n, "name", "?"), e,
+                )
+
+        if removed or nets_removed:
+            logger.info(
+                "Orphan cleanup: removed %d container(s), %d network(s)",
+                removed, nets_removed,
+            )
+
     def _pull_sync(self) -> None:
+        self._cleanup_orphan_containers()
+
         for image in [self._sandbox_image, self._harness_image]:
             try:
                 logger.info("Pulling latest image: %s", image)
@@ -713,34 +777,7 @@ class TrajectorySandboxHarness:
             harness.start()
 
             try:
-                # Wait for harness to complete
-                timeout = self.config.sandbox_timeout_per_episode
-                try:
-                    result = harness.wait(timeout=timeout)
-                    exit_code = result.get("StatusCode", -1)
-                except Exception:
-                    logger.warning("[%s] Episode %d timed out after %ds",
-                                   session_id, episode_index, timeout)
-                    try:
-                        harness.kill()
-                    except Exception:
-                        pass
-                    episode.timed_out = True
-
-                # Capture transcript
-                try:
-                    episode.transcript = harness.logs(
-                        stdout=True, stderr=False
-                    ).decode(errors="replace")
-                except Exception:
-                    pass
-
-                logger.info(
-                    "[%s] Episode %d testee transcript captured (%d chars)",
-                    session_id, episode_index,
-                    len(episode.transcript or ""),
-                )
-
+                self._wait_for_testee(harness, episode, session_id, episode_index)
             finally:
                 try:
                     harness.stop(timeout=3)
@@ -758,20 +795,39 @@ class TrajectorySandboxHarness:
                     pass
 
             # -----------------------------------------------------------
-            # Score via agent judge (explores sandbox state via SSH + HTTP)
+            # Score via agent judge (explores sandbox state via SSH + HTTP).
+            # Skip when the testee produced effectively no output — the
+            # judge would just confirm zero work done after burning more
+            # minutes of LLM time.
             # -----------------------------------------------------------
-            self._score_episode_agent(
-                session_id=session_id,
-                episode_index=episode_index,
-                episode=episode,
-                ep_data=ep_data,
-                world_data=world_data,
-                scenario=scenario,
-                sandbox=sandbox,
-                network=network,
-                private_key=private_key,
-                judge_skill=judge_skill,
-            )
+            transcript_len = len(episode.transcript or "")
+            if transcript_len < _EMPTY_TRANSCRIPT_THRESHOLD:
+                logger.info(
+                    "[%s] Episode %d: empty testee transcript (%d chars), "
+                    "skipping judge (quality=0.0)",
+                    session_id, episode_index, transcript_len,
+                )
+                episode.quality = 0.0
+                episode.judge_result = {
+                    "quality": 0.0,
+                    "summary": (
+                        "Testee produced no meaningful transcript "
+                        f"({transcript_len} chars); judge skipped."
+                    ),
+                }
+            else:
+                self._score_episode_agent(
+                    session_id=session_id,
+                    episode_index=episode_index,
+                    episode=episode,
+                    ep_data=ep_data,
+                    world_data=world_data,
+                    scenario=scenario,
+                    sandbox=sandbox,
+                    network=network,
+                    private_key=private_key,
+                    judge_skill=judge_skill,
+                )
 
             logger.info("[%s] Episode %d quality=%.3f",
                         session_id, episode_index, episode.quality)
@@ -783,6 +839,91 @@ class TrajectorySandboxHarness:
 
         episode.duration_s = time.time() - t0
         return episode
+
+    def _wait_for_testee(
+        self, harness: Container, episode: _EpisodeResult,
+        session_id: str, episode_index: int,
+    ) -> None:
+        """Wait for the testee container with an idle-output watchdog.
+
+        A real working agent emits transcript output continuously
+        (LLM responses, tool calls, intermediate text). An agent that
+        only printed Hermes startup boilerplate ("Dropping root
+        privileges", "Syncing bundled skills") and then went silent
+        is never going to do anything — kill it early instead of
+        burning the full per-episode budget.
+
+        The watchdog kills the container if container logs do not
+        grow for ``sandbox_idle_timeout`` seconds, capped by the
+        absolute ``sandbox_timeout_per_episode``. Either way the
+        captured transcript is whatever the container emitted.
+        """
+        max_total = float(self.config.sandbox_timeout_per_episode)
+        idle_limit = float(
+            min(self.config.sandbox_idle_timeout, max_total)
+        )
+
+        start_ts = time.time()
+        last_progress_ts = start_ts
+        last_size = 0
+        timed_out_reason: str | None = None
+
+        while True:
+            try:
+                wait_for = min(_TESTEE_POLL_INTERVAL, idle_limit)
+                result = harness.wait(timeout=wait_for)
+                # Container exited within the polling slice.
+                _ = result.get("StatusCode", -1)
+                break
+            except Exception:
+                pass  # poll timeout — still running, continue watchdog
+
+            now = time.time()
+
+            try:
+                current_logs = harness.logs(stdout=True, stderr=False)
+                current_size = len(current_logs or b"")
+            except Exception:
+                current_size = last_size
+
+            if current_size > last_size:
+                last_size = current_size
+                last_progress_ts = now
+
+            if now - last_progress_ts >= idle_limit:
+                timed_out_reason = (
+                    f"idle (no transcript growth for {idle_limit:.0f}s)"
+                )
+                break
+
+            if now - start_ts >= max_total:
+                timed_out_reason = f"hard timeout after {max_total:.0f}s"
+                break
+
+        if timed_out_reason is not None:
+            logger.warning(
+                "[%s] Episode %d killed: %s",
+                session_id, episode_index, timed_out_reason,
+            )
+            try:
+                harness.kill()
+            except Exception:
+                pass
+            episode.timed_out = True
+
+        try:
+            episode.transcript = harness.logs(
+                stdout=True, stderr=False
+            ).decode(errors="replace")
+        except Exception:
+            pass
+
+        logger.info(
+            "[%s] Episode %d testee transcript captured (%d chars, %.1fs)",
+            session_id, episode_index,
+            len(episode.transcript or ""),
+            time.time() - start_ts,
+        )
 
     def _score_episode_agent(
         self, session_id: str, episode_index: int,


### PR DESCRIPTION
## Background

Investigated why the validator had not produced new aggregations for ~30h.
Two issues surfaced:

1. **Zombie sandbox containers**: 12 containers labeled `trajectoryrl.role`
   were running on the box, some 4 days old. All validators have this bug —
   when the validator is killed, `finally` blocks in the harness never run.
2. **Eval rounds take ~20h** mostly because most testee Hermes agents only
   print startup boilerplate and then sit idle until the 180s timeout, after
   which the judge ALSO runs for another 1-3min on an empty transcript.

## Changes

1. **Orphan reaping**: `_cleanup_orphan_containers()` runs at the top of
   `_pull_sync()`, force-removes containers/networks tagged
   `trajectoryrl.role` from previous runs.
2. **Idle-timeout watchdog**: `_wait_for_testee()` polls every 5s, kills
   the container if no transcript growth for `sandbox_idle_timeout`s
   (default 45). Working agents (continuous output) unaffected.
3. **Skip judge for empty**: when transcript < 200 chars, record
   `quality=0.0` and skip the judge entirely.

New config: `sandbox_idle_timeout: int = 45` (env `SANDBOX_IDLE_TIMEOUT`).

## Expected impact

| Episode shape | Before | After |
|---|---|---|
| Working testee | 180s + 120s | unchanged |
| Empty testee   | 180s + 120s | 45s + 0s |

Round wall time roughly **20h → 14h**.

## Test plan

- 21 sandbox harness tests pass (4 new); full suite has 305 pass / 23
  pre-existing failures unchanged from main
- No new lint warnings
- [ ] Validate in staging: watch idle-kill log messages and reduced per-episode duration