### PR TITLE
fix(harness): reap orphan eval containers, anonymous volumes, and sup…

### DIFF
--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -448,11 +448,83 @@ class TrajectorySandboxHarness:
         except Exception as e:
             logger.warning("Failed to pull latest images: %s (using cached)", e)
 
+    def _cleanup_orphans(self) -> None:
+        """Remove sandbox/testee/judge containers (and their networks)
+        left behind by prior eval cycles that didn't reach their finally
+        block — typically because the validator was SIGKILL'd mid-cycle
+        by watchtower, OOM, or a host restart. These orphans pin old
+        image versions and prevent ``_pull_sync`` from rmi'ing them.
+
+        Identified by the ``trajectoryrl.role`` label set on every
+        container/network the harness creates.
+        """
+        for role in ("testee", "judge", "sandbox"):
+            try:
+                orphans = self.client.containers.list(
+                    all=True,
+                    filters={"label": f"trajectoryrl.role={role}"},
+                )
+            except Exception as e:
+                logger.warning("Orphan scan failed for role=%s: %s", role, e)
+                continue
+            for c in orphans:
+                try:
+                    c.remove(force=True, v=True)
+                    logger.info("Removed orphan %s container %s", role, c.name)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to remove orphan %s container %s: %s",
+                        role, c.name, e,
+                    )
+        try:
+            for net in self.client.networks.list(
+                filters={"label": "trajectoryrl.role=eval_net"},
+            ):
+                try:
+                    net.remove()
+                    logger.info("Removed orphan eval network %s", net.name)
+                except Exception as e:
+                    logger.warning(
+                        "Failed to remove orphan network %s: %s", net.name, e,
+                    )
+        except Exception as e:
+            logger.warning("Orphan network scan failed: %s", e)
+
     def _pull_sync(self) -> None:
+        # Reap orphans first so they release any image references —
+        # otherwise the rmi-old-image step below fails with "image is
+        # being used by stopped container" and the old version sticks
+        # around until the next ops manual prune.
+        self._cleanup_orphans()
+
         for image in [self._sandbox_image, self._harness_image]:
             try:
+                old_id: str | None = None
+                try:
+                    old_id = self.client.images.get(image).id
+                except docker.errors.ImageNotFound:
+                    pass
                 logger.info("Pulling latest image: %s", image)
                 self.client.images.pull(image)
+                try:
+                    new_id = self.client.images.get(image).id
+                except docker.errors.ImageNotFound:
+                    new_id = None
+                if old_id and new_id and old_id != new_id:
+                    try:
+                        self.client.images.remove(old_id)
+                        logger.info(
+                            "Removed superseded image %s (%s)",
+                            image, old_id[:19],
+                        )
+                    except docker.errors.APIError as e:
+                        # Still referenced by some container we couldn't
+                        # reap (e.g. unrelated user container reusing the
+                        # same hash). Leave it; ops can prune manually.
+                        logger.debug(
+                            "Skip rmi superseded %s (%s): %s",
+                            image, old_id[:19], e,
+                        )
             except Exception as e:
                 logger.warning("Failed to pull %s: %s (using cached)", image, e)
 
@@ -688,7 +760,10 @@ class TrajectorySandboxHarness:
             if sandbox:
                 try:
                     sandbox.stop(timeout=5)
-                    sandbox.remove(force=True)
+                    # v=True deletes anonymous volumes attached to the
+                    # container; without it, every eval leaks volumes
+                    # declared by the image (e.g. hermes-agent's /opt/data).
+                    sandbox.remove(force=True, v=True)
                 except Exception:
                     pass
             if network:
@@ -848,7 +923,7 @@ class TrajectorySandboxHarness:
                 t_testee_cleanup = time.time()
                 try:
                     harness.stop(timeout=3)
-                    harness.remove(force=True)
+                    harness.remove(force=True, v=True)
                 except Exception:
                     pass
                 logger.info(
@@ -1300,7 +1375,7 @@ class TrajectorySandboxHarness:
             t_judge_cleanup = time.time()
             try:
                 judge.stop(timeout=3)
-                judge.remove(force=True)
+                judge.remove(force=True, v=True)
             except Exception:
                 pass
             logger.info("[%s] ep%d STAGE judge_cleanup: %.1fs",


### PR DESCRIPTION
## Summary

  Plug three sources of unbounded `/var/lib/docker` growth on validator hosts. On at least one production
  validator the combined effect filled disk to 100%, after which every testee/judge container exited
  immediately (hermes entrypoint can't `mkdir /opt/data/*` under ENOSPC) and every miner got `quality=0.0`
   for the cycle. Symptoms were silent because the harness reads only stdout from those containers
  (`stderr=False`).

  ### What was leaking

  1. **Anonymous volumes.** The `hermes-agent` image declares `VOLUME /opt/data`, so each
  `containers.create()` for testee/judge gets a fresh anonymous volume. Cleanup called
  `remove(force=True)` without `v=True` — those volumes were never deleted. On one host: 7135 anonymous
  volumes accumulated.
  2. **Orphan containers.** Sandbox/testee/judge cleanup lives in `finally` blocks. When the validator is
  SIGKILL'd mid-cycle (watchtower recreate, OOM, host restart) the finally block doesn't run and the
  detached sandbox survives, pinning whatever `trajrl-bench` image hash it started with. On one host: 15
  orphans across 5 different image versions over 12 days.
  3. **Stale pulled images.** `_pull_sync()` runs `images.pull()` every cycle; the old image is left
  dangling forever. Watchtower's `WATCHTOWER_CLEANUP=true` only covers labelled containers (i.e.
  `trajectoryrl_validator` itself), not the harness-pulled `hermes-agent` / `trajrl-bench`. On one host:
  ~85 GB of dangling `<none>` images.

  ### Changes

  - Add `v=True` to the three `container.remove()` calls (sandbox, testee, judge) so anonymous volumes are
   deleted with their containers.
  - New `_cleanup_orphans()` that reaps containers/networks tagged
  `trajectoryrl.role={sandbox,testee,judge,eval_net}`. Called at the start of every `_pull_sync()` so
  orphans release image references before the rmi-old step runs.
  - After each `images.pull()`, compare new ID against pre-pull ID and `images.remove(old_id)` if it
  changed. `APIError` (image still in use by an unrelated container) is logged at debug and skipped.

  Order in `_pull_sync`: **orphan reap → pull → rmi old**. Reap must come first so orphans release their
  image refs; otherwise rmi fails with "image is being used by stopped container" and the dangling stays.

  ## Test plan

  - [x] `pytest tests/test_sandbox_harness.py` — 22 passed; 3 `TestConfigWiring` failures are pre-existing
   on `main` and unrelated.
  - [ ] On next validator deploy: `_pull_sync()` logs `Removed orphan ...` and `Removed superseded image
  ...` if applicable.
  - [ ] After one cycle: `docker volume ls -q | wc -l` not growing.
  - [ ] `docker images | grep '<none>'` not accumulating hermes-agent / trajrl-bench dangling.

  ## Out of scope

  - Existing backlog on already-running hosts — clears on first `_pull_sync()` after this lands.
  - `stderr=False` at `sandbox_harness.py:828` that hid the ENOSPC — separate concern.