### PR TITLE
[coding-agent] fix(validator): reconnect on chain query failure 

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -949,6 +949,183 @@ class TestGetCommitmentBlock:
         )
 
 
+class TestFetchAllCommitmentsResilience:
+    """Tests for chain-failure handling and reconnect retry in fetch_all_commitments.
+
+    Distinguishes "chain query failed" (returns None — caller MUST NOT persist
+    a snapshot) from "chain query succeeded with no commitments" (returns {} —
+    legitimate empty state).
+    """
+
+    def _hotkey(self) -> str:
+        return "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+
+    def _good_raw(self) -> str:
+        return "a" * 64 + "|https://trajrl.com/samples/pack.json"
+
+    def _metagraph_with(self, hotkey: str):
+        mg = MagicMock()
+        mg.hotkeys = [hotkey]
+        return mg
+
+    def test_returns_none_when_chain_query_fails_and_no_reconnect_cb(self):
+        """Without a reconnect callback, a chain exception → returns None
+        (signals failure so caller skips snapshot persistence)."""
+        from trajectoryrl.utils.commitments import fetch_all_commitments
+
+        mock_subtensor = MagicMock()
+        mock_subtensor.get_all_commitments.side_effect = Exception("ws closed")
+
+        result = fetch_all_commitments(
+            mock_subtensor, netuid=11, metagraph=self._metagraph_with(self._hotkey()),
+        )
+        assert result is None
+
+    def test_returns_empty_dict_when_chain_truly_empty(self):
+        """A successful chain query that returns 0 commitments → returns {} (not None).
+        Distinguishes legit empty state from query failure."""
+        from trajectoryrl.utils.commitments import fetch_all_commitments
+
+        mock_subtensor = MagicMock()
+        mock_subtensor.get_all_commitments.return_value = {}
+
+        result = fetch_all_commitments(
+            mock_subtensor, netuid=11, metagraph=self._metagraph_with(self._hotkey()),
+        )
+        assert result == {}
+
+    def test_retries_via_reconnect_callback_when_first_attempt_fails(self):
+        """When the first chain query raises, the reconnect callback is invoked
+        and the returned subtensor is used for a single retry."""
+        from trajectoryrl.utils.commitments import fetch_all_commitments
+
+        hotkey = self._hotkey()
+
+        broken_subtensor = MagicMock()
+        broken_subtensor.get_all_commitments.side_effect = Exception("ws closed")
+
+        fresh_subtensor = MagicMock()
+        fresh_subtensor.get_all_commitments.return_value = {hotkey: self._good_raw()}
+        fresh_subtensor.get_commitment_metadata.return_value = {"block": 42000}
+
+        reconnect_calls = {"count": 0}
+
+        def reconnect():
+            reconnect_calls["count"] += 1
+            return fresh_subtensor
+
+        result = fetch_all_commitments(
+            broken_subtensor,
+            netuid=11,
+            metagraph=self._metagraph_with(hotkey),
+            reconnect=reconnect,
+        )
+
+        assert reconnect_calls["count"] == 1
+        assert result is not None
+        assert 0 in result
+        assert result[0].hotkey == hotkey
+
+    def test_returns_none_when_reconnected_fetch_also_fails(self):
+        """If the chain query fails after reconnect too, returns None."""
+        from trajectoryrl.utils.commitments import fetch_all_commitments
+
+        broken_subtensor = MagicMock()
+        broken_subtensor.get_all_commitments.side_effect = Exception("ws closed")
+
+        still_broken = MagicMock()
+        still_broken.get_all_commitments.side_effect = Exception("still broken")
+
+        result = fetch_all_commitments(
+            broken_subtensor,
+            netuid=11,
+            metagraph=self._metagraph_with(self._hotkey()),
+            reconnect=lambda: still_broken,
+        )
+        assert result is None
+
+    def test_does_not_invoke_reconnect_when_first_attempt_succeeds(self):
+        """No reconnect call when the chain query succeeds on the first try."""
+        from trajectoryrl.utils.commitments import fetch_all_commitments
+
+        hotkey = self._hotkey()
+
+        mock_subtensor = MagicMock()
+        mock_subtensor.get_all_commitments.return_value = {hotkey: self._good_raw()}
+        mock_subtensor.get_commitment_metadata.return_value = {"block": 1000}
+
+        reconnect_calls = {"count": 0}
+
+        def reconnect():
+            reconnect_calls["count"] += 1
+            return mock_subtensor
+
+        result = fetch_all_commitments(
+            mock_subtensor,
+            netuid=11,
+            metagraph=self._metagraph_with(hotkey),
+            reconnect=reconnect,
+        )
+        assert reconnect_calls["count"] == 0
+        assert result is not None and 0 in result
+
+
+class TestAcquireWindowSnapshotGuard:
+    """Tests for _acquire_window_snapshot's behavior when chain query fails.
+
+    A failed chain query (fetch_all_commitments returns None) MUST NOT be
+    persisted as an "empty active set" snapshot — that locks the validator
+    into a no-eval state for the rest of the ~24h window.
+    """
+
+    def test_does_not_save_snapshot_when_fetch_returns_none(self, tmp_path):
+        """When fetch_all_commitments returns None, _acquire_window_snapshot
+        must return None and must NOT call save_snapshot — so the next loop
+        iteration (or restart) can re-attempt the fetch instead of being
+        locked by a poisoned cache file."""
+        from trajectoryrl.base import validator as validator_module
+        from trajectoryrl.utils.eval_snapshot import EvalSnapshot
+
+        # Build a minimal stub validator that exposes the methods/attrs
+        # _acquire_window_snapshot needs, without going through the full
+        # TrajectoryValidator constructor.
+        validator = MagicMock()
+        validator.config.active_set_dir = str(tmp_path)
+        validator.config.netuid = 11
+        validator.config.inactivity_blocks = 120
+        validator.subtensor = MagicMock()
+        validator.metagraph = MagicMock()
+
+        # Bind the real _acquire_window_snapshot onto our stub.
+        validator._acquire_window_snapshot = (
+            validator_module.TrajectoryValidator._acquire_window_snapshot.__get__(
+                validator
+            )
+        )
+
+        # Build a minimal EvaluationWindow-like object (the method only reads
+        # window_number and window_start from it).
+        window = MagicMock()
+        window.window_number = 1123
+        window.window_start = 8085600
+
+        with patch.object(
+            validator_module, "fetch_all_commitments", return_value=None,
+        ) as fetch_mock, patch.object(
+            validator_module, "save_snapshot",
+        ) as save_mock, patch.object(
+            validator_module, "load_snapshot", return_value=None,
+        ):
+            result = validator._acquire_window_snapshot(window, current_block=8085614)
+
+        assert fetch_mock.called
+        assert result is None, "should return None to signal caller to fall back"
+        assert not save_mock.called, (
+            "must NOT persist a snapshot when chain query failed — "
+            "would poison the cache and block the next ~24h window"
+        )
+
+
 # ===================================================================
 # Per-Scenario Eval State Tests
 # ===================================================================

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -362,19 +362,24 @@ class TrajectoryValidator:
         )
         return False
 
-    def _reconnect_subtensor(self, label: str = "") -> None:
-        """Rebuild the subtensor connection to recover from stale websockets."""
+    def _reconnect_subtensor(self, label: str = ""):
+        """Rebuild the subtensor connection to recover from stale websockets.
+
+        Returns the new ``self.subtensor`` on success, ``None`` on failure.
+        """
         try:
             logger.info("%sReconnecting subtensor (network=%s)...",
                         label, self.config.network)
             self.subtensor = bt.Subtensor(network=self.config.network)
             self.metagraph = self.subtensor.metagraph(self.config.netuid)
             logger.info("%sSubtensor reconnected", label)
+            return self.subtensor
         except Exception as e:
             logger.error(
                 "%sFailed to reconnect subtensor: %s", label, e,
                 exc_info=True,
             )
+            return None
 
     def _is_metagraph_healthy(self) -> bool:
         """Quick check whether the cached metagraph has any neurons."""
@@ -1421,17 +1426,30 @@ class TrajectoryValidator:
                     )
                     logger.info("=" * 60)
 
-                    await self._run_evaluation_cycle(current_block, target_window)
-                    self._last_eval_at = int(time.time())
-                    self._last_eval_window = target_window
-                    self._last_eval_date = datetime.datetime.utcnow().date()
-                    self.last_weight_block = self.subtensor.get_current_block()
-                    self._target_submit_done = False
-
-                    self.pack_fetcher.cleanup_cache(
-                        self.config.pack_cache_max_size
+                    cycle_result = await self._run_evaluation_cycle(
+                        current_block, target_window,
                     )
-                    self._save_eval_state()
+                    if cycle_result is False:
+                        # Infrastructure failure inside the cycle (e.g. chain
+                        # query for commitments unreachable). Do NOT mark the
+                        # window as evaluated; the next loop iteration will
+                        # retry rather than lock us out of this ~24h window.
+                        logger.warning(
+                            "Eval cycle for target_window=%d aborted; "
+                            "leaving window unmarked so it can retry",
+                            target_window,
+                        )
+                    else:
+                        self._last_eval_at = int(time.time())
+                        self._last_eval_window = target_window
+                        self._last_eval_date = datetime.datetime.utcnow().date()
+                        self.last_weight_block = self.subtensor.get_current_block()
+                        self._target_submit_done = False
+
+                        self.pack_fetcher.cleanup_cache(
+                            self.config.pack_cache_max_size
+                        )
+                        self._save_eval_state()
 
                     if self._cycle_eval_id is not None:
                         asyncio.ensure_future(
@@ -1739,7 +1757,11 @@ class TrajectoryValidator:
         window = compute_window(current_block, self._window_config)
         snapshot = self._acquire_window_snapshot(window, current_block)
         if snapshot is None:
-            return
+            # Snapshot acquisition failed (chain query unreachable even after
+            # reconnect retry). Returning False signals the outer loop NOT to
+            # mark this window as evaluated, so the next iteration can retry
+            # instead of locking the validator out of this ~24h window.
+            return False
 
         # Per-validator runtime filters (validator_permit, blacklist)
         # are dynamic and applied on top of the frozen snapshot every
@@ -2185,8 +2207,24 @@ class TrajectoryValidator:
             window.window_number, window.window_start, current_block,
         )
         raw = fetch_all_commitments(
-            self.subtensor, self.config.netuid, self.metagraph,
+            self.subtensor,
+            self.config.netuid,
+            self.metagraph,
+            reconnect=lambda: self._reconnect_subtensor(
+                f"[snapshot window {window.window_number}] "
+            ),
         )
+        if raw is None:
+            # Chain query failed even after reconnect retry. Returning None
+            # without persisting lets the next loop iteration (or restart)
+            # re-attempt the fetch instead of being locked by a poisoned
+            # cache file for the rest of the ~24h window.
+            logger.error(
+                "Window %d: chain query for commitments failed; "
+                "skipping snapshot persistence so the next cycle can retry",
+                window.window_number,
+            )
+            return None
         snapshot = take_snapshot(
             raw,
             window_number=window.window_number,

--- a/trajectoryrl/utils/commitments.py
+++ b/trajectoryrl/utils/commitments.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -224,7 +224,9 @@ def fetch_all_commitments(
     subtensor,
     netuid: int,
     metagraph,
-) -> Dict[int, MinerCommitment]:
+    *,
+    reconnect: Optional[Callable[[], object]] = None,
+) -> Optional[Dict[int, MinerCommitment]]:
     """Read all miner commitments from the chain.
 
     Calls ``subtensor.get_all_commitments(netuid)`` and parses each entry.
@@ -234,17 +236,38 @@ def fetch_all_commitments(
         subtensor: Bittensor subtensor instance.
         netuid: Subnet UID (11 for TrajectoryRL).
         metagraph: Bittensor metagraph for hotkey/UID mapping.
+        reconnect: Optional callback that rebuilds the subtensor connection
+            and returns the new instance. Invoked once if the chain query
+            raises (typically due to a stale websocket). The retry uses the
+            returned subtensor.
 
     Returns:
-        Dict mapping UID -> MinerCommitment for all valid entries.
+        ``None`` if the chain query failed (caller MUST NOT persist this
+        as an empty active set — see ``_acquire_window_snapshot``).
+        ``{}`` if the chain query succeeded but returned no commitments.
+        A populated dict (UID → MinerCommitment) otherwise.
     """
-    commitments: Dict[int, MinerCommitment] = {}
-
     try:
         raw_commitments = subtensor.get_all_commitments(netuid=netuid)
     except Exception as e:
-        logger.error(f"Failed to read on-chain commitments: {e}")
-        return commitments
+        if reconnect is None:
+            logger.error(
+                f"Failed to read on-chain commitments (no reconnect cb): {e}"
+            )
+            return None
+        logger.warning(
+            f"Failed to read on-chain commitments: {e} — reconnecting and retrying once"
+        )
+        try:
+            subtensor = reconnect()
+            raw_commitments = subtensor.get_all_commitments(netuid=netuid)
+        except Exception as e2:
+            logger.error(
+                f"Failed to read on-chain commitments after reconnect: {e2}"
+            )
+            return None
+
+    commitments: Dict[int, MinerCommitment] = {}
 
     if not raw_commitments:
         return commitments


### PR DESCRIPTION

A websocket keepalive timeout right when the validator entered window 1123's evaluation phase caused `subtensor.get_all_commitments()` to return 0 entries; the validator then persisted that as the active-set snapshot and marked the window evaluated, locking itself out of an entire ~24h window with no path to recover until next window.

Three coordinated changes:

1. `fetch_all_commitments` now returns `Optional[Dict]` — `None` means "chain query failed" (caller must NOT persist), `{}` means "chain query succeeded but no commitments". Accepts an optional `reconnect` callback that's invoked once if the query raises, and the returned subtensor is used for a single retry.

2. `_acquire_window_snapshot` passes `_reconnect_subtensor` as the callback. When the fetch returns `None` it logs and returns `None` without calling `save_snapshot`, so the next loop iteration (or restart) re-attempts the fetch instead of being locked by a poisoned cache file.

3. `_run_evaluation_cycle` now returns `False` on the snapshot-failure path; the caller skips the `_last_eval_window` state update so the window stays unmarked and eligible for retry.

`_reconnect_subtensor` returns the new subtensor (or None on failure) so it can be used directly as the reconnect callback.

Tests: 6 new (5 for fetch_all_commitments resilience, 1 for the snapshot-guard); pre-existing get_commitment_block tests still pass.