### PR TITLE
[coding-agent] fix(validator): quorum gate inside _run_consensus_aggregation

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3491,3 +3491,74 @@ class TestAggregateOnStartupConsensusWindowPersist:
         assert v._consensus_window == 1120
         v._save_eval_state.assert_called_once()
         v._set_winner_weights.assert_not_called()
+
+
+class TestRunConsensusAggregationQuorumGate:
+    """Regression: ``_run_consensus_aggregation`` must respect quorum.
+
+    The main loop checks quorum via ``_compute_quorum_status`` BEFORE invoking
+    ``_run_consensus_aggregation`` (validator.py:1503-1548), so that path is
+    safe. But ``_aggregate_on_startup`` and ``_full_cycle_on_startup`` invoke
+    ``_run_consensus_aggregation`` directly with no upstream gate. Without an
+    internal gate, a single stale on-chain submission (e.g. our own pointer
+    left behind from a prior failed cycle) is enough to bump
+    ``_consensus_window``, which then forces ``target_window`` past the
+    actual physical window and locks the validator out of the real eval.
+
+    This was the second of two bugs that caused the 2026-05-01 window-1123
+    incident on UID 221. The first bug (ws-failure-poisons-snapshot) was
+    fixed in PR #213; this regression locks in the second.
+    """
+
+    def _make_validator(self):
+        v = TrajectoryValidator.__new__(TrajectoryValidator)
+        v.config = MagicMock(netuid=11, quorum_threshold=0.5)
+        v.subtensor = MagicMock()
+        v.metagraph = MagicMock(hotkeys=[], n=10)
+        v._consensus_window = 1122
+        v._is_metagraph_healthy = MagicMock(return_value=True)
+        v._sync_metagraph = MagicMock(return_value=True)
+        v._compute_quorum_status = MagicMock()
+        v._consensus_store = MagicMock()
+        v.wallet = MagicMock()
+        v.wallet.hotkey.ss58_address = "5ValidatorOwn"
+        return v
+
+    def test_aggregation_skipped_when_quorum_not_met(self):
+        """Without quorum, ``_run_consensus_aggregation`` must return early
+        and leave ``_consensus_window`` untouched."""
+        v = self._make_validator()
+        v._compute_quorum_status.return_value = (False, 0.10, 100.0, 1000.0)
+        window = MagicMock(window_number=1123)
+
+        with patch(
+            "trajectoryrl.base.validator.fetch_validator_consensus_commitments"
+        ) as fetch_mock:
+            asyncio.run(v._run_consensus_aggregation(window))
+
+        assert v._consensus_window == 1122, (
+            "consensus_window must NOT advance when quorum is not met "
+            "(otherwise a single stale submission can lock the validator out "
+            "of the real eval cycle for that window)"
+        )
+        assert not fetch_mock.called, (
+            "should bail before fetching commitments when quorum gate fails"
+        )
+        v._compute_quorum_status.assert_called_once_with(1123)
+
+    def test_aggregation_proceeds_when_quorum_met(self):
+        """When quorum is met, the function must proceed past the gate
+        (we verify by observing the chain fetch is called)."""
+        v = self._make_validator()
+        v._compute_quorum_status.return_value = (True, 0.60, 600.0, 1000.0)
+        window = MagicMock(window_number=1123)
+
+        with patch(
+            "trajectoryrl.base.validator.fetch_validator_consensus_commitments",
+            return_value=[],  # empty downstream so the function still bails
+        ) as fetch_mock:
+            asyncio.run(v._run_consensus_aggregation(window))
+
+        assert fetch_mock.called, (
+            "should proceed to fetch chain commitments when quorum is met"
+        )

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -836,6 +836,28 @@ class TrajectoryValidator:
             )
             self._sync_metagraph(caller="consensus_aggregation")
 
+        # Quorum gate: bail if not enough validator stake has committed for
+        # this window. The main loop's aggregation phase enforces this gate
+        # externally (validator.py ~1503-1548), but `_aggregate_on_startup`
+        # and `_full_cycle_on_startup` invoke us directly with no upstream
+        # check — so without this gate, a single stale on-chain submission
+        # (e.g. our own pointer left behind by a prior failed cycle) is
+        # enough to bump _consensus_window, which then forces target_window
+        # past the actual physical window and locks the validator out of
+        # the real eval. See 2026-05-01 window-1123 incident.
+        meets, ratio, submitted_stake, total_stake = self._compute_quorum_status(
+            window.window_number,
+        )
+        if not meets:
+            logger.warning(
+                "Window %d: aggregation skipped — quorum not met "
+                "(submitted_stake=%.4f, total_validator_stake=%.4f, "
+                "ratio=%.4f, threshold=%.4f)",
+                window.window_number, submitted_stake, total_stake, ratio,
+                float(getattr(self.config, "quorum_threshold", 0.5)),
+            )
+            return
+
         chain_commitments = fetch_validator_consensus_commitments(
             self.subtensor, self.config.netuid, self.metagraph,
         )


### PR DESCRIPTION

The main loop's aggregation phase enforces a quorum gate (validator.py ~1503-1548) BEFORE invoking `_run_consensus_aggregation`, but `_aggregate_on_startup` and `_full_cycle_on_startup` invoke it directly with no upstream check. Without an internal gate, a single stale on-chain submission (e.g. our own pointer left behind from a prior failed cycle) is enough to bump `_consensus_window`, which then forces `target_window` past the actual physical window and locks the validator out of the real eval cycle.

This was the second of two bugs that caused the 2026-05-01 window-1123 incident. The first (ws-failure-poisons-snapshot) was fixed in PR #213. This PR closes the second: when a single stale pointer for window N sits on chain, startup aggregation no longer treats us-alone as valid consensus — `_consensus_window` stays at N-1, the main loop pushes target_window to N, and the real eval runs as intended.

The fix calls `_compute_quorum_status(window.window_number)` at the top of `_run_consensus_aggregation` and returns early when quorum is not met. This is consistent with what the main loop already does externally and adds defense-in-depth for the startup paths.

Tests: 2 new in TestRunConsensusAggregationQuorumGate verifying that without quorum, `_consensus_window` stays unchanged and chain fetch is not called; with quorum, fetch proceeds. Existing TestAggregateOnStartupConsensusWindowPersist + TestIssue1EpochSkipSemantics still pass.