### PR TITLE
feat(validator): window-start active-set snapshot for restart consistency

### DIFF
--- a/tests/test_eval_snapshot.py
+++ b/tests/test_eval_snapshot.py
@@ -1,0 +1,92 @@
+"""Unit tests for trajectoryrl.utils.eval_snapshot helpers."""
+
+from trajectoryrl.utils.commitments import MinerCommitment
+from trajectoryrl.utils.eval_snapshot import (
+    DEFAULT_RETENTION,
+    EvalSnapshot,
+    load_snapshot,
+    save_snapshot,
+    snapshot_path,
+    take_snapshot,
+)
+
+
+def _mk_commitment(
+    uid: int,
+    hotkey: str,
+    block_number: int,
+    pack_hash: str = "a" * 64,
+) -> MinerCommitment:
+    return MinerCommitment(
+        uid=uid,
+        hotkey=hotkey,
+        pack_hash=pack_hash,
+        pack_url=f"https://example.com/{uid}.json",
+        block_number=block_number,
+        raw=f"{pack_hash}|https://example.com/{uid}.json",
+    )
+
+
+def test_take_snapshot_filters_in_window_and_stale():
+    raw = {
+        1: _mk_commitment(1, "hk_a", 100, "a" * 64),  # keep
+        2: _mk_commitment(2, "hk_b", 190, "b" * 64),  # keep
+        3: _mk_commitment(3, "hk_c", 200, "c" * 64),  # in-window drop
+        4: _mk_commitment(4, "hk_d", 50, "d" * 64),   # stale drop
+    }
+    snapshot = take_snapshot(
+        raw_commitments=raw,
+        window_number=7,
+        window_start=200,
+        snapshot_block=205,
+        inactivity_blocks=120,
+    )
+    assert snapshot.window_number == 7
+    assert snapshot.window_start == 200
+    assert snapshot.snapshot_block == 205
+    assert sorted(snapshot.commitments.keys()) == [1, 2]
+
+
+def test_save_and_load_snapshot_round_trip(tmp_path):
+    snapshot = EvalSnapshot(
+        window_number=3,
+        window_start=300,
+        snapshot_block=307,
+        commitments={
+            11: _mk_commitment(11, "hk_11", 250, "1" * 64),
+            12: _mk_commitment(12, "hk_12", 260, "2" * 64),
+        },
+    )
+    path = save_snapshot(snapshot, tmp_path)
+    assert path == snapshot_path(tmp_path, 3)
+    loaded = load_snapshot(tmp_path, 3)
+    assert loaded is not None
+    assert loaded.window_number == 3
+    assert loaded.window_start == 300
+    assert loaded.snapshot_block == 307
+    assert set(loaded.commitments.keys()) == {11, 12}
+    assert loaded.commitments[11].hotkey == "hk_11"
+    assert loaded.commitments[12].block_number == 260
+
+
+def test_save_snapshot_prunes_old_files(tmp_path):
+    for w in range(1, 8):
+        snap = EvalSnapshot(
+            window_number=w,
+            window_start=w * 100,
+            snapshot_block=w * 100 + 3,
+            commitments={w: _mk_commitment(w, f"hk_{w}", w * 100 - 1, f"{w}" * 64)},
+        )
+        save_snapshot(snap, tmp_path, retention=DEFAULT_RETENTION)
+
+    kept = sorted(p.name for p in tmp_path.iterdir() if p.is_file())
+    assert kept == [
+        "active_set_window_4.json",
+        "active_set_window_5.json",
+        "active_set_window_6.json",
+        "active_set_window_7.json",
+    ]
+
+
+def test_load_snapshot_missing_file_returns_none(tmp_path):
+    assert load_snapshot(tmp_path, 99) is None

--- a/tests/test_pack_ownership.py
+++ b/tests/test_pack_ownership.py
@@ -36,6 +36,24 @@ class TestClaimOwner:
         owner, blk = claim_owner(table, "hash_x", "hk_alice", 9999)
         assert (owner, blk) == ("hk_alice", 100)
 
+    def test_same_hotkey_smaller_block_updates_record(self):
+        table = {"hash_x": ("hk_alice", 100)}
+        owner, blk = claim_owner(table, "hash_x", "hk_alice", 90)
+        assert (owner, blk) == ("hk_alice", 90)
+        assert table["hash_x"] == ("hk_alice", 90)
+
+    def test_earlier_block_replaces_owner(self):
+        table = {"hash_x": ("hk_alice", 100)}
+        owner, blk = claim_owner(table, "hash_x", "hk_bob", 80)
+        assert (owner, blk) == ("hk_bob", 80)
+        assert table["hash_x"] == ("hk_bob", 80)
+
+    def test_equal_block_tie_breaks_by_hotkey(self):
+        table = {"hash_x": ("hk_bob", 100)}
+        owner, blk = claim_owner(table, "hash_x", "hk_alice", 100)
+        assert (owner, blk) == ("hk_alice", 100)
+        assert table["hash_x"] == ("hk_alice", 100)
+
 
 # ── is_owner ──────────────────────────────────────────────────────────────
 

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -83,6 +83,9 @@ from ..utils.commitments import (
     format_consensus_commitment, decode_dual_address,
     is_consensus_commitment, parse_consensus_commitment,
 )
+from ..utils.eval_snapshot import (
+    EvalSnapshot, take_snapshot, load_snapshot, save_snapshot,
+)
 from ..utils.status_reporter import (
     heartbeat, pre_eval, submit_eval, upload_eval_logs, upload_cycle_logs,
 )
@@ -1484,19 +1487,35 @@ class TrajectoryValidator:
             )
             return
 
-        # 2. Read on-chain commitments
-        logger.debug("Reading on-chain commitments...")
-        commitments = fetch_all_commitments(
-            self.subtensor, self.config.netuid, self.metagraph
-        )
+        # 2. Acquire the window-N active-set snapshot.
+        #
+        # Each window has exactly one snapshot
+        # (``active_set_window_{N}.json``) freezing the deterministic
+        # commitment subset for that window (commit_block < window_start
+        # and not stale). The snapshot is the source of truth for the
+        # remainder of the cycle: cross-validator consistency comes
+        # from chain commit_block, restart consistency from the file.
+        #
+        # On the first cycle inside a window the file is absent, so we
+        # build it from a fresh chain query and persist immediately.
+        # On subsequent cycles (same window) the file hits and we
+        # avoid the chain round-trip entirely.
+        window = compute_window(current_block, self._window_config)
+        snapshot = self._acquire_window_snapshot(window, current_block)
+        if snapshot is None:
+            return
 
-        # 3. Filter to active non-validator miners (drops stale submissions)
-        active_commitments = self._filter_active_commitments(
-            commitments, current_block,
+        # Per-validator runtime filters (validator_permit, blacklist)
+        # are dynamic and applied on top of the frozen snapshot every
+        # cycle so that permit / blacklist changes take effect without
+        # invalidating the snapshot itself.
+        active_commitments = self._filter_active_commitments_runtime(
+            snapshot.commitments,
         )
         logger.info(
-            f"Commitments: {len(commitments)} total, "
-            f"{len(active_commitments)} active miners"
+            f"Window {window.window_number} snapshot: "
+            f"{len(snapshot.commitments)} eligible, "
+            f"{len(active_commitments)} after runtime filter"
         )
 
         if not active_commitments:
@@ -1523,18 +1542,30 @@ class TrajectoryValidator:
 
         await self._prefetch_packs(active_commitments)
 
+        # Iterate by chain commit_block ascending so the earliest
+        # committer of a duplicated pack_hash is processed first and
+        # claim_owner records them as the canonical owner. Even if a
+        # later iteration order would observe the same final state
+        # (claim_owner is order-independent under the new semantics),
+        # ascending order also avoids wasting an eval round-trip on a
+        # copy that is about to be demoted in the same cycle.
+        eval_order = sorted(
+            active_commitments.items(),
+            key=lambda item: (item[1].block_number, item[1].hotkey),
+        )
+
         miner_idx = 0
-        for uid, commitment in active_commitments.items():
+        for uid, commitment in eval_order:
             hotkey = commitment.hotkey
             miner_idx += 1
 
-            # Ownership lock: first observer of this pack_hash owns it.
-            # `claim_owner` is the only place pack_first_seen entries
-            # are created — once locked, ownership never transfers (see
-            # trajectoryrl.utils.pack_ownership).
+            # Ownership lock: earliest chain commit_block wins (Issue 4
+            # anti-snipe). Passing the on-chain block keeps the recorded
+            # ordering deterministic across validators rather than
+            # tied to local observation time.
             ph = commitment.pack_hash
             owner_hk, _owner_blk = claim_owner(
-                self.pack_first_seen, ph, hotkey, current_block,
+                self.pack_first_seen, ph, hotkey, commitment.block_number,
             )
             if owner_hk != hotkey:
                 copy_rejected_count += 1
@@ -1854,6 +1885,81 @@ class TrajectoryValidator:
                 continue
             active[uid] = commitment
         return active
+
+    def _filter_active_commitments_runtime(
+        self,
+        commitments: Dict[int, MinerCommitment],
+    ) -> Dict[int, MinerCommitment]:
+        """Apply per-validator runtime filters on top of a snapshot.
+
+        The snapshot already enforces the deterministic filters
+        (``commit_block < window_start`` and stale-age vs window_start).
+        This method layers on the per-validator dynamic filters that
+        intentionally do NOT participate in cross-validator consistency:
+
+        * ``validator_permit`` — current metagraph state (a permit can
+          appear or disappear mid-window).
+        * coldkey blacklist — operator-local policy.
+        """
+        blacklist = set(self.config.coldkey_blacklist)
+        active: Dict[int, MinerCommitment] = {}
+        for uid, commitment in commitments.items():
+            if uid < len(self.metagraph.validator_permit) and self.metagraph.validator_permit[uid]:
+                continue
+            if blacklist:
+                coldkey = (
+                    self.metagraph.coldkeys[uid]
+                    if uid < len(self.metagraph.coldkeys) else None
+                )
+                if coldkey in blacklist:
+                    self._get_miner_logger(commitment.hotkey).info(
+                        f"Skipping eval (coldkey {coldkey} is blacklisted)"
+                    )
+                    continue
+            active[uid] = commitment
+        return active
+
+    def _acquire_window_snapshot(
+        self,
+        window: EvaluationWindow,
+        current_block: int,
+    ) -> Optional[EvalSnapshot]:
+        """Load or build the active-set snapshot for ``window``.
+
+        Order of operations:
+
+        1. Try to load ``active_set_window_{N}.json``. A successful
+           load is the fast path for any non-first cycle in window N
+           (and for restart recovery within the same window).
+        2. On miss, query the chain once and apply the deterministic
+           filters (``commit_block < window_start`` plus stale-age vs
+           window_start). Persist the result so subsequent cycles in
+           the same window hit the cache.
+
+        Returns the snapshot, or None if there are no eligible
+        commitments at all (caller should fall back to owner weights).
+        """
+        snapshot = load_snapshot(self.config.active_set_dir, window.window_number)
+        if snapshot is not None:
+            return snapshot
+
+        logger.info(
+            "Window %d: building active-set snapshot from chain "
+            "(window_start=%d, current_block=%d)",
+            window.window_number, window.window_start, current_block,
+        )
+        raw = fetch_all_commitments(
+            self.subtensor, self.config.netuid, self.metagraph,
+        )
+        snapshot = take_snapshot(
+            raw,
+            window_number=window.window_number,
+            window_start=window.window_start,
+            snapshot_block=current_block,
+            inactivity_blocks=self.config.inactivity_blocks,
+        )
+        save_snapshot(snapshot, self.config.active_set_dir)
+        return snapshot
 
     # ------------------------------------------------------------------
     # UID re-registration tracking

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -182,6 +182,14 @@ class ValidatorConfig:
         default_factory=lambda: Path("/var/lib/trajectoryrl/pack_first_seen.json")
     )
 
+    # Per-window active-set snapshot directory. One file per window
+    # (``active_set_window_{N}.json``) freezes the deterministic
+    # commitment subset for that window so that mid-window restarts
+    # rehydrate the same eval set instead of re-querying the chain.
+    active_set_dir: Path = field(
+        default_factory=lambda: Path("/var/lib/trajectoryrl/active_sets")
+    )
+
     # Pack caching
     pack_cache_dir: Path = field(
         default_factory=lambda: Path("/var/lib/trajectoryrl/packs")
@@ -231,6 +239,7 @@ class ValidatorConfig:
             eval_state_path=Path(os.getenv("EVAL_STATE_PATH", "/var/lib/trajectoryrl/eval_state.json")),
             winner_state_path=Path(os.getenv("WINNER_STATE_PATH", "/var/lib/trajectoryrl/winner_state.json")),
             pack_first_seen_path=Path(os.getenv("PACK_FIRST_SEEN_PATH", "/var/lib/trajectoryrl/pack_first_seen.json")),
+            active_set_dir=Path(os.getenv("ACTIVE_SET_DIR", "/var/lib/trajectoryrl/active_sets")),
             pack_cache_dir=Path(os.getenv("PACK_CACHE_DIR", "/var/lib/trajectoryrl/packs")),
             log_dir=Path(os.getenv("LOG_DIR", "./logs")),
             # --- LLM (new names preferred, legacy CLAWBENCH_* still supported) ---

--- a/trajectoryrl/utils/eval_snapshot.py
+++ b/trajectoryrl/utils/eval_snapshot.py
@@ -1,0 +1,282 @@
+"""Window-start snapshot of the active miner commitment set.
+
+Each evaluation window is anchored at ``window_start = global_anchor +
+window_number * window_length``. At the start of a window, every
+validator queries the chain for all miner commitments and freezes the
+subset that is deterministic across validators:
+
+    snapshot[uid] = commitment   iff   commitment.block_number < window_start
+
+The ``block_number`` field is sourced from the chain (see
+``commitments._get_commitment_block``), so two validators that build
+the snapshot at any time strictly after ``window_start`` and before the
+next miner overwrite produce byte-identical snapshots. Both the lower
+bound (any block in window N) and the upper bound (a brief race when a
+miner overwrites mid-poll) are accepted as the per-validator polling
+granularity error documented in the redesign plan.
+
+The snapshot is persisted to ``active_set_window_{N}.json`` so that a
+restart inside the same window N rehydrates the exact same evaluation
+set without re-querying the chain. If the file is absent on restart,
+the validator rebuilds best-effort from the current chain state and
+the same ``block_number < window_start`` filter; the result is
+identical for any commitment that was not overwritten in the meantime.
+
+Stale-age filtering (``inactivity_blocks``) is applied at snapshot
+time relative to ``window_start`` rather than ``current_block`` so the
+snapshot remains stable for the entire window even if it is taken
+late. Per-validator runtime filters (validator_permit, blacklist) are
+intentionally NOT baked into the snapshot — those are dynamic and must
+be re-evaluated against the live metagraph on every cycle.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from .commitments import MinerCommitment
+
+logger = logging.getLogger(__name__)
+
+SNAPSHOT_FORMAT_VERSION = 1
+SNAPSHOT_FILE_PATTERN = re.compile(r"^active_set_window_(\d+)\.json$")
+
+# How many recent window snapshots to keep on disk, including the
+# current window snapshot file.
+DEFAULT_RETENTION = 4
+
+
+@dataclass(frozen=True)
+class EvalSnapshot:
+    """Frozen evaluation set for a single window.
+
+    ``commitments`` is keyed by UID. ``window_start`` is the chain
+    block at the beginning of the window. ``snapshot_block`` records
+    the block height observed when the snapshot was built (purely
+    informational — does not affect determinism).
+    """
+
+    window_number: int
+    window_start: int
+    snapshot_block: int
+    commitments: Dict[int, MinerCommitment]
+
+    def hotkeys(self) -> List[str]:
+        """Sorted hotkey list — useful for cross-validator diff logs."""
+        return sorted(c.hotkey for c in self.commitments.values())
+
+
+def take_snapshot(
+    raw_commitments: Dict[int, MinerCommitment],
+    window_number: int,
+    window_start: int,
+    snapshot_block: int,
+    inactivity_blocks: Optional[int] = None,
+) -> EvalSnapshot:
+    """Filter ``raw_commitments`` to the deterministic window-N set.
+
+    Two filters are applied — both reference ``window_start``, never
+    ``snapshot_block``, so the result is invariant under polling-time
+    jitter:
+
+    * ``commitment.block_number < window_start`` — only commits that
+      landed strictly before window N starts are eligible. A commit
+      submitted inside window N is held over for window N+1.
+    * If ``inactivity_blocks`` is provided:
+      ``window_start - commitment.block_number <= inactivity_blocks``.
+    """
+    eligible: Dict[int, MinerCommitment] = {}
+    dropped_in_window = 0
+    dropped_stale = 0
+    for uid, commitment in raw_commitments.items():
+        if commitment.block_number >= window_start:
+            dropped_in_window += 1
+            continue
+        if inactivity_blocks is not None:
+            age = window_start - commitment.block_number
+            if age > inactivity_blocks:
+                dropped_stale += 1
+                continue
+        eligible[uid] = commitment
+
+    logger.info(
+        "Window %d snapshot: %d eligible (filtered %d in-window, %d stale) "
+        "from %d raw commitments at block %d (window_start=%d)",
+        window_number, len(eligible), dropped_in_window, dropped_stale,
+        len(raw_commitments), snapshot_block, window_start,
+    )
+    return EvalSnapshot(
+        window_number=window_number,
+        window_start=window_start,
+        snapshot_block=snapshot_block,
+        commitments=eligible,
+    )
+
+
+def snapshot_path(directory, window_number: int) -> Path:
+    """Return the canonical file path for a window snapshot."""
+    return Path(directory) / f"active_set_window_{window_number}.json"
+
+
+def save_snapshot(
+    snapshot: EvalSnapshot,
+    directory,
+    retention: int = DEFAULT_RETENTION,
+) -> Path:
+    """Persist ``snapshot`` to ``active_set_window_{N}.json`` and prune.
+
+    The write is two-phase (tmp file + rename) so a crash mid-write
+    cannot leave a partially-decoded file that a restart would mistake
+    for the canonical snapshot.
+
+    After the new snapshot lands, keeps only the most recent
+    ``retention`` windows (including current) and unlinks older files.
+    """
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "version": SNAPSHOT_FORMAT_VERSION,
+        "window_number": snapshot.window_number,
+        "window_start": snapshot.window_start,
+        "snapshot_block": snapshot.snapshot_block,
+        "commitments": [
+            {
+                "uid": c.uid,
+                "hotkey": c.hotkey,
+                "pack_hash": c.pack_hash,
+                "pack_url": c.pack_url,
+                "block_number": int(c.block_number),
+                "raw": c.raw,
+            }
+            for c in snapshot.commitments.values()
+        ],
+    }
+
+    target = snapshot_path(directory, snapshot.window_number)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    with open(tmp, "w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+    os.replace(tmp, target)
+    logger.info(
+        "Saved active-set snapshot for window %d (%d commitments) → %s",
+        snapshot.window_number, len(snapshot.commitments), target,
+    )
+
+    _prune_old_snapshots(directory, snapshot.window_number, retention)
+    return target
+
+
+def load_snapshot(directory, window_number: int) -> Optional[EvalSnapshot]:
+    """Load the snapshot for ``window_number``, or None if missing/invalid.
+
+    Missing file is the common case (first cycle in a fresh window) and
+    is logged at debug level. A malformed file logs a warning and
+    returns None; the caller is expected to rebuild from the chain.
+    """
+    path = snapshot_path(directory, window_number)
+    if not path.exists():
+        logger.debug("No snapshot file at %s", path)
+        return None
+
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Failed to read snapshot %s: %s", path, e)
+        return None
+
+    if not isinstance(data, dict):
+        logger.warning("Snapshot %s has invalid root type %s", path, type(data))
+        return None
+
+    file_version = data.get("version")
+    if file_version != SNAPSHOT_FORMAT_VERSION:
+        logger.warning(
+            "Snapshot %s has unsupported format version %r (expected %d)",
+            path, file_version, SNAPSHOT_FORMAT_VERSION,
+        )
+        return None
+
+    try:
+        loaded_window = int(data["window_number"])
+        if loaded_window != window_number:
+            logger.warning(
+                "Snapshot %s window_number mismatch: file=%d expected=%d",
+                path, loaded_window, window_number,
+            )
+            return None
+        window_start = int(data["window_start"])
+        snapshot_block = int(data["snapshot_block"])
+        raw_entries = data["commitments"]
+    except (KeyError, TypeError, ValueError) as e:
+        logger.warning("Snapshot %s missing required field: %s", path, e)
+        return None
+
+    if not isinstance(raw_entries, list):
+        logger.warning("Snapshot %s commitments field is not a list", path)
+        return None
+
+    commitments: Dict[int, MinerCommitment] = {}
+    for entry in raw_entries:
+        try:
+            uid = int(entry["uid"])
+            commitments[uid] = MinerCommitment(
+                uid=uid,
+                hotkey=str(entry["hotkey"]),
+                pack_hash=str(entry["pack_hash"]),
+                pack_url=str(entry["pack_url"]),
+                block_number=int(entry["block_number"]),
+                raw=str(entry["raw"]),
+            )
+        except (KeyError, TypeError, ValueError) as e:
+            logger.warning(
+                "Snapshot %s: skipping malformed entry (%s): %r",
+                path, e, entry,
+            )
+            continue
+
+    snapshot = EvalSnapshot(
+        window_number=loaded_window,
+        window_start=window_start,
+        snapshot_block=snapshot_block,
+        commitments=commitments,
+    )
+    logger.info(
+        "Loaded active-set snapshot for window %d (%d commitments) ← %s",
+        snapshot.window_number, len(snapshot.commitments), path,
+    )
+    return snapshot
+
+
+def _prune_old_snapshots(directory: Path, current_window: int, retention: int) -> None:
+    """Drop snapshot files older than the retained recent window range.
+
+    A negative ``retention`` is treated as "keep everything"; zero
+    keeps only the current window file.
+    """
+    if retention < 0:
+        return
+    cutoff = current_window - max(retention - 1, 0)
+    for entry in directory.iterdir():
+        if not entry.is_file():
+            continue
+        match = SNAPSHOT_FILE_PATTERN.match(entry.name)
+        if not match:
+            continue
+        try:
+            file_window = int(match.group(1))
+        except ValueError:
+            continue
+        if file_window < cutoff:
+            try:
+                entry.unlink()
+                logger.debug("Pruned old snapshot %s", entry)
+            except OSError as e:
+                logger.warning("Failed to prune snapshot %s: %s", entry, e)

--- a/trajectoryrl/utils/pack_ownership.py
+++ b/trajectoryrl/utils/pack_ownership.py
@@ -54,20 +54,51 @@ def claim_owner(
     table: PackOwnershipTable,
     pack_hash: str,
     hotkey: str,
-    block: int,
+    commit_block: int,
 ) -> Tuple[str, int]:
-    """Record ownership of ``pack_hash`` if not already recorded.
+    """Record ownership of ``pack_hash`` keyed on chain commit block.
 
-    First-writer-wins: subsequent calls with a different hotkey return
-    the originally claimed ``(owner_hotkey, owner_block)`` tuple. The
-    table is mutated in place via ``setdefault`` so callers can compare
-    the returned hotkey with their own to detect copies.
+    Semantics — earliest-on-chain-commit wins, deterministic across
+    validators (Issue 4 anti-snipe):
+
+    * No existing entry → claim with ``(hotkey, commit_block)``.
+    * Existing entry, same hotkey, smaller ``commit_block`` → update
+      the recorded block downward. This handles migration from the
+      legacy "current_block at first observation" semantics: the
+      first time a known owner is re-observed against the chain, its
+      block falls to the true on-chain commit block, which restores
+      ordering correctness for any later disputes.
+    * Existing entry, different hotkey:
+        - smaller ``commit_block`` → take ownership;
+        - equal ``commit_block`` → tie-break by lexicographically
+          smaller hotkey, so two validators converge to the same
+          owner regardless of iteration order.
+
+    The function mutates ``table`` in place. The caller should sort
+    its iteration by ``(commit_block, hotkey)`` to keep the post-call
+    state observable in a single pass — but the function is correct
+    under any iteration order.
 
     Returns:
-        ``(owner_hotkey, owner_block)`` — the recorded owner after this
-        call (either pre-existing or just claimed).
+        ``(owner_hotkey, owner_block)`` — the recorded owner after
+        this call.
     """
-    return table.setdefault(pack_hash, (hotkey, block))
+    existing = table.get(pack_hash)
+    if existing is None:
+        table[pack_hash] = (hotkey, commit_block)
+        return table[pack_hash]
+
+    existing_hotkey, existing_block = existing
+    if existing_hotkey == hotkey:
+        if commit_block < existing_block:
+            table[pack_hash] = (hotkey, commit_block)
+        return table[pack_hash]
+
+    if commit_block < existing_block:
+        table[pack_hash] = (hotkey, commit_block)
+    elif commit_block == existing_block and hotkey < existing_hotkey:
+        table[pack_hash] = (hotkey, commit_block)
+    return table[pack_hash]
 
 
 def is_owner(


### PR DESCRIPTION
Issue 3: freeze per-window active commitment set via window-start snapshot and persist to active_set_window_{N}.json for restart consistency. Also switch ownership lock to chain commit_block ordering, add ACTIVE_SET_DIR config, and add snapshot/ownership tests.

Made with [Cursor](https://cursor.com)