### PR TITLE
[coding-agent] fix(llm_client): drop the naive provider-prefix strip …

### DIFF
--- a/trajectoryrl/utils/llm_client.py
+++ b/trajectoryrl/utils/llm_client.py
@@ -34,8 +34,6 @@ def _generate(
     Prefer ``async_generate`` in async contexts — this function blocks
     the calling thread until the HTTP request completes.
     """
-    if "/" in model:
-        model = model.split("/", 1)[1]
     if not api_key:
         raise ValueError("api_key required (judge LLM credentials must be passed explicitly).")
 


### PR DESCRIPTION
## Summary

  `_generate` had a leftover one-liner that chopped the first slash segment off any model id:

  ```python
  if "/" in model:
      model = model.split("/", 1)[1]
  ```

  It was a best-effort hack to handle `openrouter/<vendor>/<model>` style routing prefixes. It also chops
  the legitimate first segment of any bare `<vendor>/<model>` id — `z-ai/glm-5.1` → `glm-5.1`,
  `qwen/qwen3.5-35b-a3b` → `qwen3.5-35b-a3b` — which OpenRouter then rejects because it expects the full
  vendor-qualified id.

  After #204, the validator's defaults are `LLM_MODEL=qwen/qwen3.5-35b-a3b` (testee) and
  `JUDGE_MODEL=z-ai/glm-5.1` (judge). The Python-level judge path (`PackIntegrityJudge` /
  `TrajectoryJudge` → `async_generate` → `_generate`) is exactly where this strip fires, so the bug
  becomes load-bearing on the cutover.

  Configuration no longer prepends extra routing prefixes — model ids carry the provider's native form,
  and routing happens via `LLM_BASE_URL` / `JUDGE_BASE_URL`. There's nothing to strip, so the line is
  gone.

  ## What this PR does NOT touch

  `sandbox_harness._strip_provider_prefix` — that helper only strips *known* prefixes (`openrouter/`,
  `chutes/`) and is safe defensive code for operators who might still pin a routing prefix explicitly.
  It's a no-op for current default configs.

  ## Test plan

  - [x] `pytest tests/test_llm_judge_formatting.py` — 55/55 pass
  - [ ] One real validator cycle on the test wallet to confirm `PackIntegrityJudge` / `TrajectoryJudge`
  now get back valid OpenRouter responses with `JUDGE_MODEL=z-ai/glm-5.1`.