### PR TITLE
fix: drop near-zero-signal consensus submissions above threshold

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1818,6 +1818,34 @@ class TestConsensusFilter:
         assert len(passed) == 2
         assert skipped == 0
 
+    def test_filter_zero_signal_threshold_drops_near_zero(self):
+        # val_b has 41/42 zero scores (97.6%) — a single token-nonzero — and
+        # should be dropped when zero_threshold < 0.976. val_a has real signal.
+        big_all_zero = {f"m{i}": 0.0 for i in range(41)}
+        big_near_zero = {**big_all_zero, "m_winner": 0.02}
+        big_real = {f"m{i}": 0.5 for i in range(5)}
+        subs = [
+            self._make_submission(hotkey="val_a", scores=big_real),
+            self._make_submission(hotkey="val_b", scores=big_near_zero),
+        ]
+        passed, skipped = filter_zero_signal(subs, zero_threshold=0.95)
+        assert len(passed) == 1
+        assert skipped == 1
+        assert passed[0][0].validator_hotkey == "val_a"
+
+    def test_filter_zero_signal_default_threshold_keeps_near_zero(self):
+        # Same near-zero payload passes under the legacy default (1.0) —
+        # only strictly all-zero payloads are dropped.
+        big_all_zero = {f"m{i}": 0.0 for i in range(41)}
+        big_near_zero = {**big_all_zero, "m_winner": 0.02}
+        subs = [
+            self._make_submission(hotkey="val_a", scores={"m": 0.85}),
+            self._make_submission(hotkey="val_b", scores=big_near_zero),
+        ]
+        passed, skipped = filter_zero_signal(subs)
+        assert len(passed) == 2
+        assert skipped == 0
+
     def test_full_pipeline_cascading_filters(self):
         subs = [
             self._make_submission(hotkey="good", window=42, protocol=1, version="0.1.0", scores={"m": 0.85}),

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -738,6 +738,7 @@ class TrajectoryValidator:
                 validator_stakes[hotkey] = stake
 
         min_stake = getattr(self.config, "min_validator_stake", 0.0)
+        zero_threshold = getattr(self.config, "zero_signal_threshold", 1.0)
         validated, stats = run_filter_pipeline(
             submissions=submissions,
             expected_window=window.window_number,
@@ -745,6 +746,7 @@ class TrajectoryValidator:
             min_stake=min_stake,
             expected_protocol=self.config.consensus_protocol_version,
             expected_scoring_version=_scoring_version(),
+            zero_signal_threshold=zero_threshold,
         )
 
         if not validated:

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -74,6 +74,11 @@ class ValidatorConfig:
     consensus_api_url: str = "https://trajrl.com"
     min_validator_stake: float = 10000.0  # minimum stake weight (α) for consensus participation
 
+    # Fraction of zero scores above which a submission is treated as a
+    # free-rider / near-zero-signal payload and dropped from consensus.
+    # 1.0 = only all-zero payloads dropped (legacy behaviour).
+    zero_signal_threshold: float = 0.95
+
     # Bootstrap config (graduated rewards until enough miners join)
     bootstrap_threshold: int = 10
 

--- a/trajectoryrl/utils/consensus_filter.py
+++ b/trajectoryrl/utils/consensus_filter.py
@@ -136,11 +136,17 @@ def filter_scoring_version(
 
 def filter_zero_signal(
     submissions: List[Tuple[ConsensusPointer, ConsensusPayload]],
+    zero_threshold: float = 1.0,
 ) -> Tuple[List[Tuple[ConsensusPointer, ConsensusPayload]], int]:
-    """Layer 7: discard all-zero score submissions when non-zero signals exist.
+    """Layer 7: discard near-zero-signal submissions when real signal exists.
 
-    Prevents free-riding validators from diluting legitimate signals.
-    If ALL submissions are zero, they all pass (bootstrap scenario).
+    A submission is dropped when the fraction of zero scores meets or exceeds
+    ``zero_threshold``.  Default 1.0 keeps the legacy behaviour (drop only
+    strictly all-zero payloads).  Lower values (e.g. 0.95) treat free-rider
+    payloads that sprinkle one or two nonzero scores as all-zero.
+
+    If no submission has any nonzero scores, all pass through (bootstrap
+    scenario — nothing to compare against).
     """
     has_nonzero = any(
         any(s != 0.0 for s in payload.scores.values())
@@ -153,10 +159,21 @@ def filter_zero_signal(
     passed = []
     skipped = 0
     for ptr, payload in submissions:
-        if not payload.scores or all(s == 0.0 for s in payload.scores.values()):
+        scores = payload.scores
+        if not scores:
             logger.debug(
-                "Filter[zero-signal]: skip %s (all-zero scores)",
+                "Filter[zero-signal]: skip %s (empty scores)",
                 ptr.validator_hotkey[:8],
+            )
+            skipped += 1
+            continue
+        zero_count = sum(1 for s in scores.values() if s == 0.0)
+        zero_ratio = zero_count / len(scores)
+        if zero_ratio >= zero_threshold:
+            logger.debug(
+                "Filter[zero-signal]: skip %s (%d/%d = %.1f%% zero >= %.1f%%)",
+                ptr.validator_hotkey[:8],
+                zero_count, len(scores), 100 * zero_ratio, 100 * zero_threshold,
             )
             skipped += 1
         else:
@@ -171,6 +188,7 @@ def run_filter_pipeline(
     min_stake: float,
     expected_protocol: int = CONSENSUS_PROTOCOL_VERSION,
     expected_scoring_version: Optional[int] = None,
+    zero_signal_threshold: float = 1.0,
 ) -> Tuple[List[ValidatedSubmission], FilterStats]:
     """Run the full 5-layer filter pipeline.
 
@@ -194,7 +212,7 @@ def run_filter_pipeline(
     current, n = filter_scoring_version(current, expected_scoring_version)
     stats.skipped_scoring_version = n
 
-    current, n = filter_zero_signal(current)
+    current, n = filter_zero_signal(current, zero_threshold=zero_signal_threshold)
     stats.skipped_zero_signal = n
 
     validated = []


### PR DESCRIPTION
Real example from window 1113: validator UID 29 submitted 42 miner scores, 41 of them 0.0 and exactly one nonzero — miner UID 70 at 0.0256. That single 0.0256 was enough to slip past ``filter_zero_signal`` (which only drops strictly all-zero payloads), after which UID 29's full stake weight applied a 0.0 score to every other miner in its payload, dragging their consensus scores down.

This patch adds a configurable zero-score ratio. A submission is dropped when the fraction of zeros meets or exceeds the threshold. Configured via ``ValidatorConfig.zero_signal_threshold`` (default 0.95); UID 29's 97.6%-zero payload would be rejected under that setting. The filter function's own default stays at 1.0 to preserve legacy behaviour for direct callers.