### PR TITLE
feat(s1): capture Hermes session JSONL per episode and include in upload

### DIFF
--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -331,12 +331,25 @@ _HERMES_UID = 10000
 # Pre-entrypoint wrapper for Hermes containers: executed as root before
 # the image's own entrypoint gosu-drops to the hermes user. Chowns
 # /workspace so the judge can write /workspace/evaluation.json (Docker
-# creates working_dir= paths as root:root). Then exec's the image's
-# original entrypoint with the original command args intact.
+# creates working_dir= paths as root:root), then runs the image's
+# original entrypoint with the original command args.
+#
+# We deliberately do NOT `exec` the entrypoint: after `hermes chat`
+# returns, we run `hermes sessions export /workspace/turns.jsonl` to
+# capture the structured per-turn session data (every user/assistant
+# message + tool call + tool result + token counts + end_reason),
+# which the bench reads back via get_archive in _read_container_text.
+# Independent of stdout, so it survives --quiet collapsing the docker
+# logs to header + final-message only. The export is best-effort —
+# its failure must not mask the chat exit code, since downstream
+# test scoring and judging depend on chat_rc.
 _HERMES_PREENTRY = (
     "chown -R hermes:hermes /workspace 2>/dev/null; "
     "chmod 0755 /workspace 2>/dev/null; "
-    "exec /opt/hermes/docker/entrypoint.sh \"$@\""
+    "/opt/hermes/docker/entrypoint.sh \"$@\"; "
+    "chat_rc=$?; "
+    "hermes sessions export /workspace/turns.jsonl 2>/tmp/turns_export.err || true; "
+    "exit \"$chat_rc\""
 )
 _HERMES_ENTRYPOINT = ["/bin/sh", "-c", _HERMES_PREENTRY, "--"]
 

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -62,8 +62,15 @@ class _EpisodeResult:
     episode_index: int
     quality: float = 0.0
     tool_calls: int = 0
-    transcript: str = ""                      # Testee agent's Hermes log
-    judge_transcript: str = ""                # Judge agent's Hermes log
+    transcript: str = ""                      # Testee agent's Hermes log (--quiet stdout)
+    judge_transcript: str = ""                # Judge agent's Hermes log (--quiet stdout)
+    # Structured per-turn JSONL exported by hermes-preentry.sh after
+    # `hermes chat` exits. One JSON object per session containing the
+    # full message history (user/assistant/tool calls/tool results) plus
+    # token counts and end_reason. Independent of stdout — populated
+    # even when --quiet collapses transcript.txt to header-only.
+    turns_log: str = ""                       # Testee /workspace/turns.jsonl
+    judge_turns_log: str = ""                 # Judge /workspace/turns.jsonl
     mock_state: dict = field(default_factory=dict)
     timed_out: bool = False
     error: str | None = None
@@ -155,8 +162,10 @@ class SandboxEvaluationResult:
               metadata.json               # final_score, delta, scenario, etc.
               episodes/
                 episode_0/
-                  testee_transcript.txt
-                  judge_transcript.txt
+                  testee_transcript.txt   # Hermes stdout (--quiet'd)
+                  judge_transcript.txt    # Hermes stdout (--quiet'd)
+                  turns.jsonl             # full per-turn testee session (when image supports export)
+                  judge_turns.jsonl       # full per-turn judge session
                   evaluation.json
                   episode.json            # fixtures + instruction
                 episode_1/ ...
@@ -191,6 +200,14 @@ class SandboxEvaluationResult:
             (ep_dir / "testee_transcript.txt").write_text(ep.transcript or "")
             (ep_dir / "judge_transcript.txt").write_text(
                 ep.judge_transcript or "")
+            # Structured per-turn JSONL — full Hermes session export
+            # (every user/assistant message + tool call + tool result),
+            # populated by hermes-preentry.sh when the harness/judge
+            # image supports it. Skipped silently on older images.
+            if ep.turns_log:
+                (ep_dir / "turns.jsonl").write_text(ep.turns_log)
+            if ep.judge_turns_log:
+                (ep_dir / "judge_turns.jsonl").write_text(ep.judge_turns_log)
             (ep_dir / "evaluation.json").write_text(
                 json.dumps(ep.judge_result, indent=2, default=str))
             (ep_dir / "episode.json").write_text(
@@ -202,6 +219,36 @@ class SandboxEvaluationResult:
 # ---------------------------------------------------------------------------
 # Docker helpers
 # ---------------------------------------------------------------------------
+
+def _read_container_text(container, path: str) -> str:
+    """Read a single text file from a container via get_archive.
+
+    Returns "" on any failure (file missing, container gone, decode error).
+    Used to pull /workspace/turns.jsonl — the structured Hermes session
+    export the harness preentry writes after `hermes chat` exits.
+    """
+    try:
+        archive, _ = container.get_archive(path)
+    except docker.errors.NotFound:
+        return ""
+    except Exception:
+        return ""
+    try:
+        buf = io.BytesIO()
+        for chunk in archive:
+            buf.write(chunk)
+        buf.seek(0)
+        with tarfile.open(fileobj=buf, mode="r") as tar:
+            members = tar.getmembers()
+            if not members:
+                return ""
+            f = tar.extractfile(members[0])
+            if f is None:
+                return ""
+            return f.read().decode("utf-8", errors="replace")
+    except Exception:
+        return ""
+
 
 def _docker_run_json(client: docker.DockerClient, image: str,
                      command: list[str], environment: dict | None = None,
@@ -772,6 +819,13 @@ class TrajectorySandboxHarness:
                     len(episode.transcript or ""),
                 )
 
+                # Pull the structured session JSONL the preentry exported
+                # before container teardown. Best-effort: empty string on
+                # any failure (missing file = old image, no harm done).
+                episode.turns_log = _read_container_text(
+                    harness, "/workspace/turns.jsonl",
+                )
+
             finally:
                 t_testee_cleanup = time.time()
                 try:
@@ -1190,6 +1244,13 @@ class TrajectorySandboxHarness:
                 session_id, episode_index,
                 time.time() - t_judge_log,
                 len(episode.judge_transcript or ""),
+            )
+
+            # Structured judge session JSONL — captures the SSH grounding
+            # queries, criterion scoring reasoning, and evaluation.json
+            # write call as discrete turn objects.
+            episode.judge_turns_log = _read_container_text(
+                judge, "/workspace/turns.jsonl",
             )
 
             t_judge_archive = time.time()

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -344,6 +344,11 @@ _HERMES_UID = 10000
 # its failure must not mask the chat exit code, since downstream
 # test scoring and judging depend on chat_rc.
 _HERMES_PREENTRY = (
+    # /workspace may not exist in the testee container — only the judge
+    # container sets working_dir="/workspace" which auto-creates it.
+    # mkdir unconditionally so chown + the post-chat export below can
+    # both find the directory.
+    "mkdir -p /workspace; "
     "chown -R hermes:hermes /workspace 2>/dev/null; "
     "chmod 0755 /workspace 2>/dev/null; "
     "/opt/hermes/docker/entrypoint.sh \"$@\"; "


### PR DESCRIPTION
## TL;DR

Counterpart to trajrl-bench PR #30 — wires the validator's S1 eval path to capture the structured Hermes session JSONL that the bench image now exports, and includes it in the eval log archive uploaded to \`https://trajrl.com\`. The trajrl CLI already extracts the new files via the existing \`tar.extractall()\` path, so no CLI change required.

## Why

\`--quiet\` is on for every Hermes chat call (necessary — without it, Qwen3.5 stalls on the TUI). With \`--quiet\`, transcript.txt is header + final message only — every tool call, tool result, and intermediate assistant turn is invisible. The judge, the dashboard, and miners debugging their pack scores all see the same crippled view.

trajrl-bench PR #30 fixed the local-pilot side: hermes-preentry.sh now runs \`hermes sessions export /workspace/turns.jsonl\` after every chat exits. The DB it reads from is per-container and ephemeral, so we have to dump it before teardown.

This PR wires the same capture into the validator's S1 eval driver (which uses its own \`sandbox_harness.py\`, not bench's \`EvalSession\`) so production trajectories actually get uploaded.

## What changes

\`trajectoryrl/utils/sandbox_harness.py\`:

1. New fields on \`_EpisodeResult\`: \`turns_log: str = \"\"\` and \`judge_turns_log: str = \"\"\`.
2. New helper \`_read_container_text(container, path) -> str\` — wraps \`get_archive\` + tar extract + UTF-8 decode, returns \`\"\"\` on any failure (missing file, dead container, decode error).
3. After \`episode.transcript = harness.logs(...)\` in \`_run_episode\`, capture testee \`/workspace/turns.jsonl\`.
4. After \`episode.judge_transcript = judge.logs(...)\` in the judge pass, capture judge \`/workspace/turns.jsonl\`.
5. \`write_artifacts(eval_dir)\` writes \`turns.jsonl\` and \`judge_turns.jsonl\` per episode (skipped silently when the field is empty — older images that don't export).

## Upload + download path

- **Validator**: \`_fire_upload_eval_logs\` already calls \`s1_result.write_artifacts(eval_dir)\` before \`_collect_eval_logs(eval_dir)\` packs everything into a tar.gz. New files land in eval_dir → land in tarball → uploaded via \`upload_eval_logs\` to \`https://trajrl.com/api/validators/logs/upload\`. **No upload code change needed.**
- **CLI**: \`trajrl subnet logs --dump-to DIR\` calls \`tarfile.extractall()\` ([trajrl/api.py:64-70](https://github.com/trajectoryRL/trajrl/blob/main/trajectoryrl_inspector/api.py#L64-L70)). Any new files in the tarball auto-extract. **No CLI change needed.**

## Backward compatibility

Two failure modes, both handled silently:

1. **Older harness image** (no \`hermes sessions export\` step in preentry): \`get_archive\` returns NotFound → helper returns \`\"\"\` → \`write_artifacts\` skips emitting the empty file. Existing artifact layout unchanged for old-image runs.
2. **Future schema changes in Hermes' export format**: bench/validator just write the bytes verbatim — no parsing. Adapter layer is just two strings on a dataclass.

## Sample artifact

A 25-turn smoke run produces ~40KB of JSONL with structure:

\`\`\`json
{
  \"id\": \"20260428_101713_d33d34\",
  \"model\": \"qwen/qwen3.5-35b-a3b\",
  \"started_at\": \"...\", \"ended_at\": \"...\",
  \"end_reason\": \"completed\",
  \"message_count\": 25,
  \"tool_call_count\": 12,
  \"input_tokens\": ..., \"output_tokens\": ...,
  \"messages\": [
    {\"role\": \"user\", \"content\": \"...\"},
    {\"role\": \"assistant\", \"content\": \"...\", \"tool_calls\": [{\"function\": {\"name\": \"terminal\", \"arguments\": \"...\"}}]},
    {\"role\": \"tool\", \"content\": \"...\"},
    ...
  ]
}
\`\`\`

\`end_reason\` is the field we want for diagnosing Qwen3.5 stalls vs real completions.

## Test plan
- [ ] Re-tag a hermes-agent release with trajrl-bench PR #30 baked in
- [ ] Run \`tests/test_s1_e2e.py\` (or equivalent) against the new image and a current pack
- [ ] Confirm \`evals/<id>/<hk16>/episodes/episode_<N>/turns.jsonl\` is populated and non-empty
- [ ] Confirm the eval log tar.gz uploaded to trajrl.com contains the new files
- [ ] Confirm \`trajrl subnet logs --dump-to DIR\` extracts them
- [ ] Confirm older eval logs (pre-rebuild) still extract cleanly without the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)