### PR TITLE
[coding-agent] docs: reflect Qwen3.5 testee + GLM-5.1 judge cutover (…

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ btcli stake add --wallet-name my-validator --hotkey default --netuid 11 --amount
 
 # 2. Configure
 cp .env.validator.example .env.validator
-# Edit: set WALLET_NAME, LLM_API_KEY, LLM_BASE_URL, LLM_MODEL
+# Edit: set WALLET_NAME, LLM_API_KEY, LLM_BASE_URL, LLM_MODEL (testee),
+# and JUDGE_API_KEY/JUDGE_BASE_URL/JUDGE_MODEL (independent judge family).
 
 # 3. Start
 docker compose -f docker/docker-compose.validator.yml --env-file .env.validator up -d

--- a/docs/MINER_GUIDE.md
+++ b/docs/MINER_GUIDE.md
@@ -331,4 +331,4 @@ A: No. Season 1 packs must contain `SKILL.md` only. `AGENTS.md` and `tool_policy
 A: Your pack is rejected. Season 1 requires SKILL.md.
 
 **Q: What model do the testee and judge use?**
-A: Configurable by validators. Default is via OpenRouter. Both testee and judge use the same model by default.
+A: Configurable by validators. Default provider is OpenRouter. As of v0.5.14 the recommended setup splits the two: testee runs **Qwen3.5-35B-A3B** (`LLM_MODEL`), judge runs **GLM-5.1** (`JUDGE_MODEL`). Different model families on purpose — judge bias stays uncorrelated with testee bias.

--- a/docs/seasons/self_learning_s1.md
+++ b/docs/seasons/self_learning_s1.md
@@ -559,7 +559,7 @@ Per miner: typical ~12 min (4 × ~3 min combined testee + judge), worst case ~24
 
 Judge cost is higher than v0.19's fixed LLM judge (~$40 at 200 miners) because the judge is now an agent that makes multiple tool calls. Still manageable for validators earning TAO emissions.
 
-**Cost mitigation:** Harness-aware cost caps (kill testee/judge if exceeding token budget); cheap default model (GLM-5.1); ephemeral lightweight containers.
+**Cost mitigation:** Harness-aware cost caps (kill testee/judge if exceeding token budget); cheap default models (Qwen3.5-35B-A3B testee + GLM-5.1 judge, both via OpenRouter); ephemeral lightweight containers.
 
 ### 4. The "already good" problem
 


### PR DESCRIPTION
## Summary

  Three call-out spots in the *latest* docs (and the README) still described the pre-cutover (single-model
   GLM-5.1) setup. Updates them to match the post-#204 / post-#205 reality:

  - **`README.md`** — validator quick-start now lists `JUDGE_API_KEY` / `JUDGE_BASE_URL` / `JUDGE_MODEL`
  alongside the `LLM_*` vars, so first-time validators see the testee/judge split before opening
  `.env.validator.example`.
  - **`docs/MINER_GUIDE.md`** — the FAQ entry "What model do the testee and judge use?" no longer claims
  they use the same model. Replaced with the v0.5.14 default (Qwen3.5-35B-A3B testee + GLM-5.1 judge,
  OpenRouter) and the rationale (judge bias kept uncorrelated with testee bias).
  - **`docs/seasons/self_learning_s1.md`** — the cost-mitigation paragraph's "cheap default model
  (GLM-5.1)" phrasing now names both default models.

  ## Scope

  - Touches only the *latest* docs (top-level `docs/` + `README.md`). `docs/legacy/*` is intentionally
  left as a historical archive.
  - No code changes, no env-example changes (#204 already updated `.env.validator.example`).
  - The cost numbers in `self_learning_s1.md` (lines ~555-558) are **not** adjusted — they were derived
  under the prior single-GLM setup and accurate per-call pricing for Qwen3.5-35B-A3B on OpenRouter is out
  of scope. The *qualitative* cost-mitigation description is what was stale.

  ## Test plan

  - [x] `grep` for `glm-5\.1`, `bigmodel`, `Zhipu`, `same model by default`, `cheap default model` across
  `docs/` and `README.md` — only intentional/updated mentions remain.
  - [ ] Render the README on GitHub to spot-check formatting.