### PR TITLE
test: pin generate to codebase_fix scenario for evaluation

### DIFF
--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -508,6 +508,7 @@ class TrajectorySandboxHarness:
         gen_data = _docker_run_json(
             self.client, self._sandbox_image,
             command=["python", "-m", "trajrl_bench.cli", "generate",
+                     "--scenario", "codebase_fix",
                      "--seed", str(epoch_seed), "--salt", salt,
                      "--episodes", str(num_episodes)],
         )


### PR DESCRIPTION
## Summary
- Pin the sandbox harness `generate` command to `--scenario codebase_fix` so evaluation runs target the `codebase_fix` scenario specifically (instead of the harness default).

## Motivation
Used for targeted evaluation of miners on the `codebase_fix` scenario. Currently `incident_response` is the default that gets exercised; this change forces the harness to generate `codebase_fix` episodes for testing.

## Test plan
- [ ] Run `scripts/eval_miners.py --miner-uid <uid>` and confirm logs show `Scenario: codebase_fix` for generated episodes.
- [ ] Verify episode generation succeeds end-to-end against sandbox image 3.1.0.


Made with [Cursor](https://cursor.com)