### PR TITLE
fix: clear _waiting_for_quorum when target aggregation is in the future

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3167,3 +3167,34 @@ class TestIssue1EpochSkipSemantics:
         v._compute_quorum_status.assert_not_called()
         assert v._set_burn_weights.await_count == 0
         assert v._waiting_for_quorum is False
+
+    def test_waiting_for_quorum_cleared_when_target_agg_in_future(self):
+        # A validator that boots with _waiting_for_quorum=True latched in
+        # persisted state (e.g. from a pre-fix run, or from an earlier
+        # iteration that spuriously latched) must clear the flag once the
+        # loop notices target_window's aggregation phase hasn't started
+        # yet on the chain timeline. Otherwise the tempo refresh keeps
+        # burning through eval phases even though there is no real quorum
+        # question to be waiting on.
+        v = self._make_validator()
+        aligned = 7986780 + ((100 - (7986780 % 100)) % 100)
+        # Place current_block in target's evaluation phase (well before
+        # target's aggregation start at offset 90).
+        current_block = aligned + 3 * 100 + 5
+        v.subtensor.get_current_block.side_effect = [current_block, current_block]
+        v._target_window = current_block // 100   # target == physical
+        v._last_eval_window = v._target_window
+        v._target_submit_done = False
+        v._consensus_window = v._target_window - 1
+        v._waiting_for_quorum = True   # ← stale latched flag
+
+        def _close_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("trajectoryrl.base.validator.asyncio.create_task", side_effect=_close_task), \
+             patch("trajectoryrl.base.validator.asyncio.sleep", AsyncMock(side_effect=KeyboardInterrupt())):
+            asyncio.run(v.run())
+
+        assert v._waiting_for_quorum is False
+        assert v._set_burn_weights.await_count == 0

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -1392,6 +1392,31 @@ class TrajectoryValidator:
                     self._save_eval_state()
                     target_window = self._target_window
 
+                # Clear stale waiting flag when target_window's aggregation
+                # phase hasn't started yet on the chain timeline. A freshly
+                # bumped target (or a stale latched flag carried over from a
+                # previous run / spec bump) cannot legitimately be "waiting
+                # for quorum" before the round it points at has even reached
+                # its aggregation block. Without this reset, the main-loop
+                # tempo refresh's burn branch fires through the upcoming
+                # eval phase even though aggregation isn't due yet.
+                target_agg_start_block = (
+                    self._window_config.global_anchor
+                    + target_window * self._window_config.window_length
+                    + self._window_config.aggregate_block
+                )
+                if (
+                    current_block < target_agg_start_block
+                    and self._waiting_for_quorum
+                ):
+                    logger.info(
+                        "Clearing _waiting_for_quorum: target_window=%d "
+                        "aggregation starts at block %d, current_block=%d",
+                        target_window, target_agg_start_block, current_block,
+                    )
+                    self._waiting_for_quorum = False
+                    self._save_eval_state()
+
                 target_window_view = self._make_window_view(window, target_window)
 
                 # --- Target window: evaluation ---


### PR DESCRIPTION
After the bump path advances target_window, reset the latched _waiting_for_quorum flag if the chain hasn't reached target's aggregation start block yet. Otherwise a stale latch (carried from a prior run or an earlier spurious set) burns through the upcoming eval phase via the main-loop tempo refresh.