### PR TITLE
fix(validator): submit testee model as llm_model + add judge_llm_model

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -167,7 +167,17 @@ class TrajectoryValidator:
         judge_base_url = config.judge_base_url or config.llm_base_url
         self._judge_model = judge_model
         self._judge_base_url = judge_base_url
-        logger.debug("Initializing LLM judges (model=%s)...", judge_model)
+
+        # Testee model is what runs SKILL.md inside the sandbox. We surface
+        # it as the primary "llm_model" on the validators page (the model
+        # operators most want visibility into); judge model is reported
+        # separately via judge_llm_model in the submit payload.
+        self._testee_model = config.llm_model
+        self._testee_base_url = config.llm_base_url
+        logger.debug(
+            "Initializing LLM judges (testee=%s, judge=%s)...",
+            self._testee_model, judge_model,
+        )
 
         self.integrity_judge = PackIntegrityJudge(
             model=judge_model,
@@ -966,8 +976,10 @@ class TrajectoryValidator:
                                 qualified=False,
                                 pack_url=pre_eval_result.get("pack_url", ""),
                                 pack_hash=pre_eval_result.get("pack_hash", ""),
-                                llm_base_url=self._judge_base_url,
-                                llm_model=self._judge_model,
+                                llm_base_url=self._testee_base_url,
+                                llm_model=self._testee_model,
+                                judge_llm_base_url=self._judge_base_url,
+                                judge_llm_model=self._judge_model,
                                 rejected=True,
                                 rejection_stage=_stage,
                                 rejection_detail=_detail,
@@ -1829,8 +1841,10 @@ class TrajectoryValidator:
                         qualified=False,
                         pack_url=commitment.pack_url,
                         pack_hash=commitment.pack_hash,
-                        llm_base_url=self._judge_base_url,
-                        llm_model=self._judge_model,
+                        llm_base_url=self._testee_base_url,
+                        llm_model=self._testee_model,
+                        judge_llm_base_url=self._judge_base_url,
+                        judge_llm_model=self._judge_model,
                         rejected=True,
                         rejection_stage="integrity_check",
                         rejection_detail=detail,
@@ -1883,8 +1897,10 @@ class TrajectoryValidator:
                             qualified=False,
                             pack_url=commitment.pack_url,
                             pack_hash=commitment.pack_hash,
-                            llm_base_url=self._judge_base_url,
-                            llm_model=self._judge_model,
+                            llm_base_url=self._testee_base_url,
+                            llm_model=self._testee_model,
+                            judge_llm_base_url=self._judge_base_url,
+                            judge_llm_model=self._judge_model,
                             rejected=True,
                             rejection_stage=_stage,
                             rejection_detail=_detail,
@@ -2423,8 +2439,10 @@ class TrajectoryValidator:
             pack_hash=commitment.pack_hash,
             eval_count=eval_count,
             scenario_results=scenario_results,
-            llm_base_url=self._judge_base_url,
-            llm_model=self._judge_model,
+            llm_base_url=self._testee_base_url,
+            llm_model=self._testee_model,
+            judge_llm_base_url=self._judge_base_url,
+            judge_llm_model=self._judge_model,
             spec_number=_spec_number(),
             epoch_number=window_number,
             **self._harness_metadata(),

--- a/trajectoryrl/utils/status_reporter.py
+++ b/trajectoryrl/utils/status_reporter.py
@@ -394,6 +394,8 @@ async def submit_eval(
     scenario_results: Optional[Dict[str, Any]] = None,
     llm_base_url: Optional[str] = None,
     llm_model: Optional[str] = None,
+    judge_llm_base_url: Optional[str] = None,
+    judge_llm_model: Optional[str] = None,
     rejected: Optional[bool] = None,
     rejection_stage: Optional[str] = None,
     rejection_detail: Optional[str] = None,
@@ -448,6 +450,10 @@ async def submit_eval(
         payload["llm_base_url"] = llm_base_url
     if llm_model is not None:
         payload["llm_model"] = llm_model
+    if judge_llm_base_url is not None:
+        payload["judge_llm_base_url"] = judge_llm_base_url
+    if judge_llm_model is not None:
+        payload["judge_llm_model"] = judge_llm_model
     if rejected is not None:
         payload["rejected"] = rejected
     if rejection_stage is not None:


### PR DESCRIPTION
## Bug

Validators page still shows `glm-5.1` for every validator's "LLM Model" column, even though the Qwen3.5-35B-A3B testee + GLM judge cutover landed in v0.5.14 and validators have been actually running Qwen3 for hours.

## Root cause

After the v0.5.14 split-judge cutover, the validator's submit code still sends `self._judge_model` in the `submit_eval(...llm_model=...)` field. With `JUDGE_MODEL=z-ai/glm-5.1` set in `.env.validator`, that value is the judge model — and the testee model (`LLM_MODEL=qwen/qwen3.5-35b-a3b`) wasn't reaching the dashboard at all. The page reads `score_submit_log.llm_model` and shows what's in the DB — which is the judge model.

Verified via Postgres on prod ([taken from staging snapshot]):

```
 5Cd6htiu44... | z-ai/glm-5.1 |  1
 5EcgNdYQ5i... | z-ai/glm-5.1 | 11    ← UID 221 trajrl.com (just submitted under v0.5.15)
 5ECzcM7six... | z-ai/glm-5.1 | 17    ← UID 74 trajrl.com
 5HTZ6CxJmd... | z-ai/glm-5.1 | 29    ← UID 107 TAO.com
```

All `glm-5.1`. None mention Qwen3 anywhere.

## Fix

Treat `llm_model` as **the testee model** (the one that actually runs `SKILL.md` — what operators most want surfaced) and add a separate `judge_llm_model` field for the independent judge.

- `validator.py`: add `self._testee_model` and `self._testee_base_url` (mirrors the sandbox harness's testee/judge split that landed in v0.5.14).
- All 4 `submit_eval` call sites now pass:
  - `llm_base_url=self._testee_base_url`
  - `llm_model=self._testee_model` ← Qwen3 lands here
  - `judge_llm_base_url=self._judge_base_url`
  - `judge_llm_model=self._judge_model` ← GLM still reported, separately
- `status_reporter.submit_eval`: accepts `judge_llm_base_url` + `judge_llm_model` kwargs and forwards them in the JSON payload to `/api/v2/scores/submit`.

## Companion change

This PR is the validator half. The website half (separate PR in `trajectoryrl.web`) will:
- Add `judge_llm_model` (and `judge_llm_base_url`) columns to `score_submit_log`.
- Update `/api/v2/scores/submit` to accept the new fields.
- Update `/api/validators` to return both.
- Update the validators page UI to display both — likely as `qwen/qwen3.5-35b-a3b · judge: z-ai/glm-5.1`.

Until the website side merges, the new fields are silently ignored by the existing `submit` endpoint, and the `llm_model` column on the page flips from `glm-5.1` to `qwen/qwen3.5-35b-a3b` — which is the more salient signal anyway. No DB schema change is required for this PR alone.

## Test plan

- [ ] `python -c "from trajectoryrl.base.validator import TrajectoryValidator; ..."` import sanity.
- [ ] Local restart on a test wallet; verify next score row carries `llm_model=qwen/qwen3.5-35b-a3b` (testee) and that the dashboard receives a `judge_llm_model` field even if it ignores it.
- [ ] After website-side PR lands, validators page shows both testee and judge model.

## Scope

One-function change in `validator.py:165–181` (`__init__` adds two fields) plus a kwarg flip at four `submit_eval` sites + a 4-line addition in `status_reporter.py`. No schema migration on the validator side; no behavior change for validators that haven't set `JUDGE_MODEL` (single-model fallback continues to work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)