### PR TITLE
fix: count missing miner entries as 0-score in consensus aggregation

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1897,13 +1897,17 @@ class TestConsensusAggregation:
         assert scores["m1"] == pytest.approx(0.5)
 
     def test_different_miners_per_validator(self):
+        # v2 omits m2 from its payload — that counts as a 0-score vote
+        # with v2's full stake weight.
         subs = [
             self._make_validated("v1", 100.0, {"m1": 0.4, "m2": 0.6}),
             self._make_validated("v2", 100.0, {"m1": 0.8}),
         ]
         scores, _ = compute_consensus_scores(subs)
+        # m1: (100*0.4 + 100*0.8) / 200 = 0.6
         assert scores["m1"] == pytest.approx(0.6)
-        assert scores["m2"] == pytest.approx(0.6)
+        # m2: (100*0.6 + 100*0.0) / 200 = 0.3
+        assert scores["m2"] == pytest.approx(0.3)
 
     def test_disqualification_equal_stake_split_not_disqualified(self):
         """50/50 stake split: disq_ratio = 0.5, NOT > 0.5, so NOT disqualified."""

--- a/trajectoryrl/scoring/__init__.py
+++ b/trajectoryrl/scoring/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 import numpy as np
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 from dataclasses import dataclass, field
 
 from ..utils.consensus_filter import ValidatedSubmission
@@ -554,6 +554,14 @@ def compute_consensus_scores(
     if not validated_submissions:
         return {}, {}
 
+    # Union of miners mentioned in any submission. A validator that omits a
+    # miner from its own payload is treated as a 0-score vote with full stake
+    # weight, rather than being excluded from that miner's denominator.
+    all_miners_global: Set[str] = set()
+    for sub in validated_submissions:
+        all_miners_global.update(sub.payload.scores.keys())
+        all_miners_global.update(sub.payload.disqualified.keys())
+
     miner_weighted_score: Dict[str, float] = {}
     miner_total_stake: Dict[str, float] = {}
 
@@ -568,9 +576,13 @@ def compute_consensus_scores(
             continue
 
         disqualified = sub.payload.disqualified
+        scores = sub.payload.scores
 
-        all_miners = set(sub.payload.scores.keys()) | set(disqualified.keys())
-        for miner_hk in all_miners:
+        # Disqualification ratio stays per-submission: a validator can only
+        # vote to disqualify miners it actually reported on, and the
+        # denominator matches so silence doesn't implicitly vote against.
+        per_sub_miners = set(scores.keys()) | set(disqualified.keys())
+        for miner_hk in per_sub_miners:
             if miner_hk not in miner_reporting_stake:
                 miner_reporting_stake[miner_hk] = 0.0
                 miner_disq_stake[miner_hk] = 0.0
@@ -580,16 +592,17 @@ def compute_consensus_scores(
                 miner_disq_stake[miner_hk] += stake
                 miner_disq_reasons[miner_hk] = disqualified[miner_hk]
 
-        for miner_hk, score in sub.payload.scores.items():
+        # Score aggregation covers every miner seen anywhere. Missing entries
+        # contribute a 0-score with full stake weight so validators that
+        # failed to evaluate a miner drag its consensus score down.
+        for miner_hk in all_miners_global:
             if miner_hk in disqualified:
                 continue
-
             if miner_hk not in miner_total_stake:
                 miner_total_stake[miner_hk] = 0.0
                 miner_weighted_score[miner_hk] = 0.0
-
             miner_total_stake[miner_hk] += stake
-            miner_weighted_score[miner_hk] += stake * score
+            miner_weighted_score[miner_hk] += stake * scores.get(miner_hk, 0.0)
 
     # Compute consensus disqualification via stake-weighted majority
     consensus_disqualified: Dict[str, str] = {}


### PR DESCRIPTION
A validator that submits a payload but omits a miner from its scores dict now contributes a 0-score with full stake weight for that miner, instead of being excluded from the miner's denominator. This prevents validators with partial evaluations from disproportionately weighing their subset of the miner population.

Disqualification voting still runs per-submission (a validator can only vote to disqualify miners it actually reported on).