### PR TITLE
feat: target-window quorum flow and lighter validator state

### DIFF
--- a/docs/INCENTIVE_MECHANISM.md
+++ b/docs/INCENTIVE_MECHANISM.md
@@ -2,9 +2,9 @@
 
 **Subnet**: SN11 (TrajectoryRL)
 
-**Version**: v5.1
+**Version**: v5.2
 
-**Date**: 2026-04-24
+**Date**: 2026-04-26
 
 ---
 
@@ -168,9 +168,9 @@ An **epoch** is TrajectoryRL's validation cycle — a fixed-length period (measu
 
 ```
 Epoch (7200 blocks, ~24h)
-├── Evaluation window    (block 0 → 5760, 80%)    Run season benchmark, record raw scores
-├── Propagation window   (block 5760 → 6480, 10%) Upload to CAS at T_publish, wait for others
-└── Aggregation window   (block 6480 → 7200, 10%) Compute consensus, select winner
+├── Evaluation window    (block 0 → 5760, 80%)    Run season benchmark for target_window
+├── Propagation window   (block 5760 → 6480, 10%) Dissemination buffer (not a hard publish gate)
+└── Aggregation window   (block 6480 → 7200, 10%) Quorum-gated consensus for target_window
 ```
 
 Validators run a **continuous evaluation loop** synchronized by chain block height:
@@ -180,49 +180,38 @@ Validators run a **continuous evaluation loop** synchronized by chain block heig
 | `eval_interval` | 7200 blocks (~24h at 12s/block) | Epoch length, block-aligned |
 | `tempo` | 360 blocks (~72 min, chain-determined) | Set weights on-chain via commit-reveal |
 
-### Continuous Validator Loop
+### Continuous Validator Loop (Dual-Window)
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Evaluation Epoch (eval_interval blocks)        │
-│  epoch_number = floor((current_block - anchor) / eval_interval)  │
-├────────────────────────┬──────────────┬──────────────────────────┤
-│   Evaluation (0–80%)   │ Publish (80–90%) │  Aggregation (90–100%) │
-└────────────────────────┴──────────────┴──────────────────────────┘
-
- ┌──────────────────────────────────────────────────────────┐
- │  Evaluation Window (0% – 80% of epoch)                   │
- │                                                          │
- │  For each miner with valid commitment:                   │
- │    ① Pack ownership lock (pack_first_seen):              │
- │       reject as copy if not the first-observed owner     │
- │    ② Pre-eval gate → DISQUALIFY if rejected              │
- │    ③ Run evaluation pipeline → record score              │
- └──────────────────────────────────────────────────────────┘
-                          │
-                          ▼
- ┌──────────────────────────────────────────────────────────┐
- │  Propagation Window (80% – 90%)                          │
- │                                                          │
- │  Upload ConsensusPayload {scores, disqualified} to CAS   │
- │  Write pointer on-chain (set_commitment)                 │
- └──────────────────────────────────────────────────────────┘
-                          │
-                          ▼
- ┌──────────────────────────────────────────────────────────┐
- │  Aggregation Window (90% – 100%)                         │
- │                                                          │
- │  Read all validator submissions from CAS                  │
- │  Filter + stake-weighted aggregation                     │
- │  Pre-eval gate (second pass) → disqualify new rejects    │
- │  Apply Winner Protection → update winner state           │
- └──────────────────────────────────────────────────────────┘
-                          │
-                          ▼
- ┌──────────────────────────────────────────────────────────┐
- │  Every tempo: set_weights (commit-reveal)                │
- └──────────────────────────────────────────────────────────┘
+while running:
+  1. Sync metagraph and compute physical_window from block height
+  2. Ensure persisted target_window (logical consensus window)
+  3. Build/load active-set snapshot for target_window:
+       active_set_window_N = commitments with commitment.block_number < window_start(N)
+       + inactivity filter at window_start reference
+  4. If target_window == physical_window and target not evaluated:
+       evaluate all active miners in snapshot (no hard deadline)
+  5. Once evaluation is complete:
+       submit full payload immediately (phase-decoupled from T_publish)
+  6. At each physical aggregation phase:
+       check quorum = submitted_stake(target_window, effective_spec) / total_validator_stake
+       if quorum > quorum_threshold (default 0.5):
+         aggregate and update winner, then jump target_window to physical_window
+       else:
+         keep target_window anchored and retry next aggregation phase
+  7. Every tempo:
+       always call set_weights; burn weights while waiting for quorum
 ```
+
+### Deterministic Active-Set Snapshot
+
+Each target window persists a frozen miner set as `active_set_window_{N}.json`:
+
+```
+active_set_window_N = { commitment | commitment.block_number < window_start(N) }
+```
+
+This makes evaluation inputs restart-safe and cross-validator consistent (within accepted polling-granularity overwrite races). Runtime-only filters such as validator permit and blacklist are still applied live, outside snapshot materialization.
 
 ### Evaluation Rate-Limiting
 
@@ -423,9 +412,18 @@ latest_consensus persists across epochs and restarts:
   If no consensus ever computed:         set_fallback_weights()
 ```
 
-**Timing rationale**: The 80/10/10 window split gives validators ~19.2 hours for evaluation (sufficient for multi-hour runs across many miners), ~2.4 hours for propagation (submission + wait, ample for IPFS propagation and on-chain commitment finality), and ~2.4 hours for aggregation before the next epoch starts.
+**Timing rationale**: The 80/10/10 split remains useful as a phase rhythm for evaluation, dissemination, and aggregation checkpoints. `T_publish` is no longer a hard submit deadline.
 
-**Partial submission**: If a validator has not finished evaluating all miners by T_publish, it submits results for the miners it has completed. The consensus aggregation handles partial coverage — a miner's consensus score is computed from whichever validators have data for that miner.
+**Submission rule**: Validators submit only after full target-window evaluation is complete (no partial payload at `T_publish`).
+
+**Quorum gate rule**: Aggregation is phase-aligned but stake-gated:
+
+```
+quorum_ratio = submitted_stake(target_window, effective_spec) / total_validator_stake
+aggregate iff quorum_ratio > quorum_threshold  # default 0.5
+```
+
+If quorum is not met, validators keep `target_window` unchanged, retry next physical aggregation phase, and set burn weights while waiting. Once quorum succeeds, `target_window` jumps to current `physical_window`.
 
 ### Payload Externalization + On-Chain Pointer Registration
 
@@ -452,7 +450,7 @@ Before aggregation, each validator filters incoming submissions:
 | 2 | Epoch number | Wrong epoch |
 | 3 | Stake threshold | Below minimum stake |
 | 4 | Data integrity | CAS hash mismatch |
-| 5 | Scoring version | Incompatible evaluation version |
+| 5 | spec_number target | Payload spec_number mismatches chain-derived target spec |
 | 6 | Zero-signal | All-zero scores when others report non-zero |
 
 Valid submissions → stake-weighted aggregation.
@@ -525,8 +523,9 @@ If winner exists and is not disqualified:
 | **CAS upload failure** | Validator skips submission for this epoch; continues using previous epoch's consensus for weight setting. Logged as degraded state. |
 | **CAS download failure** (aggregation) | Skip that validator's submission; aggregate from the remaining valid subset. Log failure statistics. |
 | **Zero valid submissions** | Previous epoch's consensus is retained for weight setting. If no consensus has ever been computed, fallback weights are set. |
-| **Late evaluator** (missed T_publish) | Do not submit this epoch. Still read other validators' consensus at T_aggregate and adopt their result for own weight setting. Allows low-stake validators to "free-ride" on high-stake evaluators. |
-| **Mid-epoch restart** | Compute elapsed epoch fraction. If > skip threshold (default 30%), skip to next epoch boundary. Otherwise resume evaluation. Consensus is loaded from persisted state. |
+| **Slow evaluator** | Continue evaluating without hard deadline and submit only after full target-window coverage. |
+| **Aggregation quorum miss** | Keep `target_window` anchored, retry at each future physical aggregation phase, and burn weights while waiting. |
+| **Mid-window restart** | Reload `active_set_window_{N}.json` and continue the same frozen target set. |
 
 ### Cross-Validator: YC3 On-Chain Consensus
 
@@ -614,13 +613,15 @@ Bootstrap:     top-3 qualified get 70/20/10
 | δ (score_delta) | 0.10 (10%) — Winner Protection threshold | Yes |
 | disqualify_stake_threshold | 0.50 (>50% stake majority to disqualify) | Yes |
 | eval_interval | 7200 blocks (~24h at 12s/block) | Yes |
-| T_publish (propagation window start) | 80% of epoch (block 5760) | Yes |
+| T_publish (propagation window start) | 80% of epoch (block 5760) | Yes (phase boundary only; no hard submit deadline) |
 | T_aggregate (aggregation window start) | 90% of epoch (block 6480) | Yes |
+| quorum_threshold | 0.50 (aggregate only when submitted stake share > threshold) | Yes |
 | min_validator_stake | minimum stake for consensus participation | Yes |
-| epoch_skip_threshold | 0.30 (30% of epoch elapsed) | Yes |
+| `target_window` catch-up policy | On success, jump directly to current `physical_window` | No (protocol behavior) |
 | Bootstrap threshold | 10 active miners | Yes |
 | `pack_first_seen` eviction | by-active with grace (drop entries inactive for `EVICTION_GRACE_WINDOWS` consecutive windows) | No |
 | `EVICTION_GRACE_WINDOWS` | 7 windows (~7 days; clock resets on any active reference) | No (validator-side constant) |
+| active-set snapshot persistence | `active_set_window_{N}.json` | Yes (`ACTIVE_SET_DIR`) |
 | inactivity_blocks | 14400 (~48h) | Yes |
 | yuma_version | 3 | Subnet owner (on-chain) |
 | liquid_alpha_enabled | True | Subnet owner (on-chain) |
@@ -632,6 +633,7 @@ Bootstrap:     top-3 qualified get 70/20/10
 
 | Version | Date | Summary |
 |---------|------|---------|
+| v5.2 | 2026-04-26 | Added deterministic window-start active-set snapshots (`active_set_window_{N}.json`) for restart-safe, cross-validator-stable evaluation sets. Replaced hard `T_publish` cutoff with submit-when-fully-done, introduced stake-quorum-gated aggregation (`quorum_threshold`), dual-window semantics (`physical_window` vs `target_window`), burn-while-waiting on quorum miss, and jump-to-current catch-up after delayed aggregation succeeds. |
 | v5.1 | 2026-04-24 | Replaced on-chain `block_number`-based first-mover priority + pairwise NCD pre-eval gate with a per-validator `pack_first_seen` ownership lock (no succession; by-active eviction with `EVICTION_GRACE_WINDOWS = 7` wall-clock-window grace period that resets on any active reference). Lock state persists to its own `pack_first_seen.json` (separate from `eval_state.json`) alongside the `pack_last_seen_window` tracker that drives grace eviction. Paraphrase defense delegated to Winner Protection's δ threshold. NCD library kept for tooling, no longer gates evaluation. |
 | v5.0 | 2026-04-21 | Refactored into season-agnostic core. Extracted scoring, pack schema, and evaluation details to EVALUATION_S1.md. Abstracted "cost" to "score" (direction defined per season). |
 | v4.2 | 2026-03-29 | Simplified winner selection: removed EMA, unified Winner Protection (δ=10%), stake-weighted majority qualification. |
@@ -653,6 +655,6 @@ Bootstrap:     top-3 qualified get 70/20/10
 
 ---
 
-**Version**: v5.1
+**Version**: v5.2
 
-**Date**: 2026-04-24
+**Date**: 2026-04-26

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1021,6 +1021,9 @@ class TestPerScenarioEvalState:
             validator._miner_log_dir = Path("/tmp/test_logs/miners")
             validator._miner_log_dir.mkdir(parents=True, exist_ok=True)
             validator._consensus_window = -1
+            validator._target_window = 0
+            validator._target_submit_done = False
+            validator._waiting_for_quorum = False
             validator.scenarios = {
                 "client_escalation": {"weight": 1.5},
                 "morning_brief": {"weight": 1.0},
@@ -1096,6 +1099,10 @@ class TestPerScenarioEvalState:
             # eval_state.json must NOT carry the legacy pack_first_seen key.
             saved = json.loads(v.config.eval_state_path.read_text())
             assert "pack_first_seen" not in saved
+            assert "quorum_wait_cycles" not in saved
+            assert "last_quorum_ratio" not in saved
+            assert "last_submitted_stake" not in saved
+            assert "last_total_validator_stake" not in saved
 
             v2 = self._make_validator()
             v2.config.eval_state_path = v.config.eval_state_path
@@ -2942,3 +2949,188 @@ class TestConsensusWeightSetting:
 
         assert qualified[10] is True
         assert qualified[20] is False
+
+
+class TestIssue1EpochSkipSemantics:
+    """Tests for dual-window orchestration and quorum-gated aggregation."""
+
+    def _make_validator(self):
+        v = TrajectoryValidator.__new__(TrajectoryValidator)
+        v.config = MagicMock()
+        v.config.full_cycle_on_startup = False
+        v.config.aggregate_when_start = False
+        v.config.weight_interval_blocks = 999999
+        v.config.pack_cache_max_size = 100
+        v.config.quorum_threshold = 0.5
+        v.config.netuid = 11
+        v.config.log_level = "WARNING"
+
+        v._window_config = WindowConfig(
+            window_length=100,
+            global_anchor=0,
+            publish_pct=0.8,
+            aggregate_pct=0.9,
+        )
+
+        v._last_eval_window = -1
+        v._consensus_window = -1
+        v._target_window = -1
+        v._target_submit_done = False
+        v._waiting_for_quorum = False
+        v._last_eval_at = None
+        v._last_eval_date = None
+        v.last_weight_block = 0
+
+        v._cycle_eval_id = None
+        v._cycle_log_offset = 0
+        v._cycle_log_block = 0
+        v._cycle_window_number = 0
+
+        v.wallet = MagicMock()
+        v.wallet.hotkey.ss58_address = "validator_hotkey"
+        v.subtensor = MagicMock()
+        v.metagraph = MagicMock()
+        v.metagraph.hotkeys = ["v1", "v2", "v3"]
+        v.metagraph.validator_permit = [True, True, True]
+        v.metagraph.stake = [60.0, 30.0, 10.0]
+        v.metagraph.n = 3
+
+        v.pack_fetcher = MagicMock()
+        v._sandbox_harness = MagicMock()
+        v._sandbox_harness.bench_image_hash = "bench"
+        v._sandbox_harness.harness_image_hash = "harness"
+        v._sandbox_harness.sandbox_version = "vtest"
+
+        v._replay_pending_uploads = AsyncMock()
+        v._run_evaluation_cycle = AsyncMock()
+        v._submit_consensus_payload = AsyncMock(return_value=True)
+        v._run_consensus_aggregation = AsyncMock()
+        v._set_winner_weights = AsyncMock()
+        v._set_burn_weights = AsyncMock()
+        v._set_fallback_weights = AsyncMock()
+        v._save_eval_state = MagicMock()
+        v._check_own_commitment_on_chain = MagicMock(return_value=False)
+        v._is_metagraph_healthy = MagicMock(return_value=True)
+        v._sync_metagraph = MagicMock(return_value=True)
+        v._fire_upload_cycle_logs = AsyncMock()
+        v._heartbeat_loop = AsyncMock()
+        return v
+
+    def test_compute_quorum_status_uses_effective_spec(self):
+        v = self._make_validator()
+        commitments = [
+            ValidatorConsensusCommitment(
+                protocol_version=2,
+                window_number=9,
+                content_address="cid-1",
+                validator_hotkey="v1",
+                block_number=100,
+                raw="r1",
+                spec_number=7,
+            ),
+            ValidatorConsensusCommitment(
+                protocol_version=2,
+                window_number=9,
+                content_address="cid-2",
+                validator_hotkey="v2",
+                block_number=101,
+                raw="r2",
+                spec_number=7,
+            ),
+            ValidatorConsensusCommitment(
+                protocol_version=2,
+                window_number=9,
+                content_address="cid-3",
+                validator_hotkey="v3",
+                block_number=102,
+                raw="r3",
+                spec_number=4,
+            ),
+        ]
+        with patch(
+            "trajectoryrl.base.validator.fetch_validator_consensus_commitments",
+            return_value=commitments,
+        ):
+            meets, ratio, submitted, total = v._compute_quorum_status(9)
+
+        assert meets is True
+        assert ratio == pytest.approx(0.9)
+        assert submitted == pytest.approx(90.0)
+        assert total == pytest.approx(100.0)
+
+    def test_submit_is_phase_decoupled(self):
+        v = self._make_validator()
+        aligned = 7986780 + ((100 - (7986780 % 100)) % 100)
+        block = aligned + 10  # evaluation phase
+        v.subtensor.get_current_block.side_effect = [block, block]
+        target = block // 100
+        v._target_window = target
+        v._last_eval_window = target
+        v._consensus_window = target - 1
+
+        def _close_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("trajectoryrl.base.validator.asyncio.create_task", side_effect=_close_task), \
+             patch("trajectoryrl.base.validator.asyncio.sleep", AsyncMock(side_effect=KeyboardInterrupt())):
+            asyncio.run(v.run())
+
+        assert v._submit_consensus_payload.await_count == 1
+        assert v._target_submit_done is True
+
+    def test_quorum_miss_keeps_target_and_sets_burn_weights(self):
+        v = self._make_validator()
+        aligned = 7986780 + ((100 - (7986780 % 100)) % 100)
+        block = aligned + 3 * 100 + 95  # physical window +3, aggregation phase
+        v.subtensor.get_current_block.side_effect = [block, block]
+        v._target_window = 0
+        v._last_eval_window = 0
+        v._target_submit_done = True
+        v._consensus_window = -1
+        v._compute_quorum_status = MagicMock(
+            return_value=(False, 0.49, 49.0, 100.0)
+        )
+
+        def _close_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("trajectoryrl.base.validator.asyncio.create_task", side_effect=_close_task), \
+             patch("trajectoryrl.base.validator.asyncio.sleep", AsyncMock(side_effect=KeyboardInterrupt())):
+            asyncio.run(v.run())
+
+        assert v._set_burn_weights.await_count >= 1
+        assert v._target_window == 0
+        assert v._waiting_for_quorum is True
+
+    def test_quorum_success_jumps_target_to_physical_window(self):
+        v = self._make_validator()
+        aligned = 7986780 + ((100 - (7986780 % 100)) % 100)
+        block = aligned + 3 * 100 + 95  # physical window +3, aggregation phase
+        v.subtensor.get_current_block.side_effect = [block, block]
+        v._target_window = 0
+        v._last_eval_window = 0
+        v._target_submit_done = True
+        v._consensus_window = -1
+        v._compute_quorum_status = MagicMock(
+            return_value=(True, 0.8, 80.0, 100.0)
+        )
+
+        async def _agg(window):
+            v._consensus_window = window.window_number
+
+        v._run_consensus_aggregation = AsyncMock(side_effect=_agg)
+        v._check_own_commitment_on_chain.return_value = False
+
+        def _close_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("trajectoryrl.base.validator.asyncio.create_task", side_effect=_close_task), \
+             patch("trajectoryrl.base.validator.asyncio.sleep", AsyncMock(side_effect=KeyboardInterrupt())):
+            asyncio.run(v.run())
+
+        assert v._run_consensus_aggregation.await_count == 1
+        assert v._target_window == (block // 100)
+        assert v._waiting_for_quorum is False

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -252,6 +252,14 @@ class TrajectoryValidator:
         # Which window's aggregation has completed (persisted in eval state).
         # Guards one-shot aggregation per window — survives restarts.
         self._consensus_window: int = -1
+        # Logical consensus anchor (Issue 1): the only window allowed to
+        # progress eval/submit/aggregation state. Decoupled from physical
+        # window derived from current block.
+        self._target_window: int = -1
+        # Submit idempotency marker for the target window.
+        self._target_submit_done: bool = False
+        # Sticky marker: quorum not yet met for current target window.
+        self._waiting_for_quorum: bool = False
 
         # Cycle log state — uploaded after each window phase completes
         self._cycle_eval_id: Optional[str] = None
@@ -433,6 +441,11 @@ class TrajectoryValidator:
             self._migrate_legacy_pack_first_seen(data)
 
             self._consensus_window = data.get("consensus_window", -1)
+            self._target_window = int(
+                data.get("target_window", self._consensus_window + 1)
+            )
+            self._target_submit_done = bool(data.get("target_submit_done", False))
+            self._waiting_for_quorum = bool(data.get("waiting_for_quorum", False))
 
             integrity_cache = data.get("integrity_cache")
             if integrity_cache:
@@ -505,6 +518,9 @@ class TrajectoryValidator:
             "last_eval_window": self._last_eval_window,
             "last_eval_window_per_hotkey": self.last_eval_window,
             "consensus_window": self._consensus_window,
+            "target_window": self._target_window,
+            "target_submit_done": self._target_submit_done,
+            "waiting_for_quorum": self._waiting_for_quorum,
             "integrity_cache": self.integrity_judge.dump_cache(),
         }
         try:
@@ -1144,15 +1160,128 @@ class TrajectoryValidator:
                 window.window_number,
             )
 
-    def _should_start_evaluation(self, current_block: int) -> bool:
-        """Return True if a new evaluation cycle should start.
+    def _ensure_target_window(self, physical_window: EvaluationWindow) -> int:
+        """Initialize target window from persisted state or physical window."""
+        if self._target_window < 0:
+            self._target_window = max(self._consensus_window + 1, 0)
+            if self._target_window < physical_window.window_number:
+                self._target_window = physical_window.window_number
+            self._target_submit_done = False
+            self._save_eval_state()
+        return self._target_window
 
-        Block-based: fires once per window during the evaluation phase.
-        """
-        window = compute_window(current_block, self._window_config)
-        if window.phase != WindowPhase.EVALUATION:
+    def _should_start_target_evaluation(
+        self,
+        physical_window: EvaluationWindow,
+        target_window: int,
+    ) -> bool:
+        """Return True if target window evaluation should start now."""
+        if target_window != physical_window.window_number:
             return False
-        return window.window_number > self._last_eval_window
+        return target_window > self._last_eval_window
+
+    def _make_window_view(
+        self,
+        physical_window: EvaluationWindow,
+        window_number: int,
+    ) -> EvaluationWindow:
+        """Build an EvaluationWindow view for a logical target window."""
+        window_start = (
+            self._window_config.global_anchor
+            + window_number * self._window_config.window_length
+        )
+        return EvaluationWindow(
+            window_number=window_number,
+            window_start=window_start,
+            block_offset=physical_window.block_offset,
+            phase=physical_window.phase,
+            blocks_into_phase=physical_window.blocks_into_phase,
+            blocks_remaining_in_phase=physical_window.blocks_remaining_in_phase,
+            publish_offset=self._window_config.publish_block,
+            aggregate_offset=self._window_config.aggregate_block,
+        )
+
+    def _compute_quorum_status(
+        self, target_window: int
+    ) -> Tuple[bool, float, float, float]:
+        """Return quorum verdict and stake metrics for target window."""
+        chain_commitments = fetch_validator_consensus_commitments(
+            self.subtensor, self.config.netuid, self.metagraph,
+        )
+        # Total validator stake in subnet (permit + positive stake).
+        total_validator_stake = 0.0
+        for uid in range(len(self.metagraph.hotkeys)):
+            permitted = (
+                uid < len(self.metagraph.validator_permit)
+                and self.metagraph.validator_permit[uid]
+            )
+            if not permitted:
+                continue
+            stake = float(self.metagraph.stake[uid])
+            if stake > 0:
+                total_validator_stake += stake
+
+        if total_validator_stake <= 0:
+            return False, 0.0, 0.0, 0.0
+
+        hk_to_stake: Dict[str, float] = {}
+        for uid in range(len(self.metagraph.hotkeys)):
+            hotkey = self.metagraph.hotkeys[uid]
+            stake = float(self.metagraph.stake[uid])
+            permitted = (
+                uid < len(self.metagraph.validator_permit)
+                and self.metagraph.validator_permit[uid]
+            )
+            if permitted and stake > 0:
+                hk_to_stake[hotkey] = stake
+
+        target_commitments: List[ValidatorConsensusCommitment] = []
+        for vc in chain_commitments:
+            if vc.window_number == target_window:
+                target_commitments.append(vc)
+
+        stake_by_spec: Dict[int, float] = {}
+        seen_for_spec: set = set()
+        for vc in target_commitments:
+            if vc.validator_hotkey in seen_for_spec:
+                continue
+            stake = hk_to_stake.get(vc.validator_hotkey, 0.0)
+            if stake <= 0:
+                continue
+            seen_for_spec.add(vc.validator_hotkey)
+            stake_by_spec[vc.spec_number] = stake_by_spec.get(vc.spec_number, 0.0) + stake
+
+        effective_spec = _spec_number()
+        spec_total_stake = sum(stake_by_spec.values())
+        if spec_total_stake > 0 and stake_by_spec:
+            dominant_spec = max(stake_by_spec, key=lambda s: stake_by_spec[s])
+            dominant_share = stake_by_spec[dominant_spec] / spec_total_stake
+            if dominant_share > 0.5:
+                effective_spec = dominant_spec
+
+        submitted_stake = 0.0
+        seen_hotkeys = set()
+        for vc in target_commitments:
+            if vc.spec_number != effective_spec:
+                continue
+            if vc.validator_hotkey in seen_hotkeys:
+                continue
+            stake = hk_to_stake.get(vc.validator_hotkey, 0.0)
+            if stake <= 0:
+                continue
+            seen_hotkeys.add(vc.validator_hotkey)
+            submitted_stake += stake
+
+        ratio = submitted_stake / total_validator_stake
+        meets = ratio > float(getattr(self.config, "quorum_threshold", 0.5))
+        return meets, ratio, submitted_stake, total_validator_stake
+
+    async def _set_burn_weights(self, reason: str) -> None:
+        """Always set burn weights (no copy-owner fallback)."""
+        uids, weights = self._fallback_to_owner()
+        await self._do_set_weights(
+            uids, weights, label=f"[burn: {reason}] ",
+        )
 
     async def run(self):
         """Main validator loop with block-based window phases.
@@ -1241,21 +1370,46 @@ class TrajectoryValidator:
                     await asyncio.sleep(300)
                     continue
 
-                # --- Window phase: evaluation ---
-                if self._should_start_evaluation(current_block):
+                target_window = self._ensure_target_window(window)
+                if target_window > window.window_number:
+                    logger.warning(
+                        "Target window %d is ahead of physical window %d; "
+                        "clamping to physical window",
+                        target_window, window.window_number,
+                    )
+                    self._target_window = window.window_number
+                    self._target_submit_done = self._check_own_commitment_on_chain(
+                        self._target_window
+                    )
+                    self._save_eval_state()
+                    target_window = self._target_window
+
+                if target_window <= self._consensus_window:
+                    self._target_window = self._consensus_window + 1
+                    self._target_submit_done = self._check_own_commitment_on_chain(
+                        self._target_window
+                    )
+                    self._save_eval_state()
+                    target_window = self._target_window
+
+                target_window_view = self._make_window_view(window, target_window)
+
+                # --- Target window: evaluation ---
+                if self._should_start_target_evaluation(window, target_window):
                     logger.info("=" * 60)
                     logger.info(
-                        f"Evaluation window {window.window_number} at block "
+                        f"Evaluation target_window={target_window} at block "
                         f"{current_block} (phase={window.phase.value}, "
                         f"offset={window.block_offset}/{self._window_config.window_length})"
                     )
                     logger.info("=" * 60)
 
-                    await self._run_evaluation_cycle(current_block, window.window_number)
+                    await self._run_evaluation_cycle(current_block, target_window)
                     self._last_eval_at = int(time.time())
-                    self._last_eval_window = window.window_number
+                    self._last_eval_window = target_window
                     self._last_eval_date = datetime.datetime.utcnow().date()
                     self.last_weight_block = self.subtensor.get_current_block()
+                    self._target_submit_done = False
 
                     self.pack_fetcher.cleanup_cache(
                         self.config.pack_cache_max_size
@@ -1272,54 +1426,105 @@ class TrajectoryValidator:
                             )
                         )
 
-                # --- Propagation window: submit results (idempotent — checks on-chain) ---
-                if (window.phase == WindowPhase.PROPAGATION
-                        and not self._check_own_commitment_on_chain(window.window_number)):
+                # --- Submit when target eval is fully done (phase-decoupled) ---
+                if (
+                    self._last_eval_window >= target_window
+                    and not self._target_submit_done
+                ):
+                    if self._check_own_commitment_on_chain(target_window):
+                        self._target_submit_done = True
+                        self._save_eval_state()
+                    else:
+                        logger.info(
+                            "Target window %d: eval complete, submitting payload at block %d",
+                            target_window, current_block,
+                        )
+                        ok = await self._submit_consensus_payload(target_window_view)
+                        if ok:
+                            self._target_submit_done = True
+                            self._save_eval_state()
+                        else:
+                            logger.warning(
+                                "Target window %d: submission attempt failed; "
+                                "will retry next loop iteration",
+                                target_window,
+                            )
+
+                        if self._cycle_eval_id is not None:
+                            asyncio.ensure_future(
+                                self._fire_upload_cycle_logs(
+                                    self._cycle_eval_id,
+                                    self._cycle_log_offset,
+                                    self._cycle_log_block,
+                                    self._cycle_window_number,
+                                )
+                            )
+
+                # --- Aggregation phase: quorum gate on target window ---
+                if (
+                    window.phase == WindowPhase.AGGREGATION
+                    and self._consensus_window < target_window
+                ):
                     logger.info(
-                        "Window %d: submitting evaluation results at block %d",
-                        window.window_number, current_block,
+                        "Physical window %d in aggregation; checking quorum for target window %d",
+                        window.window_number, target_window,
                     )
-                    ok = await self._submit_consensus_payload(window)
-                    if not ok:
+                    meets, ratio, submitted_stake, total_stake = self._compute_quorum_status(
+                        target_window
+                    )
+
+                    if not meets:
+                        self._waiting_for_quorum = True
                         logger.warning(
-                            "Window %d: submission attempt failed, "
-                            "will retry next loop iteration",
-                            window.window_number,
+                            "Target window %d quorum miss: submitted_stake=%.4f total_validator_stake=%.4f "
+                            "ratio=%.4f threshold=%.4f — setting burn weights",
+                            target_window,
+                            submitted_stake,
+                            total_stake,
+                            ratio,
+                            float(getattr(self.config, "quorum_threshold", 0.5)),
                         )
-
-                    if self._cycle_eval_id is not None:
-                        asyncio.ensure_future(
-                            self._fire_upload_cycle_logs(
-                                self._cycle_eval_id,
-                                self._cycle_log_offset,
-                                self._cycle_log_block,
-                                self._cycle_window_number,
+                        await self._set_burn_weights(
+                            reason=(
+                                f"quorum-miss target={target_window} "
+                                f"ratio={ratio:.4f}"
                             )
                         )
-
-                # --- Window phase: aggregation (idempotent — checks _consensus_window) ---
-                if (window.phase == WindowPhase.AGGREGATION
-                        and self._consensus_window != window.window_number):
-                    logger.info(
-                        f"Window {window.window_number}: T_aggregate reached "
-                        f"at block {current_block}, running consensus aggregation"
-                    )
-                    await self._run_consensus_aggregation(window)
-
-                    if self._consensus_window == window.window_number:
-                        await self._set_winner_weights()
                         self.last_weight_block = current_block
-
-                    if self._cycle_eval_id is not None:
-                        asyncio.ensure_future(
-                            self._fire_upload_cycle_logs(
-                                self._cycle_eval_id,
-                                self._cycle_log_offset,
-                                self._cycle_log_block,
-                                self._cycle_window_number,
-                            )
+                        self._save_eval_state()
+                    else:
+                        logger.info(
+                            "Target window %d quorum met: submitted_stake=%.4f total_validator_stake=%.4f "
+                            "ratio=%.4f — running consensus aggregation",
+                            target_window, submitted_stake, total_stake, ratio,
                         )
-                        self._cycle_eval_id = None
+                        await self._run_consensus_aggregation(target_window_view)
+
+                        if self._consensus_window == target_window:
+                            await self._set_winner_weights()
+                            self.last_weight_block = current_block
+                            self._waiting_for_quorum = False
+                            self._target_window = window.window_number
+                            self._target_submit_done = self._check_own_commitment_on_chain(
+                                self._target_window
+                            )
+                            self._save_eval_state()
+                        else:
+                            logger.warning(
+                                "Target window %d aggregation did not produce consensus result",
+                                target_window,
+                            )
+
+                        if self._cycle_eval_id is not None:
+                            asyncio.ensure_future(
+                                self._fire_upload_cycle_logs(
+                                    self._cycle_eval_id,
+                                    self._cycle_log_offset,
+                                    self._cycle_log_block,
+                                    self._cycle_window_number,
+                                )
+                            )
+                            self._cycle_eval_id = None
 
                 # --- Tempo cadence: re-assert winner weights ---
                 current_block = self.subtensor.get_current_block()
@@ -1330,7 +1535,14 @@ class TrajectoryValidator:
                         f"({blocks_since_weights} blocks since last, "
                         f"window={window.window_number} phase={window.phase.value})"
                     )
-                    await self._set_winner_weights()
+                    if self._waiting_for_quorum and self._consensus_window < self._target_window:
+                        await self._set_burn_weights(
+                            reason=(
+                                f"tempo-refresh waiting target={self._target_window}"
+                            )
+                        )
+                    else:
+                        await self._set_winner_weights()
                     self.last_weight_block = current_block
 
                 await asyncio.sleep(300)

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -104,6 +104,7 @@ class ValidatorConfig:
     )
     consensus_api_url: str = "https://trajrl.com"
     min_validator_stake: float = 10000.0  # minimum stake weight (α) for consensus participation
+    quorum_threshold: float = 0.5  # aggregate only when submitted stake share > threshold
 
     # Fraction of zero scores above which a submission is treated as a
     # free-rider / near-zero-signal payload and dropped from consensus.
@@ -260,6 +261,7 @@ class ValidatorConfig:
                 if gw.strip()
             ],
             consensus_api_url=os.getenv("CONSENSUS_API_URL", "https://trajrl.com"),
+            quorum_threshold=float(os.getenv("QUORUM_THRESHOLD", "0.5")),
             # --- trajrl-bench ---
             # IMAGE_CHANNEL is the only env-driven knob: it selects the tag
             # for both sandbox and harness images. Programmatic callers can


### PR DESCRIPTION
## Summary
- switch validator orchestration to target-window semantics: submit when target eval is complete, run aggregation only behind a stake quorum gate, and burn weights while waiting on quorum
- persist only protocol-essential restart state (`target_window`, `target_submit_done`, `waiting_for_quorum`) and remove observability-only quorum counters/ratios from class/persistence state
- update incentive mechanism docs to v5.2 to describe no-hard-deadline submit, deterministic active-set snapshots, quorum-gated aggregation, and jump-to-physical catch-up

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_validator.py -k "eval_state_persistence_roundtrip or Issue1EpochSkipSemantics"`
- [x] optional: run full `tests/test_validator.py`

Made with [Cursor](https://cursor.com)