### PR TITLE
fix(validator): persist _consensus_window after startup aggregation

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -1045,9 +1045,11 @@ class TrajectoryValidator:
         ``_set_winner_weights`` to compute the winner and set weights
         immediately — without waiting for the normal window lifecycle.
 
-        This is a side-effect-free operation with respect to the main loop:
-        ``_consensus_window`` is saved and restored so the normal per-window
-        aggregation guard is not consumed.
+        On success we **persist** ``_consensus_window = target_window`` so
+        the main loop's "advance target_window past the just-aggregated
+        window" check ([1404]) actually fires after restart. On failure we
+        restore the saved value so the main loop can retry aggregation
+        normally without poisoning its per-window guard.
         """
         logger.info("=" * 60)
         logger.info("aggregate_when_start enabled — running startup aggregation")
@@ -1089,7 +1091,16 @@ class TrajectoryValidator:
         await self._run_consensus_aggregation(synthetic_window)
         aggregation_succeeded = (self._consensus_window == target_window)
 
-        self._consensus_window = saved_consensus_window
+        # Persist _consensus_window = target_window when aggregation succeeded
+        # so the main loop's "target_window <= _consensus_window → advance"
+        # check fires next tick. Restoring the saved value here would leave
+        # _consensus_window stuck at -1 (or the pre-restart value), which
+        # deadlocks the main loop: target_window stays at the just-aggregated
+        # window, _should_start_target_evaluation refuses to start the next
+        # eval cycle (target != physical), and _submit_consensus_payload
+        # retries forever with no local data to submit.
+        if not aggregation_succeeded:
+            self._consensus_window = saved_consensus_window
         self._save_eval_state()
 
         if aggregation_succeeded:


### PR DESCRIPTION
## Bug

After a validator restart that lands in or after the aggregation phase, the validator deadlocks: the main loop refuses to start a new eval cycle and instead loops forever on a publish-payload retry that can never succeed.

Hit live on UID 221 (trajrl.com) on 2026-04-30 02:59 UTC after the v0.5.14 cutover restart. Validator sat in burn-only mode for ~30 min before being manually unblocked via a state-file edit.

## Root cause

`_aggregate_on_startup` ([validator.py:1040](trajectoryrl/base/validator.py#L1040)) was saving `_consensus_window`, calling `_run_consensus_aggregation` (which correctly sets `_consensus_window = target_window` on success), then **unconditionally restoring the saved value**:

```python
saved_consensus_window = self._consensus_window
await self._run_consensus_aggregation(synthetic_window)
aggregation_succeeded = (self._consensus_window == target_window)

self._consensus_window = saved_consensus_window   # ← undoes the update on success too
self._save_eval_state()
```

Comment said the restore is to keep startup-aggregation "side-effect-free with respect to the main loop." Intent was right (don't burn the per-window aggregation guard for the *current* main-loop window), but the implementation persisted the sentinel value `-1` to disk after a successful startup-aggregation. Re-entering the main loop with `consensus_window=-1` and `target_window=1121` (loaded from saved state) lands in this deadlock:

| Check | Value | Result |
|---|---|---|
| `target_window <= self._consensus_window` (advance) | `1121 <= -1` | **False** — target stays at 1121 |
| `target_window == physical_window.window_number` (start eval) | `1121 != 1122` | **False** — eval never starts |
| `_last_eval_window >= target_window` (try publish) | `1121 >= 1121` | True — enter publish block |
| `_build_local_consensus_payload(window=1121)` | `None` (no local eval data) | **Retry forever** |

State on disk during the deadlock:
```json
{
  "consensus_window": -1,
  "last_eval_window": 1121,
  "target_window": 1121,
  "target_submit_done": false
}
```

## Fix

Persist `_consensus_window = target_window` on success (i.e. when `_run_consensus_aggregation` already set it to that value) — let the assignment from `_run_consensus_aggregation` stand. Only restore the saved value on failure, so a busted aggregation doesn't poison the main loop's per-window guard.

```python
# Persist on success; restore on failure.
if not aggregation_succeeded:
    self._consensus_window = saved_consensus_window
self._save_eval_state()
```

After this fix, the same restart sequence produces:

```json
{ "consensus_window": 1121, "last_eval_window": 1121, "target_window": 1121, "target_submit_done": false }
```

…which the main loop correctly advances on the next tick:
- `target_window=1121 <= consensus_window=1121` → advance to 1122
- `_should_start_target_evaluation(target=1122, physical=1122)` → True
- Eval cycle starts for window 1122 ✓

## Verification

Manually applied the equivalent state patch (`consensus_window: -1 → 1121` via `docker cp` of edited `eval_state.json`) on the live UID 221 host. After restart:

```
03:36:41 set_weights OK uids=[136, 74]
03:36:47 Evaluation target_window=1122 at block 8078872 (phase=evaluation, offset=472/7200)
03:38:35 [1/88] Evaluating miner 185 (5CSzJRKd) ...
03:38:35 S1 evaluation starting: pack_hash=ab2319804dc5, seed=2792753291, episodes=4
```

i.e. exactly the unblock this PR's code change produces deterministically.

## Test plan

- [ ] On a test wallet, set `aggregate_when_start=true`, restart with state file containing `consensus_window=-1` and `target_window=N`. Verify after one main-loop tick: `consensus_window=N`, `target_window=N+1` (or physical_window if larger), eval cycle starts.
- [ ] Verify failure path: kill chain RPC mid-aggregation, confirm `_consensus_window` reverts to saved value (no false positive).
- [ ] Run `python -m pytest tests/test_s1_e2e.py::TestS1UnitMath` — unit math should still pass (this PR doesn't touch scoring).

## Scope note

This is a minimal one-function fix on top of v0.5.14 (PR #204). Could be folded into v0.5.14 if not yet tagged, otherwise ships as v0.5.14.1 / v0.5.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)