### PR TITLE
feat: default sandbox_scenario to codebase_fix

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -136,12 +136,11 @@ class ValidatorConfig:
     sandbox_num_episodes: int = 4
     # Scenario the sandbox CLI should generate fixtures for. The CLI
     # supports incident_response, morning_brief, and codebase_fix (see
-    # trajrl_bench.fixture_factory.SCENARIOS). Previously the validator
-    # never passed --scenario so the CLI silently defaulted to
-    # incident_response regardless of the bench image's advertised
-    # catalog — making morning_brief and codebase_fix unreachable from
-    # the validator path.
-    sandbox_scenario: str = "incident_response"
+    # trajrl_bench.fixture_factory.SCENARIOS). Default is codebase_fix
+    # — the newest scenario and the one the mistakes-and-memory
+    # learning rubric is designed around; operators can still pin an
+    # older scenario via ``SANDBOX_SCENARIO``.
+    sandbox_scenario: str = "codebase_fix"
 
     # Evaluation state persistence
     eval_state_path: Path = field(
@@ -231,7 +230,7 @@ class ValidatorConfig:
             image_channel=os.getenv("IMAGE_CHANNEL", DEFAULT_IMAGE_CHANNEL),
             sandbox_timeout_per_episode=int(os.getenv("SANDBOX_TIMEOUT_PER_EPISODE", "180")),
             sandbox_num_episodes=int(os.getenv("SANDBOX_NUM_EPISODES", "4")),
-            sandbox_scenario=os.getenv("SANDBOX_SCENARIO", "incident_response"),
+            sandbox_scenario=os.getenv("SANDBOX_SCENARIO", "codebase_fix"),
             # --- Startup aggregation ---
             aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "1") == "1",
             full_cycle_on_startup=os.getenv("FULL_CYCLE_ON_STARTUP", "0") == "1",

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -1176,7 +1176,13 @@ class TrajectorySandboxHarness:
             t_judge_wait = time.time()
             judge_timed_out = False
             try:
-                judge.wait(timeout=180)  # 3 min max for judging
+                # 5 min max for judging. 3 min (180s) was too tight on
+                # codebase_fix episodes where the judge walks git
+                # history + diffs + test_results/ep*.json across
+                # episodes; multiple judge containers timed out and
+                # produced quality=0.0 because evaluation.json was
+                # never written.
+                judge.wait(timeout=300)
             except Exception:
                 judge_timed_out = True
                 logger.warning("[%s] Episode %d judge agent timed out",


### PR DESCRIPTION
Flip both the dataclass default and the ``SANDBOX_SCENARIO`` env fallback from ``incident_response`` to ``codebase_fix`` so validators run the newest scenario without any operator intervention. Operators who want to pin a specific older scenario can still set ``SANDBOX_SCENARIO=incident_response`` (or ``morning_brief``) in the env.