### PR TITLE
fix: prevent stale eval state leaking across skip paths

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -358,13 +358,8 @@ class TrajectoryValidator:
         """
         path = self.config.eval_state_path
         if not path.exists():
-            legacy = path.parent / "ema_state.json"
-            if legacy.exists():
-                logger.info("Migrating legacy ema_state.json → %s", path.name)
-                path = legacy
-            else:
-                logger.debug("No persisted eval state found, starting fresh")
-                return
+            logger.debug("No persisted eval state found, starting fresh")
+            return
         try:
             data = json.loads(path.read_text())
 
@@ -384,7 +379,7 @@ class TrajectoryValidator:
                 return
 
             self.scenario_scores = data.get("scenario_scores", {})
-            self._eval_pack_hash = data.get("eval_pack_hash", data.get("ema_pack_hash", {}))
+            self._eval_pack_hash = data.get("eval_pack_hash", {})
             self.last_eval_block = {
                 k: int(v) for k, v in data.get("last_eval_block", {}).items()
             }
@@ -421,6 +416,31 @@ class TrajectoryValidator:
             )
         except Exception as e:
             logger.warning(f"Failed to save eval state: {e}")
+
+    def _drop_miner_eval_state(self, hotkey: str):
+        """Remove all per-miner eval state and persist.
+
+        Invariant: eval_state only contains miners that successfully
+        completed an evaluation. Any pre-evaluation gate failure
+        (duplicate pack_hash, NCD copy, pre-eval rejection, pack
+        fetch / integrity failure, ...) must wipe the hotkey here so
+        stale data from a previous cycle cannot leak into scoring or
+        survive across restarts.
+        """
+        changed = False
+        for store in (
+            self.scenario_scores,
+            self._eval_pack_hash,
+            self.last_eval_block,
+            self._eval_counts,
+            self.latest_token_usage,
+            self.latest_model_usage,
+        ):
+            if hotkey in store:
+                store.pop(hotkey, None)
+                changed = True
+        if changed:
+            self._save_eval_state()
 
     # ------------------------------------------------------------------
     # Eval state update
@@ -1460,6 +1480,7 @@ class TrajectoryValidator:
             hotkey = commitment.hotkey
 
             if uid in skip_uids:
+                self._drop_miner_eval_state(hotkey)
                 continue
 
             miner_idx += 1
@@ -1495,8 +1516,7 @@ class TrajectoryValidator:
                         **self._harness_metadata(),
                     )
                 )
-                self.scenario_scores.pop(hotkey, None)
-                self._eval_pack_hash.pop(hotkey, None)
+                self._drop_miner_eval_state(hotkey)
                 continue
 
             # Pre-eval gate: ask the server whether this miner's submission
@@ -1547,8 +1567,7 @@ class TrajectoryValidator:
                         )
                     )
                     self._disqualified_miners[hotkey] = f"pre_eval_rejected:{reason}"
-                    self.scenario_scores.pop(hotkey, None)
-                    self._eval_pack_hash.pop(hotkey, None)
+                    self._drop_miner_eval_state(hotkey)
                     continue
 
             needs_eval = self._needs_evaluation(
@@ -1636,6 +1655,10 @@ class TrajectoryValidator:
 
                 self._track_uid_change(uid, hotkey)
 
+                # Persist per-miner so a crash mid-cycle doesn't lose
+                # work already paid for in LLM tokens.
+                self._save_eval_state()
+
             else:
                 elapsed_str = f" ({eval_elapsed:.1f}s)" if eval_elapsed else ""
                 logger.info(
@@ -1643,11 +1666,7 @@ class TrajectoryValidator:
                     f"{elapsed_str} "
                     f"(pack fetch/integrity failed)"
                 )
-                # Drop any stale cached scores so a future successful eval
-                # starts from a clean slate rather than re-surfacing old data
-                # under a potentially-stale pack_hash.
-                self.scenario_scores.pop(hotkey, None)
-                self._eval_pack_hash.pop(hotkey, None)
+                self._drop_miner_eval_state(hotkey)
 
             # Mid-eval tempo refresh: re-assert the current winner's weights
             # to keep the validator active on-chain without recomputing.
@@ -1823,9 +1842,14 @@ class TrajectoryValidator:
                 self._disqualified_miners[commitment.hotkey] = outcome.skip_reason
             return None
 
+        # Defensive: judge_details is built in-place by evaluate_miner_s1 today
+        # so this normally cannot raise, but a future contract drift (renamed
+        # field, missing scenario, None outcome) must not crash the whole cycle
+        # — that would silently kill all subsequent miners until restart.
         scenario_qualified = {
-            sn: d["qualification_gate"]
-            for sn, d in outcome.judge_details.items()
+            sn: bool((d or {}).get("qualification_gate", False))
+            for sn, d in (outcome.judge_details or {}).items()
+            if isinstance(d, dict)
         }
 
         return {

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -191,10 +191,7 @@ class ValidatorConfig:
             netuid=int(os.getenv("NETUID", "11")),
             network=os.getenv("NETWORK", "finney"),
             # --- Paths ---
-            eval_state_path=Path(os.getenv(
-                "EVAL_STATE_PATH",
-                os.getenv("EMA_STATE_PATH", "/var/lib/trajectoryrl/eval_state.json"),
-            )),
+            eval_state_path=Path(os.getenv("EVAL_STATE_PATH", "/var/lib/trajectoryrl/eval_state.json")),
             winner_state_path=Path(os.getenv("WINNER_STATE_PATH", "/var/lib/trajectoryrl/winner_state.json")),
             pack_cache_dir=Path(os.getenv("PACK_CACHE_DIR", "/var/lib/trajectoryrl/packs")),
             log_dir=Path(os.getenv("LOG_DIR", "./logs")),

--- a/trajectoryrl/utils/miner_eval.py
+++ b/trajectoryrl/utils/miner_eval.py
@@ -35,6 +35,7 @@ from .sandbox_harness import SandboxEvaluationResult, TrajectorySandboxHarness
 # Skip-reason taxonomy — kept stable for callers that branch on these values
 # (e.g. validator's ``_disqualified_miners``).
 SKIP_PACK_VERIFY = "pack_verify"          # silent skip in validator (pre-eval reject)
+SKIP_INVALID_PACK = "invalid_pack_structure"  # pack JSON parsed but root / files not an object
 SKIP_MISSING_SKILL_MD = "missing_skill_md"
 SKIP_EMPTY_SKILL_MD = "empty_skill_md"
 SKIP_S1_EVAL_ERROR = "s1_eval_error"
@@ -103,7 +104,31 @@ async def evaluate_miner_s1(
         )
 
     pack = verification.pack_content
-    files = pack.get("files", {})
+    if not isinstance(pack, dict):
+        # Hash check passes for any well-formed JSON, including arrays /
+        # scalars / null. Without this guard, ``pack.get(...)`` below would
+        # raise AttributeError and propagate out of the whole eval cycle.
+        log.warning(
+            "Pack root is %s, expected JSON object", type(pack).__name__
+        )
+        return MinerEvalOutcome(
+            success=False,
+            skip_reason=SKIP_INVALID_PACK,
+            skip_detail=f"pack root is {type(pack).__name__}, expected object",
+        )
+
+    files = pack.get("files")
+    if not isinstance(files, dict):
+        log.warning(
+            "Pack 'files' is %s, expected JSON object",
+            type(files).__name__,
+        )
+        return MinerEvalOutcome(
+            success=False,
+            skip_reason=SKIP_INVALID_PACK,
+            skip_detail=f"'files' is {type(files).__name__}, expected object",
+        )
+
     if "SKILL.md" not in files:
         log.warning("Pack missing SKILL.md in files")
         return MinerEvalOutcome(
@@ -115,9 +140,12 @@ async def evaluate_miner_s1(
     if extra_files:
         log.warning("S1 pack contains unexpected files: %s", extra_files)
 
-    skill_md = files["SKILL.md"]
-    if not skill_md or not skill_md.strip():
-        log.warning("Empty SKILL.md submission")
+    skill_md = files.get("SKILL.md")
+    if not isinstance(skill_md, str) or not skill_md.strip():
+        log.warning(
+            "SKILL.md is %s or empty",
+            type(skill_md).__name__,
+        )
         return MinerEvalOutcome(
             success=False,
             skip_reason=SKIP_EMPTY_SKILL_MD,


### PR DESCRIPTION
## Summary

- Centralize per-miner eval state cleanup in `_drop_miner_eval_state` and call it on every pre-evaluation gate failure (`skip_uids`, duplicate `pack_hash`, NCD copy, pre-eval rejection, pack fetch / integrity failure) so `eval_state` only ever holds miners whose evaluations actually completed — no stale `scenario_scores` / `_eval_pack_hash` / `last_eval_block` / `_eval_counts` / token & model usage can survive across restarts.
- Persist eval state per-miner after each successful evaluation so a crash mid-cycle doesn't lose work already paid for in LLM tokens.
- Harden `evaluate_miner_s1` against malformed pack JSON (non-object root, non-object `files`, non-string `SKILL.md`) which previously raised `AttributeError` and tore down the whole eval cycle, silently killing all subsequent miners until restart. Failures are reported via the new `SKIP_INVALID_PACK` taxonomy.
- Defensive normalization of `judge_details` so a future contract drift (renamed field, missing scenario, `None` outcome) cannot crash the cycle.
- Drop the legacy `ema_state.json` migration path and `EMA_STATE_PATH` env-var fallback now that the rename has shipped.

## Test plan

- [ ] Validator restart loads `eval_state.json` cleanly with the legacy migration path removed.
- [ ] Submit a malformed pack (root array, `files` array, non-string `SKILL.md`) and confirm the miner is skipped with `SKIP_INVALID_PACK` while subsequent miners in the same cycle continue evaluating.
- [ ] Trigger each skip path (skip_uids, duplicate pack_hash, NCD copy, pre-eval reject, pack fetch failure) and verify the miner's entries are removed from all six eval-state maps and persisted to disk.
- [ ] Kill the validator mid-cycle after at least one successful evaluation and confirm that miner's score survives the restart.

Made with [Cursor](https://cursor.com)