### PR TITLE
fix: clear cached eval data when evaluation returns None

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -1641,6 +1641,11 @@ class TrajectoryValidator:
                     f"{elapsed_str} "
                     f"(pack fetch/integrity failed)"
                 )
+                # Drop any stale cached scores so a future successful eval
+                # starts from a clean slate rather than re-surfacing old data
+                # under a potentially-stale pack_hash.
+                self.scenario_scores.pop(hotkey, None)
+                self._eval_pack_hash.pop(hotkey, None)
 
             # Mid-eval tempo refresh: re-assert the current winner's weights
             # to keep the validator active on-chain without recomputing.


### PR DESCRIPTION
When _evaluate_miner returns None (pack fetch or integrity failure), the miner's entries in self.scenario_scores and self._eval_pack_hash are now popped. Previously the stale cache survived the failure and kept feeding old scores into consensus payloads, which could misrepresent a miner whose pack is currently broken as still having the last known good result.

This matches the existing cache-pop behaviour on integrity and pre-eval rejection paths elsewhere in the same loop.