### PR TITLE
fix(validator): heal legacy waiting_for_quorum false-positive on load

### DIFF
--- a/docs/INCENTIVE_MECHANISM.md
+++ b/docs/INCENTIVE_MECHANISM.md
@@ -193,12 +193,16 @@ while running:
        evaluate all active miners in snapshot (no hard deadline)
   5. Once evaluation is complete:
        submit full payload immediately (phase-decoupled from T_publish)
-  6. At each physical aggregation phase:
+  6. At each physical aggregation phase, once own target_window commitment is on-chain:
        check quorum = submitted_stake(target_window, effective_spec) / total_validator_stake
        if quorum > quorum_threshold (default 0.5):
          aggregate and update winner, then jump target_window to physical_window
        else:
          keep target_window anchored and retry next aggregation phase
+     (If the validator has not yet submitted for target_window, the quorum
+      check is skipped — a freshly-bumped target where only a tiny fraction
+      of validators have submitted would otherwise trivially miss and latch
+      the burn-while-waiting state.)
   7. Every tempo:
        always call set_weights; burn weights while waiting for quorum
 ```

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1117,6 +1117,74 @@ class TestPerScenarioEvalState:
             v.config.eval_state_path.unlink(missing_ok=True)
             v.config.pack_first_seen_path.unlink(missing_ok=True)
 
+    def test_load_heals_legacy_waiting_for_quorum_false_positive(self):
+        """Pre-PR197 binaries could persist waiting_for_quorum=True with
+        target_submit_done=False. Loading such a file must clear the flag
+        so the main loop does not keep burning on a phantom quorum wait.
+        """
+        v = self._make_validator()
+        v._waiting_for_quorum = True
+        v._target_submit_done = False
+        v._target_window = 42
+        v._consensus_window = 41
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            v.config.eval_state_path = Path(f.name)
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            v.config.pack_first_seen_path = Path(f.name)
+
+        try:
+            v._save_eval_state()
+
+            poisoned = json.loads(v.config.eval_state_path.read_text())
+            assert poisoned["waiting_for_quorum"] is True
+            assert poisoned["target_submit_done"] is False
+
+            v2 = self._make_validator()
+            v2.config.eval_state_path = v.config.eval_state_path
+            v2.config.pack_first_seen_path = v.config.pack_first_seen_path
+            v2._load_eval_state()
+
+            assert v2._waiting_for_quorum is False
+            assert v2._target_submit_done is False
+            assert v2._target_window == 42
+            assert v2._consensus_window == 41
+
+            healed = json.loads(v2.config.eval_state_path.read_text())
+            assert healed["waiting_for_quorum"] is False
+        finally:
+            v.config.eval_state_path.unlink(missing_ok=True)
+            v.config.pack_first_seen_path.unlink(missing_ok=True)
+
+    def test_load_preserves_legitimate_waiting_for_quorum(self):
+        """Waiting_for_quorum=True with target_submit_done=True is a real
+        post-submission wait and must NOT be cleared by the legacy heal.
+        """
+        v = self._make_validator()
+        v._waiting_for_quorum = True
+        v._target_submit_done = True
+        v._target_window = 42
+        v._consensus_window = 41
+
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            v.config.eval_state_path = Path(f.name)
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            v.config.pack_first_seen_path = Path(f.name)
+
+        try:
+            v._save_eval_state()
+
+            v2 = self._make_validator()
+            v2.config.eval_state_path = v.config.eval_state_path
+            v2.config.pack_first_seen_path = v.config.pack_first_seen_path
+            v2._load_eval_state()
+
+            assert v2._waiting_for_quorum is True
+            assert v2._target_submit_done is True
+        finally:
+            v.config.eval_state_path.unlink(missing_ok=True)
+            v.config.pack_first_seen_path.unlink(missing_ok=True)
+
     def test_pack_first_seen_persistence_roundtrip(self):
         """pack_first_seen + pack_last_seen_window are persisted together."""
         v = self._make_validator()

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -447,6 +447,23 @@ class TrajectoryValidator:
             self._target_submit_done = bool(data.get("target_submit_done", False))
             self._waiting_for_quorum = bool(data.get("waiting_for_quorum", False))
 
+            # Heal legacy false-positive from pre-PR197 validator binaries:
+            # the old aggregation-phase gate could latch _waiting_for_quorum
+            # on a freshly-bumped target where the validator had not yet
+            # submitted. That combination is unreachable after the fix, so
+            # treat it as a corrupt carryover and clear it — otherwise the
+            # main-loop tempo refresh would keep burning until the next
+            # quorum success flips the flag back.
+            if self._waiting_for_quorum and not self._target_submit_done:
+                logger.warning(
+                    "Eval state heal: clearing waiting_for_quorum on "
+                    "target_window=%d with target_submit_done=False "
+                    "(legacy pre-PR197 false-positive)",
+                    self._target_window,
+                )
+                self._waiting_for_quorum = False
+                self._save_eval_state()
+
             integrity_cache = data.get("integrity_cache")
             if integrity_cache:
                 self.integrity_judge.load_cache(integrity_cache)


### PR DESCRIPTION
## Context

PR #197 closed the aggregation-phase gate that could latch `_waiting_for_quorum=True` on a freshly-bumped target where the validator had not yet submitted. But it only prevents the bad state from being **written** going forward — it does not **clear** validators whose on-disk eval state is already stuck in that shape. Those validators will keep burning every tempo until the next successful aggregation happens to flip the flag back.

## What this changes

- **Self-heal on load** (`trajectoryrl/base/validator.py`): in `_load_eval_state`, if the loaded state has `waiting_for_quorum=True` and `target_submit_done=False`, log a warning, clear `_waiting_for_quorum` to `False`, and immediately persist. Combined with PR #197's gate, that combination is unreachable in the new code, so seeing it on disk always means a legacy carryover.
- **Tests** (`tests/test_validator.py`):
  - `test_load_heals_legacy_waiting_for_quorum_false_positive` — poisoned state is cleaned on load and the cleaned state is re-saved.
  - `test_load_preserves_legitimate_waiting_for_quorum` — a legitimate post-submission wait (`waiting_for_quorum=True && target_submit_done=True`) is **not** cleared.
- **Docs** (`docs/INCENTIVE_MECHANISM.md`): mirror the two prose additions already merged into the canonical TrajOS doc — clarify that the aggregation-phase quorum check runs *once own target_window commitment is on-chain*, and explain why it is skipped otherwise.

## Timing / how operators apply it

Heal runs in `_load_eval_state` → it triggers on every validator start. Because PR #197 is already on `main`, the heal is stable: once cleared, the flag won't be re-latched by the main loop. Practical consequence:

- Any affected validator → just restart on the new binary. No need to wait for a specific epoch / tempo / aggregation-phase boundary.
- Without this PR, validators stuck with the poisoned state would continue burning until the next real aggregation succeeds (~ up to one epoch).

## Test plan

- [ ] CI: `pytest tests/test_validator.py` (new heal tests)
- [ ] CI: full suite still green on `main + this PR`
- [ ] Sanity: restart a validator that has `waiting_for_quorum=True && target_submit_done=False` on disk and confirm the warning line appears and the flag is cleared in the persisted state file.

## Related

- Builds on #197 (gates the write)
- Canonical doc already updated in TrajOS (`TrajectoryRL/INCENTIVE_MECHANISM.md` @ `abaa766`); this PR only mirrors it into the project repo per the docs-sync workflow.

Made with [Cursor](https://cursor.com)