### PR TITLE
fix: drop fleet-wide bootstrap bypass in filter_zero_signal

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -2134,14 +2134,17 @@ class TestConsensusFilter:
         assert skipped == 1
         assert passed[0][0].validator_hotkey == "val_a"
 
-    def test_filter_zero_signal_all_zero_passes(self):
+    def test_filter_zero_signal_all_zero_dropped(self):
+        # Fleet-wide all-zero (e.g. LLM outage) used to pass via a bootstrap
+        # bypass. That gave the lex-first hotkey a free win on a 0.0 consensus
+        # score. Now every all-zero submission is dropped individually.
         subs = [
             self._make_submission(hotkey="val_a", scores={"m": 0.0}),
             self._make_submission(hotkey="val_b", scores={"m": 0.0}),
         ]
         passed, skipped = filter_zero_signal(subs)
-        assert len(passed) == 2
-        assert skipped == 0
+        assert len(passed) == 0
+        assert skipped == 2
 
     def test_filter_zero_signal_threshold_drops_near_zero(self):
         # val_b has 41/42 zero scores (97.6%) — a single token-nonzero — and

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -850,19 +850,50 @@ class TrajectoryValidator:
 
         min_stake = getattr(self.config, "min_validator_stake", 0.0)
         zero_threshold = getattr(self.config, "zero_signal_threshold", 1.0)
-        validated, stats = run_filter_pipeline(
-            submissions=submissions,
-            expected_window=window.window_number,
-            validator_stakes=validator_stakes,
-            min_stake=min_stake,
-            local_spec_number=_spec_number(),
-            expected_protocol=self.config.consensus_protocol_version,
-            zero_signal_threshold=zero_threshold,
-        )
+
+        def _filter(expected_window: int):
+            return run_filter_pipeline(
+                submissions=submissions,
+                expected_window=expected_window,
+                validator_stakes=validator_stakes,
+                min_stake=min_stake,
+                local_spec_number=_spec_number(),
+                expected_protocol=self.config.consensus_protocol_version,
+                zero_signal_threshold=zero_threshold,
+            )
+
+        validated, stats = _filter(window.window_number)
+        aggregation_window = window.window_number
+
+        # Fall back to the prior window when the current one yields nothing.
+        # Without this, a fleet-wide all-zero round (e.g. simultaneous LLM
+        # outage) leaves every validator pinned to whatever winner_state was
+        # last persisted — including a lex-first hotkey that may have been
+        # elected under the old bootstrap-bypass behaviour. Re-aggregating
+        # against the previous window's still-on-chain commitments lets the
+        # legitimate prior winner be reinstated.
+        if not validated:
+            prior_window = window.window_number - 1
+            logger.warning(
+                "Window %d: all current-window submissions filtered out "
+                "(%s); retrying against window %d",
+                window.window_number, stats.summary(), prior_window,
+            )
+            prior_validated, prior_stats = _filter(prior_window)
+            if prior_validated:
+                validated = prior_validated
+                stats = prior_stats
+                aggregation_window = prior_window
+                logger.info(
+                    "Window %d: aggregating from window %d submissions "
+                    "(%d passed filter)",
+                    window.window_number, prior_window, stats.passed,
+                )
 
         if not validated:
             logger.warning(
-                "Window %d: all submissions filtered out (%s), using local results",
+                "Window %d: no usable submissions in current or prior "
+                "window (%s), using local results",
                 window.window_number, stats.summary(),
             )
             return
@@ -889,7 +920,7 @@ class TrajectoryValidator:
                 async def _limited_pre_eval(hk: str):
                     async with sem:
                         return await pre_eval(
-                            hk, epoch_number=window.window_number,
+                            hk, epoch_number=aggregation_window,
                             wallet=self.wallet,
                         )
 

--- a/trajectoryrl/utils/consensus_filter.py
+++ b/trajectoryrl/utils/consensus_filter.py
@@ -212,24 +212,19 @@ def filter_zero_signal(
     submissions: List[Tuple[ConsensusPointer, ConsensusPayload]],
     zero_threshold: float = 1.0,
 ) -> Tuple[List[Tuple[ConsensusPointer, ConsensusPayload]], int]:
-    """Layer 5: discard near-zero-signal submissions when real signal exists.
+    """Layer 5: discard near-zero-signal submissions.
 
     A submission is dropped when the fraction of zero scores meets or exceeds
     ``zero_threshold``.  Default 1.0 keeps the legacy behaviour (drop only
     strictly all-zero payloads).  Lower values (e.g. 0.95) treat free-rider
     payloads that sprinkle one or two nonzero scores as all-zero.
 
-    If no submission has any nonzero scores, all pass through (bootstrap
-    scenario — nothing to compare against).
+    Payloads are evaluated individually — there is no fleet-wide bootstrap
+    bypass.  If every validator submits all-zero (e.g. LLM outage across the
+    whole fleet), every submission is dropped and aggregation falls back to
+    local results rather than letting the lex-first hotkey win deterministically
+    with a 0.0 consensus score.
     """
-    has_nonzero = any(
-        any(s != 0.0 for s in payload.scores.values())
-        for _, payload in submissions
-    )
-
-    if not has_nonzero:
-        return submissions, 0
-
     passed = []
     skipped = 0
     for ptr, payload in submissions:


### PR DESCRIPTION
Previously, if every submission in a window had only zero scores, filter_zero_signal let them all through ("bootstrap scenario — nothing to compare against"). That produced a consensus where every miner scored exactly 0.0, after which select_winner_with_protection's sorted() — stable with all-zero ties — awarded full emissions to the lexicographically-first hotkey (JSON payloads are serialized with sort_keys=True, so insertion order through compute_consensus_scores is lex-ascending).

Concrete path to abuse / accidental harm: all-zero payloads across validators. Bootstrap bypass lets them through. Consensus gives every miner 0.0. Lex-first hotkey wins for one tempo before any non-zero submission arrives to dethrone with a trivially-clearable winner_score=0.0 × 1.10 threshold.

Remove the bypass. Every submission is now evaluated against zero_threshold individually. When the whole fleet submits zero, all submissions are dropped and _run_consensus_aggregation falls back to local results (validator.py:748-753) instead of minting a lex winner.