### PR TITLE
fix: gate quorum check on _target_submit_done

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3134,3 +3134,36 @@ class TestIssue1EpochSkipSemantics:
         assert v._run_consensus_aggregation.await_count == 1
         assert v._target_window == (block // 100)
         assert v._waiting_for_quorum is False
+
+    def test_quorum_gate_skipped_when_target_not_yet_submitted(self):
+        # After a successful aggregation in window N's agg phase, target
+        # bumps to N+1 on the next iteration but the validator hasn't
+        # evaluated/submitted for N+1 yet. The agg gate must NOT fire on
+        # that freshly-bumped target — otherwise it trivially misses
+        # quorum (zero / tiny stake at N+1) and latches
+        # _waiting_for_quorum=True, which then poisons the next eval phase
+        # via the main-loop tempo refresh's burn branch.
+        v = self._make_validator()
+        aligned = 7986780 + ((100 - (7986780 % 100)) % 100)
+        block = aligned + 3 * 100 + 95  # physical window +3, aggregation phase
+        v.subtensor.get_current_block.side_effect = [block, block]
+        v._target_window = (block // 100) + 1   # bumped past physical
+        v._last_eval_window = block // 100      # evaluated only the prior window
+        v._consensus_window = block // 100      # just succeeded on the prior window
+        v._target_submit_done = False           # ← key: not submitted for the new target
+
+        v._compute_quorum_status = MagicMock(
+            return_value=(False, 0.0, 0.0, 100.0)
+        )
+
+        def _close_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("trajectoryrl.base.validator.asyncio.create_task", side_effect=_close_task), \
+             patch("trajectoryrl.base.validator.asyncio.sleep", AsyncMock(side_effect=KeyboardInterrupt())):
+            asyncio.run(v.run())
+
+        v._compute_quorum_status.assert_not_called()
+        assert v._set_burn_weights.await_count == 0
+        assert v._waiting_for_quorum is False

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -1461,9 +1461,16 @@ class TrajectoryValidator:
                             )
 
                 # --- Aggregation phase: quorum gate on target window ---
+                # Only assess quorum on a target this validator has actually
+                # submitted for. A freshly-bumped target (e.g. consensus+1
+                # right after a successful aggregation) has no own commitment
+                # yet; checking quorum on it would trivially miss and latch
+                # _waiting_for_quorum=True, poisoning the upcoming eval phase
+                # via the main-loop tempo refresh's burn branch.
                 if (
                     window.phase == WindowPhase.AGGREGATION
                     and self._consensus_window < target_window
+                    and self._target_submit_done
                 ):
                     logger.info(
                         "Physical window %d in aggregation; checking quorum for target window %d",


### PR DESCRIPTION
# Fix: gate quorum check on `_target_submit_done`

## What's wrong

After a successful aggregation on window N, the validator **immediately burns weights** within the *next* eval phase — even though it just elected a real winner and is normally publishing N+1's payload.

```
02:05:33  Eval cycle complete (target=1119)
02:05:50  [winner=5CAHndMU UID 47] set_weights OK — uids=[47, 74]   ← winner weights
02:06:41  Window 1119: consensus pointer written on-chain
   ~72m   [burn: tempo-refresh waiting target=1119] set_weights OK — uids=[74]   ← pure burn
```

## Why

Inside one ~5-min loop iteration during N's aggregation phase:

1. Window N aggregation **succeeds** → `_consensus_window=N`, `_waiting_for_quorum=False`.
2. Next iteration, `_ensure_target_window` bumps target: `_target_window=N+1`, `_target_submit_done=False` (we haven't evaluated N+1 yet).
3. The aggregation gate at [validator.py:1463-1467](trajectoryrl/base/validator.py#L1463-L1467) fires anyway:

   ```python
   if (window.phase == WindowPhase.AGGREGATION
           and self._consensus_window < target_window):    # N < N+1 ✓
   ```

4. `_compute_quorum_status(N+1)` runs against a chain that has **zero** commitments at N+1 → ratio≈0 → miss → **`_waiting_for_quorum=True` latches**.

`_set_winner_weights` doesn't consult the flag, so the post-eval re-assert at 02:05:50 still writes `[47, 74]`. But the **main-loop tempo refresh** does check it — and ~72 min later flips to pure burn:

```python
if self._waiting_for_quorum and self._consensus_window < self._target_window:
    await self._set_burn_weights(...)
```

The flag stays True forever for low-stake validators that race ahead of the fleet (they're alone on N+1, quorum never forms).

## Fix

Skip the gate on a target the validator hasn't submitted for. One added condition:

```python
if (window.phase == WindowPhase.AGGREGATION
        and self._consensus_window < target_window
        and self._target_submit_done):                  # ← new
    meets, ratio, ... = self._compute_quorum_status(target_window)
```

A target with no own commitment trivially misses quorum — that "miss" is a measurement artifact, not a real signal. Once the validator finishes evaluating N+1 and submits, `_target_submit_done` flips True and the gate re-engages with meaningful inputs.

## Test

`test_quorum_gate_skipped_when_target_not_yet_submitted` reproduces the bumped-target case and asserts:

- `_compute_quorum_status` is **not** called.
- `_set_burn_weights` is **not** invoked.
- `_waiting_for_quorum` stays False.

The three existing quorum tests (success, miss, effective-spec) all pass unchanged — they exercise the post-submission case the gate is supposed to handle.

## Scope

One condition added to one `if`. No semantic change to the success / real-miss paths. Does not address the deeper fleet-fragmentation issue (low-stake validator alone on N+1 still legitimately burns once it submits) — that's a separate problem.
