### PR TITLE
refactor: decouple SPEC_NUMBER from trajrl-bench, derive aggregation target from chain

### DIFF
--- a/docs/EVALUATION_S1.md
+++ b/docs/EVALUATION_S1.md
@@ -123,7 +123,7 @@ For the reference miner implementation and local testing, see [MINER_OPERATIONS.
 
 ## Evaluation Dataset
 
-The current evaluation benchmark is defined by the **sandbox image version** (`scoring_version`). Scenarios live in [trajrl-bench](https://github.com/trajectoryRL/trajrl-bench) and include:
+The current evaluation benchmark is defined by **trajrl-bench** image plus a manually maintained `spec_number` constant in the validator code (`trajectoryrl/utils/config.py::SPEC_NUMBER`). Scenarios live in [trajrl-bench](https://github.com/trajectoryRL/trajrl-bench) and include:
 
 - Natural-language `JUDGE.md` per scenario (scoring rubric)
 - Fixture logic (mock services, data generation)
@@ -131,7 +131,7 @@ The current evaluation benchmark is defined by the **sandbox image version** (`s
 
 Adding a new scenario means writing a new JUDGE.md + fixture logic in trajrl-bench — no validator code change required.
 
-All scenarios run every evaluation cycle. No subset selection or rotation. When the scenario pool changes, the sandbox image version bumps (`scoring_version` increment), triggering a winner state reset.
+All scenarios run every evaluation cycle. No subset selection or rotation. Whenever the scenario set, scoring methodology, or judge prompt changes in a way that breaks score comparability, validator maintainers bump `SPEC_NUMBER` in the next validator release. Bench bug fixes that preserve scoring semantics do **not** bump it. Aggregation picks the target `spec_number` from on-chain commitments themselves (stake-weighted majority), so the upgrade is self-coordinating: while most validators are still on the old `spec_number`, weights continue to flow to the previous winner; once majority stake migrates to the new `spec_number`, the new winner takes over automatically.
 
 See [seasons/self_learning_s1.md](seasons/self_learning_s1.md) for the full Season 1 design, scenario list, and learning-signal architecture.
 

--- a/docs/INCENTIVE_MECHANISM.md
+++ b/docs/INCENTIVE_MECHANISM.md
@@ -145,7 +145,7 @@ Where:
 - `winner_hotkey` — current winner's hotkey
 - `winner_pack_hash` — the pack hash when they won
 - `winner_score` — the consensus score when they won
-- `scoring_version` — the `SCORING_VERSION` when they won (state resets on version change)
+- `spec_number` — the `SPEC_NUMBER` under which they won (audit field; state is **not** reset on `SPEC_NUMBER` change — see "SPEC_NUMBER and target spec selection")
 
 
 ---
@@ -248,11 +248,33 @@ set_weights:  every tempo (360 blocks), independent of epoch
 
 ### Benchmark Stability
 
-Every evaluation runs the **full benchmark set** defined by the season. No subset selection or rotation. The benchmark is fixed within a `scoring_version`: same scenarios, same criteria, same evaluation method. This ensures scores are directly comparable across validators and across time.
+Every evaluation runs the **full benchmark set** defined by the season. No subset selection or rotation. The benchmark is fixed within a `spec_number`: same scenarios, same criteria, same evaluation method. This ensures scores are directly comparable across validators and across time.
 
-**Anti-stagnation** comes from **growing the benchmark** over time (new scenarios, harder criteria, new domains). When the benchmark changes, it's coordinated via a validator software update and a `scoring_version` bump. Packs are re-evaluated fresh on the new set.
+**Anti-stagnation** comes from **growing the benchmark** over time (new scenarios, harder criteria, new domains). When the benchmark changes, it's coordinated via a validator software update and a `SPEC_NUMBER` bump (see "SPEC_NUMBER and target spec selection"). Packs are re-evaluated fresh on the new set.
 
 **State persistence**: Winner state (hotkey, pack_hash, score) persists across validator restarts (serialized to disk as JSON). Cached evaluation results persist across restarts where applicable.
+
+### SPEC_NUMBER and target spec selection
+
+`SPEC_NUMBER` is an integer constant in validator code (`trajectoryrl/utils/config.py`). It identifies a "scoring specification" — the combination of scenario set, scoring methodology, and judge prompt that determines whether two evaluations produce comparable scores. Maintainers bump it whenever a change makes new scores incomparable with old ones (adding/removing scenarios, changing weights, modifying judge prompts). Bench-image patch releases that preserve scoring semantics do **not** bump it. The constant is decoupled from the `trajrl-bench` image version (now used purely for audit / log fields).
+
+A validator always **writes** its commitments using its locally configured `SPEC_NUMBER`. During aggregation, the **target spec_number used to filter incoming commitments** is derived from on-chain stake distribution:
+
+```
+1. Read all consensus commitments
+2. Apply basic filters (protocol / window / per-validator min stake)
+3. Group survivors by spec_number, sum validator stake per group
+4. dominant = group with the largest total stake
+5. if dominant.stake > 0.5 * total_participating_stake:
+       target_spec_number = dominant.spec_number
+   else:
+       target_spec_number = local SPEC_NUMBER
+6. Filter pipeline keeps only commitments whose payload spec_number == target
+```
+
+This makes upgrades self-coordinating. While stake-weighted majority remains on the previous spec, every validator (upgraded or not) computes weights against that spec, so the previous winner keeps receiving emissions instead of getting burned. Once stake-weighted majority migrates to the new spec, target flips automatically and the new winner takes over. When no group reaches majority (split network, partial outage), validators fall back to their local `SPEC_NUMBER` and proceed with whatever data they have, again avoiding burn. The 50% threshold reuses the existing `disqualify_stake_threshold` semantic; no new parameter.
+
+`WinnerState.spec_number` is purely audit (which spec the current winner was selected under). It does **not** trigger a state reset on its own — the new winner naturally replaces the old one once target_spec_number flips and a new aggregation round produces a different best score.
 
 ---
 
@@ -412,11 +434,11 @@ Evaluation payloads are too large for direct on-chain storage.
 **Solution**: Two-layer storage with on-chain pointer registration.
 
 1. **Content-Addressed Storage (CAS)**: Upload the full evaluation payload. IPFS is the primary backend; GCS proxy fallback stores payload and returns a public URL. The content address (IPFS CID or sha256 hash) serves as an integrity proof.
-2. **On-chain pointer**: Write a lightweight commitment via `subtensor.set_commitment()` with format: `consensus:{protocol_version}|{epoch_number}|{scoring_version}|{content_address}`.
+2. **On-chain pointer**: Write a lightweight commitment via `subtensor.set_commitment()` with format: `consensus:{protocol_version}|{epoch_number}|{spec_number}|{content_address}`.
 
 Validator consensus commitments share the same commitment channel as miner pack commitments (`pack_hash|pack_url`). They are distinguished by the `consensus:` prefix. During aggregation, each validator reads `get_all_commitments(netuid)` and filters for entries starting with `consensus:`.
 
-**Backward compatibility**: Old-format commitments (`consensus:{pv}|{epoch}|{content_address}`, 3 fields) are parsed with `scoring_version` defaulting to 1.
+**Backward compatibility**: The on-chain commitment string is positional, so the integer at field 3 is read whether it was written as `scoring_version` or `spec_number`. Older 3-field commitments (`consensus:{pv}|{epoch}|{content_address}`) parse with `spec_number` defaulting to 1. Inside CAS payloads, JSON deserialization accepts either `spec_number` or the legacy `scoring_version` key.
 
 **Verification**: Any validator can independently verify a submission: read on-chain pointer → decode address → download payload from CAS (try IPFS, fall back to GCS) → verify content hash matches.
 
@@ -492,7 +514,7 @@ If winner exists and is not disqualified:
 - Self-update follows the same δ rule — winner must beat their own winning score by δ to update
 - No automatic season reset — winner persists until beaten or disqualified. Manual reset available for operational control.
 
-**Validator local state** (`WinnerState`): Each validator persists `winner_hotkey`, `winner_pack_hash`, `winner_score`, and `scoring_version` to a local JSON file. When `SCORING_VERSION` changes (new benchmark set), the winner state resets automatically. Since all validators process the same consensus data with the same deterministic algorithm, they converge on the same winner.
+**Validator local state** (`WinnerState`): Each validator persists `winner_hotkey`, `winner_pack_hash`, `winner_score`, and `spec_number` to a local JSON file. The `spec_number` is an audit field (records the spec under which the winner was selected) and does **not** reset state on its own; the new winner naturally takes over once the chain-derived target spec flips (see "SPEC_NUMBER and target spec selection"). Since all validators process the same consensus data with the same deterministic algorithm, they converge on the same winner.
 
 **Rate-limiting**: At most one evaluation per miner per `eval_interval`, regardless of how often the miner updates their commitment.
 
@@ -533,9 +555,9 @@ disqualified[hotkey] = reason                 # miners that failed (pre-eval, sc
 
 # ── Propagation window (80% → 90%) ──
 
-payload = { scores, disqualified, scoring_version, metadata }
+payload = { scores, disqualified, spec_number, metadata }
 content_address = cas_upload(payload)
-subtensor.set_commitment("consensus:{version}|{epoch}|{scoring_version}|{content_address}")
+subtensor.set_commitment("consensus:{version}|{epoch}|{spec_number}|{content_address}")
 
 # ── Aggregation window (90% → 100%) ──
 

--- a/docs/seasons/self_learning_s1.md
+++ b/docs/seasons/self_learning_s1.md
@@ -439,7 +439,7 @@ Season 1 closes this gap by planting two structural elements:
   "miner_uid": 42,
   "pack_hash": "abc123...",
   "scenario": "incident_response",
-  "scoring_version": 3,
+  "spec_number": 3,
   "episodes": [
     {"rep": 1, "quality": 0.45, "criteria": {...}, "summary": "..."},
     {"rep": 2, "quality": 0.55, "criteria": {...}, "summary": "..."},
@@ -510,18 +510,15 @@ WTA, NCD threshold 0.80, consensus aggregation, inactivity 14400 blocks, evaluat
 
 ## Versioning
 
-Sandbox major version = scoring version for consensus. Validators running different major versions do not mix results during consensus aggregation.
+Score comparability across validators is governed by a manually maintained `SPEC_NUMBER` constant in validator code (`trajectoryrl/utils/config.py`), decoupled from the `trajrl-bench` image version. Aggregation derives the active `spec_number` from on-chain stake distribution: the stake-weighted dominant `spec_number` wins if it holds more than 50% stake; otherwise validators fall back to their local `SPEC_NUMBER` for that round (see [INCENTIVE_MECHANISM.md](../INCENTIVE_MECHANISM.md#spec_number-and-target-spec-selection)).
 
-```
-trajrl-bench v3.0.0 → scoring_version = 3  (S1 default)
-trajrl-bench v4.0.0 → scoring_version = 4
-```
-
-| Change | Bump | scoring_version |
-|--------|------|-----------------|
-| New scenario added | Minor (v3.1.0) | Unchanged (3) |
-| JUDGE.md criteria changed | **Major (v4.0.0)** | Bumps to 4 |
-| Bug fix or infra | Patch (v3.0.1) | Unchanged |
+| Change | Bench image bump | `SPEC_NUMBER` bump? |
+|--------|-------------------|---------------------|
+| New scenario added | Minor (v3.1.0) | **Yes** — new scenario set produces incomparable scores |
+| JUDGE.md criteria changed | Minor or major | **Yes** |
+| Scoring weight / aggregation rule changed | n/a (validator-side) | **Yes** |
+| Fixture / infra bug fix that preserves scoring | Patch (v3.0.1) | No |
+| Sandbox runtime upgrade with same scenarios | Major (v4.0.0) | No |
 
 ---
 
@@ -677,7 +674,7 @@ Future skill packs may include additional files (data, examples, reference docs)
 
 **Scoring:** Each contest produces an independent `final_score`. Weight allocation across contests is governance-configured.
 
-**On-chain:** Commitment format unchanged (`{pack_hash}|{pack_url}`). One commitment per contest. `scoring_version` (from sandbox major) ensures validators with different scenario sets don't mix results.
+**On-chain:** Commitment format unchanged (`{pack_hash}|{pack_url}`). One commitment per contest. `spec_number` (validator-side constant; see [versioning](#versioning)) drives the data-driven target spec used by aggregation, so validators on different scenario sets don't mix results during the rollout window.
 
 ---
 

--- a/scripts/eval_miners.py
+++ b/scripts/eval_miners.py
@@ -34,7 +34,7 @@ from typing import Dict, List, Optional
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from trajectoryrl.utils.config import ValidatorConfig
+from trajectoryrl.utils.config import SPEC_NUMBER, ValidatorConfig
 from trajectoryrl.utils.commitments import MinerCommitment, parse_commitment
 from trajectoryrl.utils.github import PackFetcher
 from trajectoryrl.utils.miner_eval import evaluate_miner_s1
@@ -218,8 +218,8 @@ async def run_evaluation(args) -> int:
     logger.info("Pulling latest sandbox + harness images...")
     await harness.pull_latest()
     logger.info(
-        "Sandbox %s, scoring_version %d, scenarios=%s",
-        harness.sandbox_version, harness.scoring_version,
+        "Sandbox %s, spec_number %d, scenarios=%s",
+        harness.sandbox_version, SPEC_NUMBER,
         harness.sandbox_scenarios or "?",
     )
 
@@ -280,7 +280,7 @@ async def run_evaluation(args) -> int:
             "eval_block": current_block,
             "epoch_seed": epoch_seed,
             "sandbox_version": harness.sandbox_version,
-            "scoring_version": harness.scoring_version,
+            "spec_number": SPEC_NUMBER,
             "scenario": result.scenario_name,
             "evaluation": {
                 "final_score": round(sr.final_score, 4),

--- a/scripts/eval_pack.py
+++ b/scripts/eval_pack.py
@@ -42,7 +42,7 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-from trajectoryrl.utils.config import ValidatorConfig
+from trajectoryrl.utils.config import SPEC_NUMBER, ValidatorConfig
 from trajectoryrl.utils.sandbox_harness import (
     SandboxEvaluationResult,
     TrajectorySandboxHarness,
@@ -100,7 +100,7 @@ def _print_summary(
     pack_hash: str,
     result: SandboxEvaluationResult,
     sandbox_version: str,
-    scoring_version: int,
+    spec_number: int,
 ) -> bool:
     """Render a human-readable summary; return qualified flag."""
     W = 70
@@ -110,7 +110,7 @@ def _print_summary(
     print(f"Source:          {source}")
     print(f"Pack hash:       {pack_hash[:16]}...")
     print(f"Sandbox version: {sandbox_version}")
-    print(f"Scoring version: {scoring_version}")
+    print(f"Spec number:     {spec_number}")
     print(f"Scenario:        {result.scenario_name}")
     print("=" * W)
 
@@ -203,8 +203,8 @@ async def run_evaluation(args) -> int:
         logger.info("Pulling latest sandbox + harness images...")
         await harness.pull_latest()
     logger.info(
-        "Sandbox %s, scoring_version %d, scenarios=%s",
-        harness.sandbox_version, harness.scoring_version,
+        "Sandbox %s, spec_number %d, scenarios=%s",
+        harness.sandbox_version, SPEC_NUMBER,
         harness.sandbox_scenarios or "?",
     )
 
@@ -253,7 +253,7 @@ async def run_evaluation(args) -> int:
         pack_hash=pack_hash,
         result=result,
         sandbox_version=harness.sandbox_version,
-        scoring_version=harness.scoring_version,
+        spec_number=SPEC_NUMBER,
     )
 
     if args.output:
@@ -271,7 +271,7 @@ async def run_evaluation(args) -> int:
             "epoch_seed": epoch_seed,
             "validator_salt": validator_salt,
             "sandbox_version": harness.sandbox_version,
-            "scoring_version": harness.scoring_version,
+            "spec_number": SPEC_NUMBER,
             "scenario": result.scenario_name,
             "model": config.llm_model,
             "evaluation": {

--- a/tests/test_ncd.py
+++ b/tests/test_ncd.py
@@ -279,6 +279,7 @@ class TestPRTestPlan:
         v.scenario_scores = {}
         v._eval_pack_hash = {}
         v.last_eval_block = {}
+        v.last_eval_window = {}
         v._hotkey_uid_map = {}
         v.scenarios = {"client_escalation": {"weight": 1.0}}
         v.wallet = MagicMock()

--- a/tests/test_s1_e2e.py
+++ b/tests/test_s1_e2e.py
@@ -138,20 +138,19 @@ class TestS1UnitMath:
         lower_pack = {"schema_version": 1, "files": {"skill.md": "# test"}}
         assert TrajectorySandboxHarness.extract_skill_md(lower_pack) == "# test"
 
-    def test_scoring_version_from_sandbox(self):
-        """Scoring version derived from sandbox major version."""
+    def test_spec_number_constant(self):
+        """SPEC_NUMBER is a validator-side constant decoupled from sandbox version."""
         _skip_if_no_docker()
         from trajectoryrl.utils.sandbox_harness import TrajectorySandboxHarness
+        from trajectoryrl.utils.config import SPEC_NUMBER
+
+        # The harness no longer exposes a derived scoring_version property.
+        # sandbox_version remains as an audit / log field only.
         harness = TrajectorySandboxHarness(_make_config())
+        assert not hasattr(harness, "scoring_version")
 
-        harness.sandbox_version = "3.1.0"
-        assert harness.scoring_version == 3
-
-        harness.sandbox_version = "4.0.0"
-        assert harness.scoring_version == 4
-
-        harness.sandbox_version = "unknown"
-        assert harness.scoring_version == 1
+        harness.sandbox_version = "3.1.0"  # bench bumps must not move SPEC_NUMBER
+        assert isinstance(SPEC_NUMBER, int) and SPEC_NUMBER >= 1
 
     def test_write_artifacts(self):
         """SandboxEvaluationResult.write_artifacts() creates correct dir layout."""

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -43,14 +43,16 @@ from trajectoryrl.utils.eval_window import (
     compute_window, is_new_window, should_submit, should_aggregate,
     can_evaluate, window_progress_pct,
 )
+from trajectoryrl.utils.config import SPEC_NUMBER
 from trajectoryrl.utils.consensus import (
     ConsensusPayload, ConsensusPointer,
-    verify_payload_integrity, CONSENSUS_PROTOCOL_VERSION, SCORING_VERSION,
+    verify_payload_integrity, CONSENSUS_PROTOCOL_VERSION,
 )
 from trajectoryrl.utils.consensus_filter import (
     run_filter_pipeline, FilterStats, ValidatedSubmission,
     filter_protocol_version, filter_window_number,
     filter_trust_threshold, filter_zero_signal,
+    filter_spec_number, select_target_spec_number,
 )
 from trajectoryrl.scoring import compute_consensus_scores
 from trajectoryrl.utils.winner_state import (
@@ -1028,11 +1030,12 @@ class TestPerScenarioEvalState:
             validator.subtensor = mock_subtensor
             validator._eval_pack_hash = {}
             validator.last_eval_block = {}
+            validator.last_eval_window = {}
+            validator.scenario_scores = {}
             validator._hotkey_uid_map = {}
             validator._hotkey_packs = {}
             validator._pack_by_hash = {}
             validator._eval_counts = {}
-            validator._scenario_config_hash = ""
             validator._last_eval_window = -1
             validator.latest_token_usage = {}
             validator.latest_model_usage = {}
@@ -1061,36 +1064,46 @@ class TestPerScenarioEvalState:
     def test_needs_evaluation_new_miner(self):
         """New miner (never evaluated) needs evaluation."""
         v = self._make_validator()
-        assert v._needs_evaluation("hk_new", "hash_a", 100000) is True
+        assert v._needs_evaluation("hk_new", "hash_a", current_window=42) is True
 
     def test_needs_evaluation_pack_changed(self):
         """Pack hash change triggers re-evaluation."""
         v = self._make_validator()
         v._eval_pack_hash["hk_0"] = "hash_a"
-        v.last_eval_block["hk_0"] = 99999
-        assert v._needs_evaluation("hk_0", "hash_b", 100000) is True
+        v.scenario_scores["hk_0"] = {"client_escalation": 0.85}
+        v.last_eval_window["hk_0"] = 41
+        assert v._needs_evaluation("hk_0", "hash_b", current_window=42) is True
 
-    def test_needs_evaluation_within_interval(self):
-        """Within eval interval and same pack → no re-evaluation."""
+    def test_needs_evaluation_same_pack_skips(self):
+        """Same pack_hash with cached scores → skip eval."""
         v = self._make_validator()
         v._eval_pack_hash["hk_0"] = "hash_a"
-        v.last_eval_block["hk_0"] = 99500  # 500 blocks ago < 1200
-        assert v._needs_evaluation("hk_0", "hash_a", 100000) is False
+        v.scenario_scores["hk_0"] = {"client_escalation": 0.85}
+        v.last_eval_window["hk_0"] = 42
+        assert v._needs_evaluation("hk_0", "hash_a", current_window=42) is False
 
-    def test_needs_evaluation_interval_exceeded(self):
-        """Past eval interval → needs re-evaluation."""
+    def test_needs_evaluation_skips_across_epochs(self):
+        """Same pack_hash across windows → still skip (reuse cached scores)."""
         v = self._make_validator()
         v._eval_pack_hash["hk_0"] = "hash_a"
-        v.last_eval_block["hk_0"] = 92000  # 8000 blocks ago > 7200
-        assert v._needs_evaluation("hk_0", "hash_a", 100000) is True
+        v.scenario_scores["hk_0"] = {"client_escalation": 0.85}
+        v.last_eval_window["hk_0"] = 40
+        assert v._needs_evaluation("hk_0", "hash_a", current_window=45) is False
+
+    def test_needs_evaluation_no_scores_cached(self):
+        """pack_hash recorded but no scenario_scores → re-eval (defensive)."""
+        v = self._make_validator()
+        v._eval_pack_hash["hk_0"] = "hash_a"
+        v.scenario_scores["hk_0"] = {}
+        assert v._needs_evaluation("hk_0", "hash_a", current_window=42) is True
 
     def test_eval_state_persistence_roundtrip(self):
         """Eval state can be saved and loaded."""
         v = self._make_validator()
-        v._scenario_config_hash = "test_hash"
         v.scenario_scores = {"hk_0": {"client_escalation": 0.85}}
         v._eval_pack_hash = {"hk_0": "hash_a"}
         v.last_eval_block = {"hk_0": 99000}
+        v.last_eval_window = {"hk_0": 13}
 
         with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
             v.config.eval_state_path = Path(f.name)
@@ -1100,12 +1113,12 @@ class TestPerScenarioEvalState:
 
             v2 = self._make_validator()
             v2.config.eval_state_path = v.config.eval_state_path
-            v2._scenario_config_hash = "test_hash"
             v2._load_eval_state()
 
             assert v2.scenario_scores == {"hk_0": {"client_escalation": 0.85}}
             assert v2._eval_pack_hash == {"hk_0": "hash_a"}
             assert v2.last_eval_block == {"hk_0": 99000}
+            assert v2.last_eval_window == {"hk_0": 13}
         finally:
             v.config.eval_state_path.unlink(missing_ok=True)
 
@@ -1148,10 +1161,10 @@ class TestPerScenarioEvalState:
         v._track_uid_change(5, "hk_0")
         assert v._hotkey_uid_map["hk_0"] == 5
 
-    def test_eval_state_invalidated_on_scenario_pool_change(self):
-        """Loading eval state with different scenario config invalidates all state."""
+    def test_eval_state_invalidated_on_spec_number_change(self):
+        """Loading eval state under a different SPEC_NUMBER invalidates state."""
+        import json as _json
         v = self._make_validator()
-        v._scenario_config_hash = "old_hash"
         v.scenario_scores = {"hk_0": {"client_escalation": 0.85}}
         v._eval_pack_hash = {"hk_0": "hash_a"}
 
@@ -1161,13 +1174,47 @@ class TestPerScenarioEvalState:
         try:
             v._save_eval_state()
 
+            data = _json.loads(v.config.eval_state_path.read_text())
+            data["spec_number"] = data.get("spec_number", 1) + 100
+            data["scoring_version"] = data["spec_number"]
+            v.config.eval_state_path.write_text(_json.dumps(data))
+
             v2 = self._make_validator()
             v2.config.eval_state_path = v.config.eval_state_path
-            v2._scenario_config_hash = "new_hash"
             v2._load_eval_state()
 
             assert v2.scenario_scores == {}
             assert v2._eval_pack_hash == {}
+        finally:
+            v.config.eval_state_path.unlink(missing_ok=True)
+
+    def test_eval_state_load_accepts_legacy_scoring_version_key(self):
+        """Old eval_state.json with `scoring_version` key still loads."""
+        import json as _json
+
+        v = self._make_validator()
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            v.config.eval_state_path = Path(f.name)
+
+        try:
+            legacy = {
+                "scoring_version": SPEC_NUMBER,  # legacy key only
+                "scenario_scores": {"hk_0": {"client_escalation": 0.7}},
+                "eval_pack_hash": {"hk_0": "hash_legacy"},
+                "last_eval_block": {"hk_0": 1234},
+                "last_eval_window": -1,
+                "last_eval_window_per_hotkey": {"hk_0": 9},
+                "consensus_window": -1,
+                "integrity_cache": {},
+            }
+            v.config.eval_state_path.write_text(_json.dumps(legacy))
+
+            v2 = self._make_validator()
+            v2.config.eval_state_path = v.config.eval_state_path
+            v2._load_eval_state()
+
+            assert v2.scenario_scores == {"hk_0": {"client_escalation": 0.7}}
+            assert v2._eval_pack_hash == {"hk_0": "hash_legacy"}
         finally:
             v.config.eval_state_path.unlink(missing_ok=True)
 
@@ -1228,6 +1275,8 @@ class TestInactivityBlocks:
             validator.subtensor = mock_subtensor
             validator._eval_pack_hash = {}
             validator.last_eval_block = {}
+            validator.last_eval_window = {}
+            validator.scenario_scores = {}
             validator._hotkey_uid_map = {}
             validator._hotkey_packs = {}
             validator._pack_by_hash = {}
@@ -1726,8 +1775,8 @@ class TestConsensusFilter:
     """Tests for the 6-layer submission filter pipeline."""
 
     def _make_submission(
-        self, hotkey="val_a", window=42, protocol=1, version="0.1.0",
-        scores=None, scoring_version=SCORING_VERSION,
+        self, hotkey="val_a", window=42, protocol=CONSENSUS_PROTOCOL_VERSION,
+        version="0.1.0", scores=None, spec_number=SPEC_NUMBER,
     ):
         if scores is None:
             scores = {"miner_x": 0.85}
@@ -1738,7 +1787,7 @@ class TestConsensusFilter:
             bench_version=version,
             scores=scores,
             timestamp=1000,
-            scoring_version=scoring_version,
+            spec_number=spec_number,
         )
         pointer = ConsensusPointer(
             protocol_version=protocol,
@@ -1848,11 +1897,11 @@ class TestConsensusFilter:
 
     def test_full_pipeline_cascading_filters(self):
         subs = [
-            self._make_submission(hotkey="good", window=42, protocol=1, version="0.1.0", scores={"m": 0.85}),
-            self._make_submission(hotkey="bad_proto", window=42, protocol=2, version="0.1.0"),
-            self._make_submission(hotkey="bad_window", window=41, protocol=1, version="0.1.0"),
-            self._make_submission(hotkey="low_stake", window=42, protocol=1, version="0.1.0"),
-            self._make_submission(hotkey="zero_score", window=42, protocol=1, version="0.1.0", scores={"m": 0.0}),
+            self._make_submission(hotkey="good", window=42, version="0.1.0", scores={"m": 0.85}),
+            self._make_submission(hotkey="bad_proto", window=42, protocol=CONSENSUS_PROTOCOL_VERSION + 1, version="0.1.0"),
+            self._make_submission(hotkey="bad_window", window=41, version="0.1.0"),
+            self._make_submission(hotkey="low_stake", window=42, version="0.1.0"),
+            self._make_submission(hotkey="zero_score", window=42, version="0.1.0", scores={"m": 0.0}),
         ]
         stakes = {"good": 100.0, "bad_proto": 100.0, "bad_window": 100.0,
                   "low_stake": 1.0, "zero_score": 100.0}
@@ -1874,6 +1923,122 @@ class TestConsensusFilter:
         )
         assert stats.passed == 0
         assert len(validated) == 0
+
+    def test_select_target_spec_majority_wins(self):
+        """Stake-weighted majority spec_number is adopted as target."""
+        subs = [
+            self._make_submission(hotkey="val_a", spec_number=2),
+            self._make_submission(hotkey="val_b", spec_number=2),
+            self._make_submission(hotkey="val_c", spec_number=3),
+        ]
+        stakes = {"val_a": 100.0, "val_b": 200.0, "val_c": 50.0}
+        target, source = select_target_spec_number(subs, stakes, local_spec=99)
+        assert target == 2
+        assert source == "chain_majority"
+
+    def test_select_target_spec_no_majority_falls_back_to_local(self):
+        """Without a >50% group the local SPEC_NUMBER is used."""
+        subs = [
+            self._make_submission(hotkey="val_a", spec_number=2),
+            self._make_submission(hotkey="val_b", spec_number=3),
+        ]
+        stakes = {"val_a": 100.0, "val_b": 100.0}  # 50/50 split
+        target, source = select_target_spec_number(subs, stakes, local_spec=7)
+        assert target == 7
+        assert source == "local_fallback"
+
+    def test_select_target_spec_no_stake_falls_back_to_local(self):
+        subs = [self._make_submission(hotkey="val_a", spec_number=4)]
+        stakes = {}  # zero stake everywhere
+        target, source = select_target_spec_number(subs, stakes, local_spec=11)
+        assert target == 11
+        assert source == "local_fallback"
+
+    def test_filter_spec_number_drops_mismatched_payloads(self):
+        subs = [
+            self._make_submission(hotkey="val_a", spec_number=2),
+            self._make_submission(hotkey="val_b", spec_number=3),
+        ]
+        passed, skipped = filter_spec_number(subs, target_spec_number=2)
+        assert len(passed) == 1
+        assert skipped == 1
+        assert passed[0][1].spec_number == 2
+
+    def test_pipeline_uses_chain_derived_target_spec(self):
+        """Pipeline filters by majority spec_number, not local."""
+        subs = [
+            self._make_submission(hotkey="val_a", spec_number=2, scores={"m": 0.8}),
+            self._make_submission(hotkey="val_b", spec_number=2, scores={"m": 0.7}),
+            self._make_submission(hotkey="val_c", spec_number=3, scores={"m": 0.6}),
+        ]
+        stakes = {"val_a": 200.0, "val_b": 200.0, "val_c": 50.0}
+        validated, stats = run_filter_pipeline(
+            subs, expected_window=42, validator_stakes=stakes,
+            min_stake=10.0, local_spec_number=99,  # local doesn't match anything
+        )
+        assert stats.target_spec_number == 2
+        assert stats.target_spec_source == "chain_majority"
+        assert stats.skipped_spec_number == 1
+        assert stats.passed == 2
+
+    def test_pipeline_falls_back_to_local_spec_when_no_majority(self):
+        subs = [
+            self._make_submission(hotkey="val_a", spec_number=2, scores={"m": 0.8}),
+            self._make_submission(hotkey="val_b", spec_number=3, scores={"m": 0.7}),
+        ]
+        stakes = {"val_a": 100.0, "val_b": 100.0}  # 50/50 -> no >50% majority
+        validated, stats = run_filter_pipeline(
+            subs, expected_window=42, validator_stakes=stakes,
+            min_stake=10.0, local_spec_number=2,
+        )
+        assert stats.target_spec_source == "local_fallback"
+        assert stats.target_spec_number == 2
+        assert stats.passed == 1
+        assert validated[0].pointer.validator_hotkey == "val_a"
+
+
+# ---------------------------------------------------------------------------
+# Consensus payload back-compat tests
+# ---------------------------------------------------------------------------
+
+class TestConsensusPayloadBackCompat:
+    """ConsensusPayload reads both spec_number and legacy scoring_version keys."""
+
+    def test_from_dict_prefers_spec_number(self):
+        d = {
+            "protocol_version": 2,
+            "window_number": 1,
+            "validator_hotkey": "v",
+            "bench_version": "x",
+            "scores": {},
+            "timestamp": 0,
+            "spec_number": 7,
+            "scoring_version": 1,  # legacy mirror, ignored when spec_number present
+        }
+        p = ConsensusPayload.from_dict(d)
+        assert p.spec_number == 7
+
+    def test_from_dict_falls_back_to_legacy_scoring_version(self):
+        d = {
+            "protocol_version": 2,
+            "window_number": 1,
+            "validator_hotkey": "v",
+            "bench_version": "x",
+            "scores": {},
+            "timestamp": 0,
+            "scoring_version": 5,  # only legacy key present (old payload)
+        }
+        p = ConsensusPayload.from_dict(d)
+        assert p.spec_number == 5
+
+    def test_to_dict_emits_both_keys(self):
+        p = ConsensusPayload(
+            protocol_version=2, window_number=1, validator_hotkey="v",
+            bench_version="x", scores={}, timestamp=0, spec_number=4,
+        )
+        d = p.to_dict()
+        assert d["spec_number"] == 4
+        assert d["scoring_version"] == 4
 
 
 # ---------------------------------------------------------------------------
@@ -2152,6 +2317,53 @@ class TestWinnerProtection:
         loaded = load_winner_state(str(tmp_path / "nonexistent.json"))
         assert loaded.winner_hotkey is None
         assert loaded.winner_cost is None
+
+    def test_load_accepts_legacy_scoring_version_key(self, tmp_path):
+        """Old winner_state.json with `scoring_version` key still loads."""
+        import json as _json
+        path = tmp_path / "winner.json"
+        path.write_text(_json.dumps({
+            "scoring_version": 7,  # legacy key only
+            "winner_hotkey": "hk_legacy",
+            "winner_pack_hash": "pack_legacy",
+            "winner_score": 0.42,
+        }))
+        loaded = load_winner_state(str(path))
+        assert loaded.winner_hotkey == "hk_legacy"
+        assert loaded.winner_pack_hash == "pack_legacy"
+        assert loaded.winner_score == 0.42
+        assert loaded.spec_number == 7
+
+    def test_load_does_not_reset_on_spec_number_mismatch(self, tmp_path):
+        """spec_number is audit-only; mismatch must NOT clear winner state."""
+        import json as _json
+
+        path = tmp_path / "winner.json"
+        path.write_text(_json.dumps({
+            "spec_number": SPEC_NUMBER + 99,
+            "winner_hotkey": "hk_should_persist",
+            "winner_pack_hash": "ph",
+            "winner_score": 0.6,
+        }))
+        loaded = load_winner_state(str(path))
+        assert loaded.winner_hotkey == "hk_should_persist"
+        assert loaded.winner_score == 0.6
+
+    def test_save_emits_both_spec_number_and_legacy_key(self, tmp_path):
+        """save_winner_state writes both spec_number and scoring_version."""
+        import json as _json
+
+        state = WinnerState(
+            winner_hotkey="hk",
+            winner_pack_hash="ph",
+            winner_score=0.5,
+            spec_number=11,
+        )
+        path = str(tmp_path / "winner.json")
+        save_winner_state(state, path)
+        data = _json.loads(open(path).read())
+        assert data["spec_number"] == 11
+        assert data["scoring_version"] == 11
 
     def test_challenger_beats_winner_self_update(self):
         """When both challenger and winner beat margin, lowest cost wins."""

--- a/tools/analyze_consensus.py
+++ b/tools/analyze_consensus.py
@@ -46,7 +46,10 @@ from trajectoryrl.utils.status_reporter import pre_eval
 
 NETUID = 11
 NETWORK = "finney"
-SCORING_VERSION = 3
+# Local fallback spec_number when no on-chain stake-weighted majority emerges.
+# When --spec-number / --scoring-version is unset, the analyzer mirrors the
+# validator and uses the trajectoryrl.utils.config.SPEC_NUMBER constant.
+SPEC_NUMBER_FALLBACK = 3
 IPFS_API_URL = "http://ipfs.metahash73.com:5001/api/v0"
 IPFS_GATEWAYS = [
     "https://ipfs.io",
@@ -166,20 +169,26 @@ async def run(args):
     print(f"\n  Target window: {target_window}")
 
     # ---- 3. Download payloads (with per-source JSON validation) -------------
-    scoring_ver = args.scoring_version if args.scoring_version is not None else SCORING_VERSION
+    # Resolve the local spec_number fallback. Mirror the production validator:
+    # prefer the SPEC_NUMBER from trajectoryrl.utils.config, allow CLI
+    # override via --spec-number / --scoring-version.
+    if args.spec_number is not None:
+        local_spec = args.spec_number
+    else:
+        try:
+            from trajectoryrl.utils.config import SPEC_NUMBER as _CONFIGURED_SPEC
+            local_spec = _CONFIGURED_SPEC
+        except ImportError:
+            local_spec = SPEC_NUMBER_FALLBACK
     max_retries = 3
     submissions = []
-    skipped_sv = 0
     for vc in chain_commitments:
         if vc.window_number != target_window:
-            continue
-        if vc.scoring_version != scoring_ver:
-            skipped_sv += 1
             continue
         uid = hk_to_uid.get(vc.validator_hotkey, -1)
         ipfs_cid, gcs_url = decode_dual_address(vc.content_address)
         addr_summary = f"ipfs={ipfs_cid or '(none)'}, gcs={(gcs_url or '(none)')[:40]}"
-        print(f"  UID {uid} ({vc.validator_hotkey[:12]}...) {addr_summary}")
+        print(f"  UID {uid} ({vc.validator_hotkey[:12]}...) spec={vc.spec_number} {addr_summary}")
 
         pointer = ConsensusPointer(
             protocol_version=vc.protocol_version,
@@ -204,9 +213,7 @@ async def run(args):
             print(f"    FAILED after {max_retries} attempts")
 
     total_target = sum(1 for vc in chain_commitments if vc.window_number == target_window)
-    if skipped_sv:
-        print(f"\n  Skipped {skipped_sv} commitments with mismatched scoring_version (expected {scoring_ver})")
-    print(f"\n  Downloaded {len(submissions)}/{total_target - skipped_sv} payloads")
+    print(f"\n  Downloaded {len(submissions)}/{total_target} payloads")
 
     if not submissions:
         print("\nFailed to download any payloads!")
@@ -226,8 +233,8 @@ async def run(args):
         expected_window=target_window,
         validator_stakes=validator_stakes,
         min_stake=0.0,
+        local_spec_number=local_spec,
         expected_protocol=CONSENSUS_PROTOCOL_VERSION,
-        expected_scoring_version=scoring_ver,
     )
     print(f"\n  Filter pipeline: {stats.summary()}")
 
@@ -319,8 +326,14 @@ def main():
     parser.add_argument("--prev-winner-score", type=float, default=None)
     parser.add_argument("--score-delta", type=float, default=0.10)
     parser.add_argument(
-        "--scoring-version", type=int, default=None,
-        help=f"Override scoring version filter (default: {SCORING_VERSION})",
+        "--spec-number", "--scoring-version", type=int, default=None,
+        dest="spec_number",
+        help=(
+            "Override the local spec_number fallback used when no on-chain "
+            f"stake-weighted majority emerges (default: validator's "
+            f"trajectoryrl.utils.config.SPEC_NUMBER, or "
+            f"{SPEC_NUMBER_FALLBACK} if unavailable)."
+        ),
     )
     parser.add_argument(
         "--skip-pre-eval", action="store_true",

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -38,16 +38,24 @@ from ..utils.eval_window import (
     compute_window, is_new_window, can_evaluate,
     should_submit, should_aggregate,
 )
-from ..utils import consensus as _consensus_mod
+from ..utils import config as _config_mod
 from ..utils.consensus import (
     ConsensusPayload, ConsensusPointer,
     CONSENSUS_PROTOCOL_VERSION,
 )
 
-def _scoring_version() -> int:
-    """Current scoring version — major version of trajrl-bench (e.g. v3.0.1 → 3).
-    Set dynamically after pulling the sandbox image at each eval cycle."""
-    return _consensus_mod.SCORING_VERSION
+
+def _spec_number() -> int:
+    """Current scoring spec identifier (validator-side constant).
+
+    See ``trajectoryrl/utils/config.py::SPEC_NUMBER`` for bump policy.
+    Used as the value written into outgoing commitments / payloads and as
+    the fallback target when no on-chain spec_number group reaches
+    stake-weighted majority.
+    """
+    return _config_mod.SPEC_NUMBER
+
+
 from ..utils.consensus_store import (
     ConsensusStore, IPFSBackend, TrajRLAPIBackend,
 )
@@ -182,8 +190,14 @@ class TrajectoryValidator:
         # Track the pack_hash that each hotkey was last evaluated with.
         self._eval_pack_hash: Dict[str, str] = {}
 
-        # Last eval block for each hotkey (for rate-limiting and inactivity)
+        # Last eval block for each hotkey (telemetry only — eval gating is
+        # by pack_hash, see _needs_evaluation).
         self.last_eval_block: Dict[str, int] = {}
+
+        # Last eval window for each hotkey. Used by _needs_evaluation logging
+        # and surfaces "which window did we last score this miner in" for
+        # debugging restart / cross-epoch reuse behavior.
+        self.last_eval_window: Dict[str, int] = {}
 
         # Pack content cache: pack_hash -> pack dict
         self._pack_by_hash: Dict[str, dict] = {}
@@ -252,11 +266,10 @@ class TrajectoryValidator:
         self._winner_state_path = str(config.winner_state_path)
         self._winner_state = load_winner_state(self._winner_state_path)
 
-
-        # Scenario config hash for state invalidation — driven by bench version
-        self._scenario_config_hash = "trajrl-bench"
-
-        # Load persisted evaluation state
+        # Load persisted evaluation state. Eval state is invalidated when the
+        # persisted spec_number disagrees with the current SPEC_NUMBER (any
+        # bump in scenario set or scoring methodology renders cached scores
+        # incomparable).
         self._load_eval_state()
 
         logger.info("Validator initialization complete!")
@@ -345,16 +358,13 @@ class TrajectoryValidator:
     # Evaluation state persistence
     # ------------------------------------------------------------------
 
-    def _compute_scenario_config_hash(self) -> str:
-        """Hash the bench version for detecting configuration changes."""
-        config_str = f"trajrl-bench:{self._sandbox_harness.sandbox_version}"
-        return hashlib.sha256(config_str.encode()).hexdigest()[:16]
-
     def _load_eval_state(self):
         """Load persisted evaluation state from disk.
 
-        Invalidates all state when either ``scoring_version`` or
-        ``scenario_config_hash`` no longer matches the running code.
+        Invalidates all state when the persisted ``spec_number`` no longer
+        matches the running ``SPEC_NUMBER`` — any spec bump implies cached
+        scores are incomparable with new ones. Accepts either ``spec_number``
+        (current) or ``scoring_version`` (legacy) JSON keys.
         """
         path = self.config.eval_state_path
         if not path.exists():
@@ -363,18 +373,12 @@ class TrajectoryValidator:
         try:
             data = json.loads(path.read_text())
 
-            file_sv = data.get("scoring_version", 1)
-            if file_sv != _scoring_version():
+            file_spec = data.get("spec_number", data.get("scoring_version", 1))
+            if file_spec != _spec_number():
                 logger.info(
-                    "Eval state scoring_version mismatch (%d != %d), "
+                    "Eval state spec_number mismatch (%d != %d), "
                     "invalidating all eval state",
-                    file_sv, _scoring_version(),
-                )
-                return
-
-            if data.get("scenario_config_hash") != self._scenario_config_hash:
-                logger.debug(
-                    "Scenario pool changed, invalidating all eval state"
+                    file_spec, _spec_number(),
                 )
                 return
 
@@ -382,6 +386,9 @@ class TrajectoryValidator:
             self._eval_pack_hash = data.get("eval_pack_hash", {})
             self.last_eval_block = {
                 k: int(v) for k, v in data.get("last_eval_block", {}).items()
+            }
+            self.last_eval_window = {
+                k: int(v) for k, v in data.get("last_eval_window_per_hotkey", {}).items()
             }
             self._last_eval_window = data.get("last_eval_window", -1)
 
@@ -399,13 +406,16 @@ class TrajectoryValidator:
 
     def _save_eval_state(self):
         """Persist evaluation state to disk for restart recovery."""
+        # Emit both keys for backward-compat with older validator binaries.
+        spec = _spec_number()
         data = {
-            "scoring_version": _scoring_version(),
-            "scenario_config_hash": self._scenario_config_hash,
+            "scoring_version": spec,
+            "spec_number": spec,
             "scenario_scores": self.scenario_scores,
             "eval_pack_hash": self._eval_pack_hash,
             "last_eval_block": self.last_eval_block,
             "last_eval_window": self._last_eval_window,
+            "last_eval_window_per_hotkey": self.last_eval_window,
             "consensus_window": self._consensus_window,
             "integrity_cache": self.integrity_judge.dump_cache(),
         }
@@ -432,6 +442,7 @@ class TrajectoryValidator:
             self.scenario_scores,
             self._eval_pack_hash,
             self.last_eval_block,
+            self.last_eval_window,
             self._eval_counts,
             self.latest_token_usage,
             self.latest_model_usage,
@@ -598,7 +609,7 @@ class TrajectoryValidator:
             protocol_version=self.config.consensus_protocol_version,
             window_number=window.window_number,
             content_address=content_address,
-            scoring_version=_scoring_version(),
+            spec_number=_spec_number(),
         )
 
         if len(commitment_str.encode("utf-8")) > MAX_COMMITMENT_BYTES:
@@ -608,7 +619,7 @@ class TrajectoryValidator:
                 protocol_version=self.config.consensus_protocol_version,
                 window_number=window.window_number,
                 content_address=fallback_address,
-                scoring_version=_scoring_version(),
+                spec_number=_spec_number(),
             )
             logger.warning(
                 "Window %d: commitment too long with dual address, "
@@ -670,12 +681,18 @@ class TrajectoryValidator:
             bench_version=bench_ver,
             scores=scores_by_hotkey,
             timestamp=int(time.time()),
-            scoring_version=_scoring_version(),
+            spec_number=_spec_number(),
             disqualified=disqualified_by_hotkey,
         )
 
     async def _run_consensus_aggregation(self, window: EvaluationWindow):
-        """Read on-chain consensus pointers, download payloads, filter, aggregate."""
+        """Read on-chain consensus pointers, download payloads, filter, aggregate.
+
+        All on-chain commitments are downloaded regardless of their
+        ``spec_number`` value; the target spec_number for filtering is
+        derived from the on-chain stake distribution by the filter pipeline
+        (see ``consensus_filter.select_target_spec_number``).
+        """
         if not self._is_metagraph_healthy():
             logger.warning(
                 "Window %d: metagraph unhealthy (n=%d) before consensus "
@@ -695,12 +712,8 @@ class TrajectoryValidator:
             return
 
         submissions = []
-        skipped_sv = 0
         download_failed = 0
         for vc in chain_commitments:
-            if vc.scoring_version != _scoring_version():
-                skipped_sv += 1
-                continue
             pointer = ConsensusPointer(
                 protocol_version=vc.protocol_version,
                 window_number=vc.window_number,
@@ -714,12 +727,6 @@ class TrajectoryValidator:
                 submissions.append((pointer, payload))
             else:
                 download_failed += 1
-        if skipped_sv:
-            logger.info(
-                "Window %d: skipped %d commitments with mismatched "
-                "scoring_version (expected %d)",
-                window.window_number, skipped_sv, _scoring_version(),
-            )
 
         my_hotkey = self.wallet.hotkey.ss58_address
         own_found = any(
@@ -734,20 +741,11 @@ class TrajectoryValidator:
 
         if not submissions:
             total = len(chain_commitments)
-            if skipped_sv == total:
-                logger.warning(
-                    "Window %d: no usable commitments — all %d filtered out "
-                    "due to scoring_version mismatch (local=%d), "
-                    "using local results",
-                    window.window_number, total, _scoring_version(),
-                )
-            else:
-                logger.warning(
-                    "Window %d: no usable submissions from %d commitments "
-                    "(%d version-filtered, %d download-failed), "
-                    "using local results",
-                    window.window_number, total, skipped_sv, download_failed,
-                )
+            logger.warning(
+                "Window %d: no usable submissions from %d commitments "
+                "(%d download-failed), using local results",
+                window.window_number, total, download_failed,
+            )
             return
 
         validator_stakes: Dict[str, float] = {}
@@ -764,8 +762,8 @@ class TrajectoryValidator:
             expected_window=window.window_number,
             validator_stakes=validator_stakes,
             min_stake=min_stake,
+            local_spec_number=_spec_number(),
             expected_protocol=self.config.consensus_protocol_version,
-            expected_scoring_version=_scoring_version(),
             zero_signal_threshold=zero_threshold,
         )
 
@@ -843,7 +841,7 @@ class TrajectoryValidator:
                                 rejected=True,
                                 rejection_stage=_stage,
                                 rejection_detail=_detail,
-                                scoring_version=_scoring_version(),
+                                spec_number=_spec_number(),
                                 **self._harness_metadata(),
                             )
                         )
@@ -1082,28 +1080,22 @@ class TrajectoryValidator:
             f"(~{self.config.weight_interval_blocks * 12 // 60}min)"
         )
 
-        # Pull sandbox image early so SCORING_VERSION is correct for
-        # startup aggregation (otherwise it stays at the default=1).
+        # Pull sandbox image early so audit logs (bench_version) are accurate
+        # for startup aggregation. SPEC_NUMBER is a code-level constant and
+        # no longer derived from the bench image.
         if self.config.full_cycle_on_startup or self.config.aggregate_when_start:
             try:
                 await self._sandbox_harness.pull_latest()
-                _consensus_mod.SCORING_VERSION = (
-                    self._sandbox_harness.scoring_version
-                )
                 logger.info(
-                    "scoring_version=%d (bench_version=%s) — set before "
+                    "spec_number=%d (bench_version=%s) — pulled before "
                     "startup aggregation",
-                    self._sandbox_harness.scoring_version,
+                    _spec_number(),
                     self._sandbox_harness.sandbox_version,
                 )
-                # Reload: __init__ loaded with stale SCORING_VERSION=1,
-                # which invalidated the saved state. Now that the real
-                # version is known, reload to recover _eval_pack_hash etc.
-                self._load_eval_state()
             except Exception as e:
                 logger.warning(
                     "Failed to pull sandbox image before startup aggregation: "
-                    "%s — scoring_version may be stale", e,
+                    "%s — bench_version audit field may be stale", e,
                 )
 
         if self.config.full_cycle_on_startup:
@@ -1336,12 +1328,13 @@ class TrajectoryValidator:
         self._cycle_log_block = current_block
 
         await self._execute_evaluation_cycle(
-            current_block, cycle_eval_id, cycle_start,
+            current_block, window_number, cycle_eval_id, cycle_start,
         )
 
     async def _execute_evaluation_cycle(
         self,
         current_block: int,
+        window_number: int,
         cycle_eval_id: str,
         cycle_start: float,
     ):
@@ -1381,11 +1374,10 @@ class TrajectoryValidator:
                 "Skipping this eval cycle. Error: %s", e,
             )
             return
-        # scoring_version = trajrl-bench major version (v3.0.1 → 3)
-        import trajectoryrl.utils.consensus as _consensus
-        _consensus_mod.SCORING_VERSION = self._sandbox_harness.scoring_version
-        logger.info("scoring_version=%d (bench_version=%s)",
-                    self._sandbox_harness.scoring_version,
+        # spec_number is a validator-side constant (see config.SPEC_NUMBER);
+        # bench_version is logged purely for audit.
+        logger.info("spec_number=%d (bench_version=%s)",
+                    _spec_number(),
                     self._sandbox_harness.sandbox_version)
 
         # Epoch seed for context variation
@@ -1512,7 +1504,7 @@ class TrajectoryValidator:
                         rejected=True,
                         rejection_stage="integrity_check",
                         rejection_detail=detail,
-                        scoring_version=_scoring_version(),
+                        spec_number=_spec_number(),
                         **self._harness_metadata(),
                     )
                 )
@@ -1562,7 +1554,7 @@ class TrajectoryValidator:
                             rejected=True,
                             rejection_stage=_stage,
                             rejection_detail=_detail,
-                            scoring_version=_scoring_version(),
+                            spec_number=_spec_number(),
                             **self._harness_metadata(),
                         )
                     )
@@ -1571,12 +1563,15 @@ class TrajectoryValidator:
                     continue
 
             needs_eval = self._needs_evaluation(
-                hotkey, commitment.pack_hash, current_block
+                hotkey, commitment.pack_hash, window_number
             )
             if not needs_eval:
                 skipped_interval_count += 1
+                last_w = self.last_eval_window.get(hotkey)
                 self._get_miner_logger(hotkey).info(
-                    f"[{miner_idx}/{total_eligible}] Skipping, within eval interval"
+                    f"[{miner_idx}/{total_eligible}] Skipping, "
+                    f"pack_hash unchanged "
+                    f"(last evaluated in window {last_w})"
                 )
                 continue
 
@@ -1629,6 +1624,7 @@ class TrajectoryValidator:
                     scenario_scores=scenario_scores_map,
                 )
                 self.last_eval_block[hotkey] = current_block
+                self.last_eval_window[hotkey] = window_number
                 evaluated_count += 1
                 q = eval_result.get("qualified", {})
                 passed = sum(1 for v in q.values() if v)
@@ -1713,27 +1709,28 @@ class TrajectoryValidator:
         await self._set_winner_weights()
 
     def _needs_evaluation(
-        self, hotkey: str, pack_hash: str, current_block: int
+        self, hotkey: str, pack_hash: str, current_window: int
     ) -> bool:
-        """Check if a miner needs re-evaluation.
+        """Return True iff the miner needs (re-)evaluation in this window.
 
-        Returns True if:
-        - pack_hash changed since last eval
-        - Time since last eval >= eval_interval
-        - Never evaluated before
+        Dedup is keyed purely on ``pack_hash``. Since
+        ``_filter_active_commitments`` drops commitments older than
+        ``inactivity_blocks`` (~2 windows), an unchanged ``pack_hash``
+        transitively means the miner is still actively re-submitting the
+        same pack — safe to reuse cached scenario scores.
+
+        ``current_window`` is accepted for symmetry / future use; it is
+        not part of the gating decision.
         """
+        del current_window  # signature only; kept for caller clarity
+
         if self._eval_pack_hash.get(hotkey) != pack_hash:
             self._get_miner_logger(hotkey).info(
                 f"pack_hash changed, marking for eval"
             )
             return True
 
-        last_block = self.last_eval_block.get(hotkey)
-        if last_block is None:
-            return True
-
-        blocks_since = current_block - last_block
-        if blocks_since >= self.config.eval_interval_blocks:
+        if not self.scenario_scores.get(hotkey):
             return True
 
         return False
@@ -1995,7 +1992,7 @@ class TrajectoryValidator:
             scenario_results=scenario_results,
             llm_base_url=self._judge_base_url,
             llm_model=self._judge_model,
-            scoring_version=_scoring_version(),
+            spec_number=_spec_number(),
             **self._harness_metadata(),
         )
 

--- a/trajectoryrl/utils/commitments.py
+++ b/trajectoryrl/utils/commitments.py
@@ -67,7 +67,7 @@ class ValidatorConsensusCommitment:
     validator_hotkey: str
     block_number: int
     raw: str
-    scoring_version: int = 1
+    spec_number: int = 1
 
 
 def encode_dual_address(
@@ -120,14 +120,17 @@ def parse_consensus_commitment(raw: str) -> Optional[Tuple[int, int, str, int]]:
 
     Supports two formats:
         Old (3-field): ``consensus:{pv}|{window}|{content_address}``
-        New (4-field): ``consensus:{pv}|{window}|{scoring_version}|{content_address}``
+        New (4-field): ``consensus:{pv}|{window}|{spec_number}|{content_address}``
 
-    Old-format commitments (missing scoring_version) default to
-    ``scoring_version=1``.
+    The integer at field 3 is the scoring spec identifier. Older commitments
+    written under the legacy ``scoring_version`` name parse to the same int
+    (the on-chain wire format is positional, so the rename does not break
+    backward compatibility). Old 3-field commitments default to
+    ``spec_number=1``.
 
     Returns:
         Tuple of (protocol_version, window_number, content_address,
-        scoring_version) or None if unparseable.
+        spec_number) or None if unparseable.
     """
     if not raw or not isinstance(raw, str):
         return None
@@ -154,13 +157,13 @@ def parse_consensus_commitment(raw: str) -> Optional[Tuple[int, int, str, int]]:
         try:
             protocol_version = int(parts[0].strip())
             window_number = int(parts[1].strip())
-            scoring_version = int(parts[2].strip())
+            spec_number = int(parts[2].strip())
         except (ValueError, TypeError):
             return None
         content_address = parts[3].strip()
         if not content_address:
             return None
-        return protocol_version, window_number, content_address, scoring_version
+        return protocol_version, window_number, content_address, spec_number
 
     return None
 
@@ -169,17 +172,17 @@ def format_consensus_commitment(
     protocol_version: int,
     window_number: int,
     content_address: str,
-    scoring_version: int = 1,
+    spec_number: int = 1,
 ) -> str:
     """Build a consensus commitment string for ``set_commitment``.
 
     Returns:
         Formatted string:
-        ``consensus:{protocol_version}|{window_number}|{scoring_version}|{content_address}``
+        ``consensus:{protocol_version}|{window_number}|{spec_number}|{content_address}``
     """
     return (
         f"{_CONSENSUS_PREFIX}{protocol_version}|{window_number}"
-        f"|{scoring_version}|{content_address}"
+        f"|{spec_number}|{content_address}"
     )
 
 
@@ -356,7 +359,7 @@ def fetch_validator_consensus_commitments(
             )
             continue
 
-        protocol_version, window_number, content_address, scoring_version = parsed
+        protocol_version, window_number, content_address, spec_number = parsed
         block_number = _get_commitment_block(subtensor, netuid, hotkey)
 
         results.append(ValidatorConsensusCommitment(
@@ -366,12 +369,12 @@ def fetch_validator_consensus_commitments(
             validator_hotkey=hotkey,
             block_number=block_number,
             raw=raw,
-            scoring_version=scoring_version,
+            spec_number=spec_number,
         ))
         logger.debug(
-            "Validator %s: consensus commitment — v%d window=%d sv=%d addr=%s",
+            "Validator %s: consensus commitment — v%d window=%d spec=%d addr=%s",
             hotkey[:8], protocol_version, window_number,
-            scoring_version, content_address[:24],
+            spec_number, content_address[:24],
         )
 
     if skipped_non_validator:

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -18,6 +18,30 @@ DEFAULT_IMAGE_CHANNEL = "latest"
 SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/trajrl-bench"
 HARNESS_IMAGE_REPO = "ghcr.io/trajectoryrl/hermes-agent"
 
+# SPEC_NUMBER identifies a "scoring specification": the combination of
+# scenario set, scoring methodology, and judge prompt that determines whether
+# two evaluations produce comparable scores.
+#
+# Bump SPEC_NUMBER whenever a change makes new scores incomparable with old
+# ones (adding/removing scenarios, changing weights, modifying judge prompts,
+# changing the aggregation rule). Bench-image patch releases that preserve
+# scoring semantics do NOT bump it.
+#
+# This constant ships with the validator binary; it is decoupled from the
+# trajrl-bench image version (now used purely for audit / log purposes).
+#
+# Aggregation derives its target spec number from on-chain stake distribution
+# rather than reading this constant directly — see
+# ``consensus_filter.select_target_spec_number`` for details. SPEC_NUMBER is
+# consulted only as the fallback target when no on-chain spec_number group
+# reaches >50% stake, and as the value written into outgoing commitments /
+# payloads.
+SPEC_NUMBER = 4
+
+# Backwards-compatible alias for legacy callers / persisted state. Will be
+# removed after one validator release cycle.
+SCORING_VERSION = SPEC_NUMBER
+
 
 @dataclass
 class ValidatorConfig:

--- a/trajectoryrl/utils/consensus.py
+++ b/trajectoryrl/utils/consensus.py
@@ -12,13 +12,6 @@ from typing import Dict
 
 CONSENSUS_PROTOCOL_VERSION = 2
 
-# Scoring version = major version of trajrl-bench (e.g. v3.0.1 → 3).
-# Overwritten at runtime by TrajectorySandboxHarness.scoring_version after
-# pulling the sandbox image.  This default is only used before the first pull.
-# Results from different scoring versions are never mixed during aggregation,
-# cached-result lookup, or winner selection.
-SCORING_VERSION = 1
-
 
 @dataclass
 class ConsensusPayload:
@@ -31,6 +24,7 @@ class ConsensusPayload:
       - scores: miner hotkey -> quality score (0.0–1.0)
       - bench_version: trajrl-bench version string
       - disqualified: miner hotkey -> reason
+      - spec_number: scoring spec identifier (see ``config.SPEC_NUMBER``)
     """
     protocol_version: int
     window_number: int
@@ -38,16 +32,20 @@ class ConsensusPayload:
     bench_version: str
     scores: Dict[str, float]        # miner hotkey -> quality score (0.0–1.0)
     timestamp: int                   # unix seconds when payload was built
-    scoring_version: int = 1         # major version of trajrl-bench
+    spec_number: int = 1
     disqualified: Dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
+        # Emit both `spec_number` (canonical) and `scoring_version` (legacy
+        # mirror) so older validators that still read the legacy key can
+        # filter incoming payloads correctly during the rollout window.
         return {
             "bench_version": self.bench_version,
             "disqualified": self.disqualified,
             "protocol_version": self.protocol_version,
             "scores": self.scores,
-            "scoring_version": self.scoring_version,
+            "scoring_version": self.spec_number,
+            "spec_number": self.spec_number,
             "timestamp": self.timestamp,
             "validator_hotkey": self.validator_hotkey,
             "window_number": self.window_number,
@@ -64,19 +62,12 @@ class ConsensusPayload:
     @classmethod
     def deserialize(cls, data: bytes) -> "ConsensusPayload":
         d = json.loads(data.decode("utf-8"))
-        return cls(
-            protocol_version=d["protocol_version"],
-            window_number=d["window_number"],
-            validator_hotkey=d["validator_hotkey"],
-            bench_version=d.get("bench_version", ""),
-            scores=d.get("scores", {}),
-            timestamp=d["timestamp"],
-            scoring_version=d.get("scoring_version", 1),
-            disqualified=d.get("disqualified", {}),
-        )
+        return cls.from_dict(d)
 
     @classmethod
     def from_dict(cls, d: dict) -> "ConsensusPayload":
+        # Accept either spec_number (current) or scoring_version (legacy).
+        spec_number = d.get("spec_number", d.get("scoring_version", 1))
         return cls(
             protocol_version=d["protocol_version"],
             window_number=d["window_number"],
@@ -84,7 +75,7 @@ class ConsensusPayload:
             bench_version=d.get("bench_version", ""),
             scores=d.get("scores", {}),
             timestamp=d["timestamp"],
-            scoring_version=d.get("scoring_version", 1),
+            spec_number=spec_number,
             disqualified=d.get("disqualified", {}),
         )
 

--- a/trajectoryrl/utils/consensus_filter.py
+++ b/trajectoryrl/utils/consensus_filter.py
@@ -8,21 +8,37 @@ Pipeline order:
   1. Protocol version  — discard mismatched protocol versions
   2. Window number     — discard submissions from wrong window
   3. Trust threshold   — discard validators below min stake
-  4. Scoring version   — discard mismatched evaluation criteria versions
+  4. spec_number       — discard submissions whose payload spec_number
+                          differs from the chain-derived target spec
   5. Zero-signal       — discard all-zero score submissions (free-riders)
+
+The target spec_number used by layer 4 is not read from a static local
+constant. Instead, ``select_target_spec_number`` derives it from the
+on-chain stake distribution of the surviving submissions: the
+stake-weighted dominant spec_number wins if it holds more than 50% of
+participating stake; otherwise the validator falls back to its locally
+configured ``SPEC_NUMBER``. This keeps SPEC_NUMBER bumps self-coordinating
+across validators (the previous winner keeps receiving emissions until
+stake-weighted majority migrates to the new spec).
 """
 
 import logging
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
-from . import consensus as _consensus_mod
+from .config import SPEC_NUMBER
 from .consensus import (
     ConsensusPayload, ConsensusPointer,
     CONSENSUS_PROTOCOL_VERSION,
 )
 
 logger = logging.getLogger(__name__)
+
+
+# Stake-share threshold for adopting an on-chain dominant spec_number as
+# this round's target. Reuses the disqualify_stake_threshold semantic from
+# scoring (>50% stake-weighted majority).
+SPEC_MAJORITY_THRESHOLD = 0.5
 
 
 @dataclass
@@ -32,8 +48,10 @@ class FilterStats:
     skipped_protocol: int = 0
     skipped_window: int = 0
     skipped_stake: int = 0
-    skipped_scoring_version: int = 0
+    skipped_spec_number: int = 0
     skipped_zero_signal: int = 0
+    target_spec_number: int = 0
+    target_spec_source: str = ""  # "chain_majority" | "local_fallback"
     passed: int = 0
 
     def summary(self) -> str:
@@ -41,7 +59,8 @@ class FilterStats:
             f"Filter: {self.total_input} in → {self.passed} passed | "
             f"protocol={self.skipped_protocol} window={self.skipped_window} "
             f"stake={self.skipped_stake} "
-            f"scoring={self.skipped_scoring_version} "
+            f"spec={self.skipped_spec_number} (target={self.target_spec_number} "
+            f"via {self.target_spec_source}) "
             f"zero={self.skipped_zero_signal}"
         )
 
@@ -113,20 +132,75 @@ def filter_trust_threshold(
     return passed, skipped
 
 
-def filter_scoring_version(
+def select_target_spec_number(
     submissions: List[Tuple[ConsensusPointer, ConsensusPayload]],
-    expected_version: Optional[int] = None,
+    validator_stakes: Dict[str, float],
+    local_spec: int,
+    threshold: float = SPEC_MAJORITY_THRESHOLD,
+) -> Tuple[int, str]:
+    """Choose this round's target spec_number from on-chain data.
+
+    Algorithm:
+      1. Group submissions by ``payload.spec_number``.
+      2. Sum validator stake per group.
+      3. dominant = group with the largest total stake.
+      4. If ``dominant.stake / total_stake > threshold`` → use dominant.spec_number.
+         Otherwise fall back to ``local_spec``.
+
+    A tied-for-max set of groups always fails the strict ``> threshold``
+    check (since two groups summing > 100% is impossible), and the function
+    falls back to ``local_spec`` — no explicit tiebreak is needed.
+
+    Args:
+        submissions: Surviving submissions after basic (protocol / window /
+            stake) filters. The ``payload.spec_number`` field is the spec
+            label this validator self-attested to.
+        validator_stakes: ``{validator_hotkey: stake}`` snapshot from the
+            metagraph. Missing hotkeys are treated as zero stake.
+        local_spec: Validator's locally configured ``SPEC_NUMBER``, used as
+            the fallback target when no group reaches majority.
+        threshold: Stake-share required for adoption (default 0.5).
+
+    Returns:
+        ``(target_spec_number, source)`` where ``source`` is
+        ``"chain_majority"`` or ``"local_fallback"``.
+    """
+    if not submissions:
+        return local_spec, "local_fallback"
+
+    stake_by_spec: Dict[int, float] = {}
+    for ptr, payload in submissions:
+        stake = validator_stakes.get(ptr.validator_hotkey, 0.0)
+        if stake <= 0:
+            continue
+        stake_by_spec[payload.spec_number] = (
+            stake_by_spec.get(payload.spec_number, 0.0) + stake
+        )
+
+    total_stake = sum(stake_by_spec.values())
+    if total_stake <= 0:
+        return local_spec, "local_fallback"
+
+    dominant_spec = max(stake_by_spec, key=lambda s: stake_by_spec[s])
+    dominant_share = stake_by_spec[dominant_spec] / total_stake
+
+    if dominant_share > threshold:
+        return dominant_spec, "chain_majority"
+    return local_spec, "local_fallback"
+
+
+def filter_spec_number(
+    submissions: List[Tuple[ConsensusPointer, ConsensusPayload]],
+    target_spec_number: int,
 ) -> Tuple[List[Tuple[ConsensusPointer, ConsensusPayload]], int]:
-    """Layer 6: discard submissions with mismatched scoring version."""
-    if expected_version is None:
-        expected_version = _consensus_mod.SCORING_VERSION
+    """Layer 4: discard submissions whose spec_number != target."""
     passed = []
     skipped = 0
     for ptr, payload in submissions:
-        if payload.scoring_version != expected_version:
+        if payload.spec_number != target_spec_number:
             logger.debug(
-                "Filter[scoring_version]: skip %s (sv%d != sv%d)",
-                ptr.validator_hotkey[:8], payload.scoring_version, expected_version,
+                "Filter[spec_number]: skip %s (spec=%d != target=%d)",
+                ptr.validator_hotkey[:8], payload.spec_number, target_spec_number,
             )
             skipped += 1
         else:
@@ -138,7 +212,7 @@ def filter_zero_signal(
     submissions: List[Tuple[ConsensusPointer, ConsensusPayload]],
     zero_threshold: float = 1.0,
 ) -> Tuple[List[Tuple[ConsensusPointer, ConsensusPayload]], int]:
-    """Layer 7: discard near-zero-signal submissions when real signal exists.
+    """Layer 5: discard near-zero-signal submissions when real signal exists.
 
     A submission is dropped when the fraction of zero scores meets or exceeds
     ``zero_threshold``.  Default 1.0 keeps the legacy behaviour (drop only
@@ -186,15 +260,24 @@ def run_filter_pipeline(
     expected_window: int,
     validator_stakes: Dict[str, float],
     min_stake: float,
+    local_spec_number: int = SPEC_NUMBER,
     expected_protocol: int = CONSENSUS_PROTOCOL_VERSION,
-    expected_scoring_version: Optional[int] = None,
     zero_signal_threshold: float = 1.0,
+    spec_majority_threshold: float = SPEC_MAJORITY_THRESHOLD,
 ) -> Tuple[List[ValidatedSubmission], FilterStats]:
     """Run the full 5-layer filter pipeline.
 
+    Layers run in order: protocol → window → stake → spec_number → zero-signal.
+
+    The spec_number target is derived from the surviving submissions after
+    the first three layers — see :func:`select_target_spec_number`. Callers
+    provide their ``local_spec_number`` only as the fallback target when no
+    on-chain group reaches majority; it is not used to pre-filter.
+
     Returns:
         - List of ValidatedSubmission that passed all layers
-        - FilterStats with per-layer skip counts
+        - FilterStats with per-layer skip counts and the target spec_number
+          used (plus its source).
     """
     stats = FilterStats(total_input=len(submissions))
 
@@ -209,8 +292,15 @@ def run_filter_pipeline(
     current, n = filter_trust_threshold(current, validator_stakes, min_stake)
     stats.skipped_stake = n
 
-    current, n = filter_scoring_version(current, expected_scoring_version)
-    stats.skipped_scoring_version = n
+    target_spec, source = select_target_spec_number(
+        current, validator_stakes, local_spec_number,
+        threshold=spec_majority_threshold,
+    )
+    stats.target_spec_number = target_spec
+    stats.target_spec_source = source
+
+    current, n = filter_spec_number(current, target_spec)
+    stats.skipped_spec_number = n
 
     current, n = filter_zero_signal(current, zero_threshold=zero_signal_threshold)
     stats.skipped_zero_signal = n

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -354,7 +354,9 @@ class TrajectorySandboxHarness:
         _model = config.judge_model or config.llm_model
         self._llm_model = _strip_provider_prefix(_model)
 
-        # Sandbox version — queried at pull time, drives scoring_version
+        # Sandbox version — queried at pull time, used purely for audit and
+        # logging. The scoring spec identifier (SPEC_NUMBER) is now a
+        # validator-side constant, decoupled from the bench image version.
         self.sandbox_version: str = "unknown"
         self.sandbox_scenarios: list[str] = []
 
@@ -372,27 +374,6 @@ class TrajectorySandboxHarness:
         if self._docker_client is None:
             self._docker_client = docker.from_env()
         return self._docker_client
-
-    @property
-    def scoring_version(self) -> int:
-        """Major version of bench_version (trajrl-bench version).
-
-        v3.0.1 → 3, v1.0.0 → 1, etc. Falls back to 1 if unparseable.
-        Validators with different bench major versions will not mix
-        results during consensus aggregation.
-        """
-        try:
-            major = self.sandbox_version.lstrip("v").split(".")[0]
-            return int(major)
-        except (ValueError, IndexError):
-            return 1
-
-        logger.info(
-            "TrajectorySandboxHarness initialized "
-            "(sandbox=%s, harness=%s, episodes=%d, timeout=%ds)",
-            self._sandbox_image, self._harness_image,
-            config.sandbox_num_episodes, config.sandbox_timeout_per_episode,
-        )
 
     async def pull_latest(self) -> None:
         """Pull latest images and query sandbox version. Gets new scenarios."""

--- a/trajectoryrl/utils/status_reporter.py
+++ b/trajectoryrl/utils/status_reporter.py
@@ -381,7 +381,7 @@ async def submit_eval(
     rejected: Optional[bool] = None,
     rejection_stage: Optional[str] = None,
     rejection_detail: Optional[str] = None,
-    scoring_version: Optional[int] = None,
+    spec_number: Optional[int] = None,
     bench_image_hash: Optional[str] = None,
     harness_image_hash: Optional[str] = None,
     bench_version: Optional[str] = None,
@@ -437,8 +437,11 @@ async def submit_eval(
         payload["rejection_stage"] = rejection_stage
     if rejection_detail is not None:
         payload["rejection_detail"] = rejection_detail
-    if scoring_version is not None:
-        payload["scoring_version"] = scoring_version
+    if spec_number is not None:
+        # Emit both keys for backward compatibility with the central status
+        # service while it migrates to the new column name.
+        payload["scoring_version"] = spec_number
+        payload["spec_number"] = spec_number
     if bench_image_hash is not None:
         payload["bench_image_hash"] = bench_image_hash
     if harness_image_hash is not None:

--- a/trajectoryrl/utils/winner_state.py
+++ b/trajectoryrl/utils/winner_state.py
@@ -14,25 +14,26 @@ import os
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 
-from . import consensus as _consensus_mod
-
 logger = logging.getLogger(__name__)
-
-
-def _scoring_version() -> int:
-    """Read the current SCORING_VERSION dynamically from the consensus module."""
-    return _consensus_mod.SCORING_VERSION
 
 
 @dataclass
 class WinnerState:
-    """Persisted state for Winner Protection."""
+    """Persisted state for Winner Protection.
+
+    ``spec_number`` is purely an audit field — it records which scoring
+    spec the current winner was selected under. It does NOT trigger a state
+    reset on its own. The new winner naturally replaces the old one once
+    the chain-derived target spec_number flips and a new aggregation round
+    produces a different best score (see consensus_filter.
+    select_target_spec_number).
+    """
 
     winner_hotkey: Optional[str] = None
     winner_pack_hash: Optional[str] = None
     winner_score: Optional[float] = None
     winner_uid: Optional[int] = None
-    scoring_version: int = 1
+    spec_number: int = 1
 
 
 def select_winner_with_protection(
@@ -159,8 +160,12 @@ def select_winner_with_protection(
 
 def save_winner_state(state: WinnerState, path: str):
     """Persist winner state to JSON file."""
+    # Emit both `spec_number` (current) and `scoring_version` (legacy mirror)
+    # so older validator binaries still in the rollout pool can read the
+    # value back without misclassifying it as "missing" (default 1).
     data = {
-        "scoring_version": state.scoring_version,
+        "scoring_version": state.spec_number,
+        "spec_number": state.spec_number,
         "winner_hotkey": state.winner_hotkey,
         "winner_pack_hash": state.winner_pack_hash,
         "winner_score": state.winner_score,
@@ -175,31 +180,26 @@ def save_winner_state(state: WinnerState, path: str):
 def load_winner_state(path: str) -> WinnerState:
     """Load winner state from JSON file, or return fresh state.
 
-    Returns an empty ``WinnerState`` when the persisted
-    ``scoring_version`` does not match the running ``SCORING_VERSION``,
-    so that an obsolete winner cannot block elections under the new
-    evaluation criteria.
+    The persisted ``spec_number`` is restored as an audit field; it does NOT
+    trigger a reset, even when it differs from the running ``SPEC_NUMBER``.
+    The new winner takes over naturally once the chain-derived target spec
+    flips (see consensus_filter.select_target_spec_number).
+
+    Accepts either ``spec_number`` (current) or ``scoring_version`` (legacy)
+    JSON keys for backward compatibility.
     """
     try:
         with open(path) as f:
             data = json.load(f)
 
-        file_sv = data.get("scoring_version", 1)
-        current_sv = _scoring_version()
-        if file_sv != current_sv:
-            logger.warning(
-                "Winner state scoring_version mismatch (%d != %d), "
-                "resetting winner protection",
-                file_sv, current_sv,
-            )
-            return WinnerState()
+        spec_number = data.get("spec_number", data.get("scoring_version", 1))
 
         return WinnerState(
             winner_hotkey=data.get("winner_hotkey"),
             winner_pack_hash=data.get("winner_pack_hash"),
             winner_score=data.get("winner_score", data.get("winner_cost")),
             winner_uid=data.get("winner_uid"),
-            scoring_version=file_sv,
+            spec_number=spec_number,
         )
     except (FileNotFoundError, json.JSONDecodeError):
         return WinnerState()


### PR DESCRIPTION
## Summary

- Rename `scoring_version` → `spec_number` and move the constant to `trajectoryrl/utils/config.py::SPEC_NUMBER`. It is now a manually maintained validator-side knob, fully decoupled from the `trajrl-bench` image version (which becomes audit/log-only).
- Aggregation no longer uses the local `SPEC_NUMBER` as a hard filter. `consensus_filter.select_target_spec_number` derives the round's target from on-chain stake distribution: stake-weighted dominant `spec_number` wins if it holds **>50% stake**; otherwise the validator falls back to its local `SPEC_NUMBER`. Spec bumps become self-coordinating — the previous winner keeps receiving emissions until majority stake migrates.
- `WinnerState.spec_number` becomes audit-only and no longer triggers a state reset on mismatch; the new winner takes over once the chain-derived target flips.
- Removed dead `_compute_scenario_config_hash` plumbing and the runtime `SCORING_VERSION` overwrite at validator startup.

## Backward compatibility (rollout window)

Both write and read paths support the old `scoring_version` key alongside the new `spec_number`:

| Surface | Write | Read |
|---|---|---|
| `ConsensusPayload` (CAS JSON) | both keys | prefer `spec_number`, fallback `scoring_version` |
| `winner_state.json` | both keys | both keys accepted |
| `eval_state.json` | both keys | both keys accepted |
| `status_reporter.submit_eval` | both keys | n/a |
| On-chain commitment string | positional, unchanged | 4-field unchanged; legacy 3-field defaults to `spec_number=1` |
| `config.SCORING_VERSION` alias | re-exported | re-exported |

Cleanup of the legacy mirror is tracked separately (Terry's TODO) — must be paired with a `CONSENSUS_PROTOCOL_VERSION` bump because removing the mirror key changes payload bytes and therefore `content_hash`.

## Test plan

- [x] `pytest tests/test_validator.py -k "spec_number or scoring_version or eval_state or legacy or ConsensusFilter or BackCompat"` → 27 pass
- [x] Smoke: `from trajectoryrl.utils.config import SPEC_NUMBER`, `_spec_number()`, `select_target_spec_number(...)` for majority / fallback / no-stake cases
- [x] Verified `ConsensusPayload.from_dict` reads legacy `scoring_version`-only JSON
- [x] Verified `load_winner_state` does NOT reset on `spec_number` mismatch (audit-only)
- [x] Lint clean on all 17 modified files (only pre-existing `dotenv` / `pytest` import warnings remain)
- [ ] Staging validator: confirm both `spec_number` and `scoring_version` keys appear in uploaded CAS payload
- [ ] Staging validator: confirm `target_spec_source` log line shows `chain_majority` once a stake-weighted majority forms

## Docs

- `docs/INCENTIVE_MECHANISM.md` — new `### SPEC_NUMBER and target spec selection` section + WinnerState carryover rule
- `docs/EVALUATION_S1.md`, `docs/seasons/self_learning_s1.md` — updated versioning narrative
- TrajOS canonical docs (`SCORING_AND_EVALUATION.md`, `INCENTIVE_MECHANISM.md`) synced first per CLAUDE.md workflow

Made with [Cursor](https://cursor.com)