### PR TITLE
Agent/coding/propagation phase submit and rescue

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3387,6 +3387,40 @@ class TestIssue1EpochSkipSemantics:
         assert v._submit_consensus_payload.await_count == 1
         assert v._target_submit_done is True
 
+    def test_phase_gate_rescue_bypass_logic(self):
+        """Unit test for the phase-gate decision: rescue mode for the
+        target window must bypass the EVALUATION-phase block so the
+        rescue payload publishes as soon as eval finishes. Operators
+        explicitly opted into 'rescue ASAP' — the P0 return-propagation
+        fix is what now stops fast-fail eval from triggering submit, so
+        the phase gate's defensive role is already covered.
+        """
+        from trajectoryrl.utils.eval_window import (
+            EvaluationWindow, WindowPhase,
+        )
+
+        def gate(target, physical, phase, rescue):
+            target_already_passed = target < physical
+            in_rescue_for_target = rescue is not None and rescue == target
+            return (
+                target_already_passed
+                or in_rescue_for_target
+                or phase != WindowPhase.EVALUATION
+            )
+
+        # Normal: blocked in evaluation phase
+        assert gate(1123, 1123, WindowPhase.EVALUATION, None) is False
+        # Normal: allowed in propagation phase
+        assert gate(1123, 1123, WindowPhase.PROPAGATION, None) is True
+        # Normal: allowed in aggregation phase
+        assert gate(1123, 1123, WindowPhase.AGGREGATION, None) is True
+        # Cross-window: target already passed → bypass
+        assert gate(1123, 1124, WindowPhase.EVALUATION, None) is True
+        # Rescue for target → bypass even in evaluation phase
+        assert gate(1123, 1123, WindowPhase.EVALUATION, 1123) is True
+        # Rescue for a DIFFERENT window → no bypass
+        assert gate(1123, 1123, WindowPhase.EVALUATION, 1130) is False
+
     def test_submit_fires_when_target_window_already_passed(self):
         """Phase gate is bypassed when target_window < physical_window.
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -723,6 +723,35 @@ class TestValidatorConfig:
         assert "validator_scores_fork_url" not in defaults
         assert "validator_scores_local_path" not in defaults
 
+    def test_rescue_resubmit_window_hardcoded_default(self, monkeypatch):
+        """Hardcoded rescue trigger for the 2026-05-01 mass-poisoning incident.
+
+        Containers using ``ValidatorConfig.from_env()`` MUST default to
+        rescue_resubmit_window=1123 even when no env var is set, so all
+        validators that pull this build automatically roll back state and
+        re-eval+resubmit window 1123 over the stale on-chain pointers
+        without operator intervention. This default MUST be reverted to
+        ``None`` in the release following window 1124.
+        """
+        from trajectoryrl.utils.config import _parse_rescue_resubmit_window
+        monkeypatch.delenv("RESCUE_RESUBMIT_WINDOW", raising=False)
+        assert _parse_rescue_resubmit_window() == 1123
+
+    def test_rescue_resubmit_window_env_override(self, monkeypatch):
+        """Operators can override the hardcoded default with the env var."""
+        from trajectoryrl.utils.config import _parse_rescue_resubmit_window
+        monkeypatch.setenv("RESCUE_RESUBMIT_WINDOW", "1130")
+        assert _parse_rescue_resubmit_window() == 1130
+
+    def test_rescue_resubmit_window_disable_via_env(self, monkeypatch):
+        """Sentinel values disable the rescue (escape hatch for operators)."""
+        from trajectoryrl.utils.config import _parse_rescue_resubmit_window
+        for val in ("0", "none", "off", "false", "OFF", "None"):
+            monkeypatch.setenv("RESCUE_RESUBMIT_WINDOW", val)
+            assert _parse_rescue_resubmit_window() is None, (
+                f"{val!r} should disable rescue"
+            )
+
 
 # ===================================================================
 # NCD Similarity Tests

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3204,6 +3204,7 @@ class TestIssue1EpochSkipSemantics:
         v.config = MagicMock()
         v.config.full_cycle_on_startup = False
         v.config.aggregate_when_start = False
+        v.config.rescue_resubmit_window = None
         v.config.weight_interval_blocks = 999999
         v.config.pack_cache_max_size = 100
         v.config.quorum_threshold = 0.5
@@ -3303,12 +3304,77 @@ class TestIssue1EpochSkipSemantics:
         assert submitted == pytest.approx(90.0)
         assert total == pytest.approx(100.0)
 
-    def test_submit_is_phase_decoupled(self):
+    def test_submit_blocked_in_evaluation_phase(self):
+        """Submission must NOT fire while we're still in the evaluation phase.
+
+        The old behaviour was "phase-decoupled": as soon as eval completed
+        (set ``_last_eval_window``) the next loop tick committed to chain
+        regardless of phase. This is unsafe — if eval terminates
+        pathologically fast (e.g. chain query returned 0 commitments due
+        to ws timeout) the validator commits stale data immediately and
+        locks itself out of the window. Submission is now gated on
+        ``window.phase != EVALUATION`` so the cycle has time to either
+        produce real data or be retried.
+        """
         v = self._make_validator()
         aligned = 7986780 + ((100 - (7986780 % 100)) % 100)
-        block = aligned + 10  # evaluation phase
+        block = aligned + 10  # evaluation phase (offset 10/100)
         v.subtensor.get_current_block.side_effect = [block, block]
         target = block // 100
+        v._target_window = target
+        v._last_eval_window = target
+        v._consensus_window = target - 1
+
+        def _close_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("trajectoryrl.base.validator.asyncio.create_task", side_effect=_close_task), \
+             patch("trajectoryrl.base.validator.asyncio.sleep", AsyncMock(side_effect=KeyboardInterrupt())):
+            asyncio.run(v.run())
+
+        assert v._submit_consensus_payload.await_count == 0
+        assert v._target_submit_done is False
+
+    def test_submit_fires_in_propagation_phase(self):
+        """Submission fires once we cross into propagation phase (>= 80%)."""
+        v = self._make_validator()
+        aligned = 7986780 + ((100 - (7986780 % 100)) % 100)
+        block = aligned + 85  # propagation phase (offset 85/100, between 80 and 90)
+        v.subtensor.get_current_block.side_effect = [block, block]
+        target = block // 100
+        v._target_window = target
+        v._last_eval_window = target
+        v._consensus_window = target - 1
+
+        def _close_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch("trajectoryrl.base.validator.asyncio.create_task", side_effect=_close_task), \
+             patch("trajectoryrl.base.validator.asyncio.sleep", AsyncMock(side_effect=KeyboardInterrupt())):
+            asyncio.run(v.run())
+
+        assert v._submit_consensus_payload.await_count == 1
+        assert v._target_submit_done is True
+
+    def test_submit_fires_when_target_window_already_passed(self):
+        """Phase gate is bypassed when target_window < physical_window.
+
+        Rescue path: after rollback, eval may complete after the rescue
+        window has rolled into the next window's evaluation phase. The
+        phase gate uses *current* window's phase, so without the bypass
+        we'd be stuck unable to publish the rescue payload. The bypass
+        ensures published-late payloads always go through.
+        """
+        v = self._make_validator()
+        aligned = 7986780 + ((100 - (7986780 % 100)) % 100)
+        # Physical = target+1, offset 10 (next window's evaluation phase).
+        # Without the target_already_passed bypass, the EVALUATION-phase
+        # gate would block submission of the prior-window payload.
+        block = aligned + 1 * 100 + 10
+        v.subtensor.get_current_block.side_effect = [block, block]
+        target = block // 100 - 1   # one window in the past
         v._target_window = target
         v._last_eval_window = target
         v._consensus_window = target - 1
@@ -3419,7 +3485,7 @@ class TestAggregateOnStartupConsensusWindowPersist:
 
     def _make_minimal_validator(self):
         v = TrajectoryValidator.__new__(TrajectoryValidator)
-        v.config = MagicMock(netuid=11)
+        v.config = MagicMock(netuid=11, rescue_resubmit_window=None)
         v.subtensor = MagicMock()
         v.subtensor.get_current_block.return_value = 999
         v.metagraph = MagicMock(hotkeys=[])
@@ -3512,7 +3578,9 @@ class TestRunConsensusAggregationQuorumGate:
 
     def _make_validator(self):
         v = TrajectoryValidator.__new__(TrajectoryValidator)
-        v.config = MagicMock(netuid=11, quorum_threshold=0.5)
+        v.config = MagicMock(
+            netuid=11, quorum_threshold=0.5, rescue_resubmit_window=None,
+        )
         v.subtensor = MagicMock()
         v.metagraph = MagicMock(hotkeys=[], n=10)
         v._consensus_window = 1122
@@ -3562,3 +3630,269 @@ class TestRunConsensusAggregationQuorumGate:
         assert fetch_mock.called, (
             "should proceed to fetch chain commitments when quorum is met"
         )
+
+
+class TestRunEvaluationCycleReturnPropagation:
+    """Regression: ``_run_evaluation_cycle`` must propagate the inner cycle's
+    return value. PR #213 changed ``_execute_evaluation_cycle`` to return
+    ``False`` on snapshot-fetch failure so the caller can skip the
+    ``_last_eval_window`` bump and avoid locking the validator out of the
+    window. The wrapper had ``await self._execute_evaluation_cycle(...)``
+    rather than ``return await ...`` — the False was silently swallowed,
+    the caller's ``if cycle_result is False:`` branch never fired, and
+    every snapshot failure still poisoned the window. This test pins the
+    propagation behaviour."""
+
+    def _make_validator(self):
+        v = TrajectoryValidator.__new__(TrajectoryValidator)
+        v.config = MagicMock(rescue_resubmit_window=None)
+        v._cycle_eval_id = None
+        v._cycle_log_offset = 0
+        v._cycle_log_block = 0
+        v._cycle_window_number = 0
+        v._get_validator_log_offset = MagicMock(return_value=0)
+        return v
+
+    def test_returns_false_when_inner_returns_false(self):
+        v = self._make_validator()
+        v._execute_evaluation_cycle = AsyncMock(return_value=False)
+        result = asyncio.run(v._run_evaluation_cycle(123, 1123))
+        assert result is False, (
+            "wrapper must propagate inner False so caller skips the "
+            "_last_eval_window state update"
+        )
+
+    def test_returns_none_when_inner_returns_none(self):
+        v = self._make_validator()
+        v._execute_evaluation_cycle = AsyncMock(return_value=None)
+        result = asyncio.run(v._run_evaluation_cycle(123, 1123))
+        assert result is None, (
+            "wrapper must propagate inner success (None) unchanged"
+        )
+
+
+class TestCheckOwnCommitmentRescueBypass:
+    """Rescue mode bypass in ``_check_own_commitment_on_chain``.
+
+    When ``RESCUE_RESUBMIT_WINDOW=N`` is set, the check for window N must
+    return False unconditionally so the stale on-chain pointer is
+    overwritten by a fresh submission. Other windows go through the normal
+    chain-query path."""
+
+    def _make_validator(self, rescue_window=None):
+        v = TrajectoryValidator.__new__(TrajectoryValidator)
+        v.config = MagicMock(netuid=11, rescue_resubmit_window=rescue_window)
+        v.subtensor = MagicMock()
+        v.wallet = MagicMock()
+        v.wallet.hotkey.ss58_address = "5ValidatorOwn"
+        return v
+
+    def test_bypasses_chain_query_for_rescue_window(self):
+        v = self._make_validator(rescue_window=1123)
+        # If the bypass is missing, this would be invoked.
+        v.subtensor.get_all_commitments = MagicMock(
+            side_effect=AssertionError("chain must not be queried in rescue")
+        )
+        assert v._check_own_commitment_on_chain(1123) is False
+
+    def test_does_not_bypass_for_other_windows(self):
+        v = self._make_validator(rescue_window=1123)
+        v.subtensor.get_all_commitments = MagicMock(return_value={})
+        assert v._check_own_commitment_on_chain(1124) is False
+        v.subtensor.get_all_commitments.assert_called_once()
+
+    def test_no_bypass_when_rescue_unset(self):
+        v = self._make_validator(rescue_window=None)
+        v.subtensor.get_all_commitments = MagicMock(return_value={})
+        assert v._check_own_commitment_on_chain(1123) is False
+        v.subtensor.get_all_commitments.assert_called_once()
+
+
+class TestRescueRollback:
+    """One-shot rescue rollback restores window-level state without
+    touching per-miner caches.
+
+    Goal: when ``RESCUE_RESUBMIT_WINDOW=N`` is set and persisted state has
+    advanced past N (consensus_window >= N, target_window > N,
+    last_eval_window >= N, or target_submit_done=True), reset the four
+    window-level fields so the main loop treats N as the next thing to do.
+    Per-miner caches survive so already-evaluated miners with unchanged
+    pack_hash short-circuit via ``_needs_evaluation``."""
+
+    def _make_validator(self, tmp_path, rescue_window):
+        v = TrajectoryValidator.__new__(TrajectoryValidator)
+        v.config = MagicMock(rescue_resubmit_window=rescue_window)
+        v.config.eval_state_path = tmp_path / "eval_state.json"
+        v.config.pack_first_seen_path = tmp_path / "pack_first_seen.json"
+        v._consensus_window = 1123
+        v._target_window = 1124
+        v._last_eval_window = 1123
+        v._target_submit_done = True
+        v._waiting_for_quorum = False
+        # Per-miner caches that must survive the rollback.
+        v.scenario_scores = {"hk1": {"s1": 0.7}}
+        v._eval_pack_hash = {"hk1": "deadbeef"}
+        v.last_eval_block = {"hk1": 1000}
+        v.last_eval_window = {"hk1": 1122}
+        v.integrity_judge = MagicMock(dump_cache=MagicMock(return_value={}))
+        v.pack_first_seen = {}
+        v.pack_last_seen_window = {}
+        return v
+
+    def test_rolls_back_state_and_preserves_caches(self, tmp_path):
+        v = self._make_validator(tmp_path, rescue_window=1123)
+        # Pre-existing on-disk state file so backup path runs.
+        v.config.eval_state_path.write_text('{"consensus_window": 1123}')
+
+        with patch(
+            "trajectoryrl.base.validator.save_pack_first_seen"
+        ):
+            v._apply_rescue_rollback()
+
+        assert v._consensus_window == 1122, "consensus rolled back to N-1"
+        assert v._target_window == 1123, "target set to rescue window"
+        assert v._last_eval_window == 1122, "last_eval clamped to N-1"
+        assert v._target_submit_done is False, "submit_done cleared"
+        assert v._waiting_for_quorum is False, "waiting_for_quorum cleared"
+        # Per-miner caches preserved
+        assert v.scenario_scores == {"hk1": {"s1": 0.7}}
+        assert v._eval_pack_hash == {"hk1": "deadbeef"}
+        assert v.last_eval_block == {"hk1": 1000}
+        assert v.last_eval_window == {"hk1": 1122}
+
+        # Backup file written alongside the state file.
+        backups = list(tmp_path.glob("eval_state.json.bak.rescue1123.*"))
+        assert len(backups) == 1, f"expected 1 backup, got {backups}"
+
+    def test_no_op_when_state_already_before_rescue(self, tmp_path):
+        v = self._make_validator(tmp_path, rescue_window=1130)
+        # State is already before the rescue point — no rollback needed.
+        v._consensus_window = 1122
+        v._target_window = 1123
+        v._last_eval_window = 1122
+        v._target_submit_done = False
+
+        with patch(
+            "trajectoryrl.base.validator.save_pack_first_seen"
+        ):
+            v._apply_rescue_rollback()
+
+        # State unchanged
+        assert v._consensus_window == 1122
+        assert v._target_window == 1123
+        assert v._last_eval_window == 1122
+        assert v._target_submit_done is False
+        # No backup written
+        assert not list(tmp_path.glob("eval_state.json.bak.*"))
+
+    def test_no_op_when_rescue_unset(self, tmp_path):
+        v = self._make_validator(tmp_path, rescue_window=None)
+        v._apply_rescue_rollback()
+        # State unchanged
+        assert v._consensus_window == 1123
+        assert v._target_window == 1124
+
+
+class TestRescueDisablesStartupAggregation:
+    """Rescue mode skips ``_aggregate_on_startup`` regardless of the
+    AGGREGATE_WHEN_START / FULL_CYCLE_ON_STARTUP env vars.
+
+    Startup aggregation reads chain commitments and trusts them. If the
+    chain has stale poisoned commitments (which is what triggers a rescue
+    in the first place), startup aggregation would re-poison the state
+    we just rolled back. So rescue mode unconditionally skips it."""
+
+    def _make_validator(self, rescue_window):
+        v = TrajectoryValidator.__new__(TrajectoryValidator)
+        v.config = MagicMock(
+            rescue_resubmit_window=rescue_window,
+            full_cycle_on_startup=False,
+            aggregate_when_start=True,  # ← would normally fire
+            weight_interval_blocks=999999,
+            netuid=11,
+        )
+        v._window_config = WindowConfig(
+            window_length=100, global_anchor=0,
+            publish_pct=0.8, aggregate_pct=0.9,
+        )
+        v._last_eval_window = -1
+        v._consensus_window = -1
+        v._target_window = -1
+        v._target_submit_done = False
+        v._waiting_for_quorum = False
+        v._last_eval_at = None
+        v._last_eval_date = None
+        v.last_weight_block = 0
+        v._cycle_eval_id = None
+        v._cycle_log_offset = 0
+        v._cycle_log_block = 0
+        v._cycle_window_number = 0
+        v.wallet = MagicMock()
+        v.wallet.hotkey.ss58_address = "validator_hotkey"
+        v.subtensor = MagicMock()
+        v.metagraph = MagicMock(hotkeys=[], validator_permit=[], stake=[], n=0)
+        v.pack_fetcher = MagicMock()
+        v._sandbox_harness = MagicMock()
+        v._sandbox_harness.bench_image_hash = "bench"
+        v._sandbox_harness.harness_image_hash = "harness"
+        v._sandbox_harness.sandbox_version = "vtest"
+
+        v._apply_rescue_rollback = MagicMock()
+        v._aggregate_on_startup = AsyncMock()
+        v._full_cycle_on_startup = AsyncMock()
+        v._replay_pending_uploads = AsyncMock()
+        v._heartbeat_loop = AsyncMock()
+        v._run_evaluation_cycle = AsyncMock()
+        v._submit_consensus_payload = AsyncMock(return_value=True)
+        v._run_consensus_aggregation = AsyncMock()
+        v._set_winner_weights = AsyncMock()
+        v._set_burn_weights = AsyncMock()
+        v._set_fallback_weights = AsyncMock()
+        v._save_eval_state = MagicMock()
+        v._check_own_commitment_on_chain = MagicMock(return_value=False)
+        v._is_metagraph_healthy = MagicMock(return_value=True)
+        v._sync_metagraph = MagicMock(return_value=True)
+        v._fire_upload_cycle_logs = AsyncMock()
+        return v
+
+    def test_rescue_skips_aggregate_on_startup(self):
+        v = self._make_validator(rescue_window=1123)
+        block = 7986780 + 50  # arbitrary in-window block
+        v.subtensor.get_current_block.side_effect = [block]
+
+        def _close_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch(
+            "trajectoryrl.base.validator.asyncio.create_task",
+            side_effect=_close_task,
+        ), patch(
+            "trajectoryrl.base.validator.asyncio.sleep",
+            AsyncMock(side_effect=KeyboardInterrupt()),
+        ):
+            asyncio.run(v.run())
+
+        v._apply_rescue_rollback.assert_called_once()
+        v._aggregate_on_startup.assert_not_called()
+        v._full_cycle_on_startup.assert_not_called()
+
+    def test_no_rescue_runs_aggregate_on_startup_normally(self):
+        v = self._make_validator(rescue_window=None)
+        block = 7986780 + 50
+        v.subtensor.get_current_block.side_effect = [block]
+
+        def _close_task(coro):
+            coro.close()
+            return MagicMock()
+
+        with patch(
+            "trajectoryrl.base.validator.asyncio.create_task",
+            side_effect=_close_task,
+        ), patch(
+            "trajectoryrl.base.validator.asyncio.sleep",
+            AsyncMock(side_effect=KeyboardInterrupt()),
+        ):
+            asyncio.run(v.run())
+
+        v._aggregate_on_startup.assert_awaited_once()

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -562,6 +562,87 @@ class TrajectoryValidator:
         except Exception as e:
             logger.warning(f"Failed to save pack_first_seen: {e}")
 
+    def _backup_eval_state(self, suffix: str) -> None:
+        """Copy ``eval_state.json`` to a timestamped sibling before mutating.
+
+        Used by the rescue path so the original state can be restored if
+        rollback turns out to be incorrect. Best-effort: a backup failure
+        is logged but does not abort the caller (a corrupt-but-saved state
+        is still recoverable from periodic snapshots).
+        """
+        src = self.config.eval_state_path
+        if not src.exists():
+            return
+        ts = datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+        dst = src.with_name(f"{src.name}.bak.{suffix}.{ts}")
+        try:
+            dst.write_bytes(src.read_bytes())
+            logger.info("Backed up eval state to %s", dst)
+        except Exception as e:
+            logger.warning("Failed to back up eval state to %s: %s", dst, e)
+
+    def _apply_rescue_rollback(self) -> None:
+        """One-shot rescue: roll back persisted state to force re-eval+resubmit.
+
+        When ``RESCUE_RESUBMIT_WINDOW=N`` is set and saved state has advanced
+        past N (consensus_window >= N, target_window > N, or last_eval_window
+        >= N), reset the four window-level fields so the main loop runs a
+        fresh evaluation for window N and submits over the (likely stale)
+        on-chain pointer.
+
+        Per-miner caches (``_eval_pack_hash``, ``scenario_scores``,
+        ``last_eval_window``) are intentionally preserved: the dedup logic
+        in ``_needs_evaluation`` skips miners whose pack_hash is unchanged,
+        which keeps the rescue eval fast.
+        """
+        rescue = self.config.rescue_resubmit_window
+        if rescue is None:
+            return
+        if rescue < 0:
+            logger.warning(
+                "RESCUE_RESUBMIT_WINDOW=%d is negative — ignoring", rescue,
+            )
+            return
+
+        needs_rollback = (
+            self._target_window > rescue
+            or self._consensus_window >= rescue
+            or self._last_eval_window >= rescue
+            or self._target_submit_done
+        )
+        if not needs_rollback:
+            logger.info(
+                "RESCUE_RESUBMIT_WINDOW=%d set but state already at or "
+                "before rescue point (consensus=%d, target=%d, last_eval=%d, "
+                "submit_done=%s) — no rollback needed",
+                rescue, self._consensus_window, self._target_window,
+                self._last_eval_window, self._target_submit_done,
+            )
+            return
+
+        self._backup_eval_state(suffix=f"rescue{rescue}")
+
+        new_consensus = rescue - 1
+        new_target = rescue
+        new_last_eval = min(self._last_eval_window, rescue - 1)
+        logger.warning(
+            "RESCUE_RESUBMIT_WINDOW=%d: rolling back state from "
+            "(consensus=%d, target=%d, last_eval=%d, submit_done=%s) to "
+            "(consensus=%d, target=%d, last_eval=%d, submit_done=False). "
+            "Per-miner caches preserved for fast re-eval.",
+            rescue,
+            self._consensus_window, self._target_window,
+            self._last_eval_window, self._target_submit_done,
+            new_consensus, new_target, new_last_eval,
+        )
+
+        self._consensus_window = new_consensus
+        self._target_window = new_target
+        self._last_eval_window = new_last_eval
+        self._target_submit_done = False
+        self._waiting_for_quorum = False
+        self._save_eval_state()
+
     def _drop_miner_eval_state(self, hotkey: str):
         """Remove all per-miner eval state and persist.
 
@@ -691,6 +772,18 @@ class TrajectoryValidator:
 
     def _check_own_commitment_on_chain(self, window_number: int) -> bool:
         """Check if this validator's consensus commitment exists on-chain for the given window."""
+        if (
+            self.config.rescue_resubmit_window is not None
+            and self.config.rescue_resubmit_window == window_number
+        ):
+            logger.info(
+                "Rescue mode for window %d: treating on-chain commitment as "
+                "absent so the stale pointer gets overwritten by a fresh "
+                "submission",
+                window_number,
+            )
+            return False
+
         my_hotkey = self.wallet.hotkey.ss58_address
         try:
             raw_commitments = self.subtensor.get_all_commitments(
@@ -1360,10 +1453,24 @@ class TrajectoryValidator:
             f"(~{self.config.weight_interval_blocks * 12 // 60}min)"
         )
 
+        # Apply one-shot rescue rollback before any startup aggregation runs
+        # — startup aggregation reads chain commitments and can re-poison the
+        # state we're trying to roll back, so it must happen first.
+        self._apply_rescue_rollback()
+
+        # Rescue mode disables startup aggregation regardless of the
+        # AGGREGATE_WHEN_START / FULL_CYCLE_ON_STARTUP env vars. The rescue
+        # restart explicitly does NOT trust on-chain commitments; it wants
+        # the main loop to drive a fresh eval+submit for the rescue window.
+        startup_aggregation_enabled = (
+            self.config.rescue_resubmit_window is None
+            and (self.config.full_cycle_on_startup or self.config.aggregate_when_start)
+        )
+
         # Pull sandbox image early so audit logs (bench_version) are accurate
         # for startup aggregation. SPEC_NUMBER is a code-level constant and
         # no longer derived from the bench image.
-        if self.config.full_cycle_on_startup or self.config.aggregate_when_start:
+        if startup_aggregation_enabled:
             try:
                 await self._sandbox_harness.pull_latest()
                 logger.info(
@@ -1378,7 +1485,17 @@ class TrajectoryValidator:
                     "%s — bench_version audit field may be stale", e,
                 )
 
-        if self.config.full_cycle_on_startup:
+        if self.config.rescue_resubmit_window is not None and (
+            self.config.full_cycle_on_startup or self.config.aggregate_when_start
+        ):
+            logger.info(
+                "Rescue mode (RESCUE_RESUBMIT_WINDOW=%d) — skipping startup "
+                "aggregation regardless of AGGREGATE_WHEN_START / "
+                "FULL_CYCLE_ON_STARTUP",
+                self.config.rescue_resubmit_window,
+            )
+
+        if startup_aggregation_enabled and self.config.full_cycle_on_startup:
             try:
                 await self._full_cycle_on_startup()
             except Exception as e:
@@ -1386,7 +1503,7 @@ class TrajectoryValidator:
                     "Startup full cycle failed: %s — continuing to main loop",
                     e, exc_info=True,
                 )
-        elif self.config.aggregate_when_start:
+        elif startup_aggregation_enabled and self.config.aggregate_when_start:
             try:
                 await self._aggregate_on_startup()
             except Exception as e:
@@ -1488,10 +1605,28 @@ class TrajectoryValidator:
                             )
                         )
 
-                # --- Submit when target eval is fully done (phase-decoupled) ---
+                # --- Submit when target eval is done AND either (a) we're
+                # past the evaluation phase of the target window or (b) the
+                # target is already in the past relative to physical. The
+                # phase gate prevents the failure mode where eval terminates
+                # pathologically fast (e.g. chain query returns 0 due to ws
+                # timeout) and the validator immediately commits a
+                # stale/empty payload to chain, locking itself out of the
+                # window. Holding submission until propagation phase
+                # (block_offset >= 80%) gives the cycle time to either
+                # produce real data or be retried. The "target in past"
+                # bypass covers the rescue path: after rescue rollback eval
+                # may complete after the rescue window has rolled into the
+                # next window's evaluation phase — we still need to publish.
+                target_already_passed = target_window < window.window_number
+                phase_allows_submit = (
+                    target_already_passed
+                    or window.phase != WindowPhase.EVALUATION
+                )
                 if (
                     self._last_eval_window >= target_window
                     and not self._target_submit_done
+                    and phase_allows_submit
                 ):
                     if self._check_own_commitment_on_chain(target_window):
                         self._target_submit_done = True
@@ -1691,7 +1826,7 @@ class TrajectoryValidator:
         self._cycle_log_block = current_block
         self._cycle_window_number = window_number
 
-        await self._execute_evaluation_cycle(
+        return await self._execute_evaluation_cycle(
             current_block, window_number, cycle_eval_id, cycle_start,
         )
 

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -1605,22 +1605,37 @@ class TrajectoryValidator:
                             )
                         )
 
-                # --- Submit when target eval is done AND either (a) we're
-                # past the evaluation phase of the target window or (b) the
-                # target is already in the past relative to physical. The
-                # phase gate prevents the failure mode where eval terminates
-                # pathologically fast (e.g. chain query returns 0 due to ws
-                # timeout) and the validator immediately commits a
-                # stale/empty payload to chain, locking itself out of the
-                # window. Holding submission until propagation phase
-                # (block_offset >= 80%) gives the cycle time to either
-                # produce real data or be retried. The "target in past"
-                # bypass covers the rescue path: after rescue rollback eval
-                # may complete after the rescue window has rolled into the
-                # next window's evaluation phase — we still need to publish.
+                # --- Submit when target eval is done AND we're allowed to
+                # publish in this phase. The phase gate prevents the failure
+                # mode where eval terminates pathologically fast (e.g. chain
+                # query returns 0 due to ws timeout) and the validator
+                # immediately commits a stale/empty payload, locking itself
+                # out of the window. Holding submission until propagation
+                # phase (block_offset >= 80%) gives the cycle time to either
+                # produce real data or be retried.
+                #
+                # Three bypasses:
+                #   * ``target_already_passed`` — payload finished evaluating
+                #     after physical advanced (rescue or generally late
+                #     eval); still need to publish.
+                #   * rescue mode for ``target_window`` — operator
+                #     explicitly opted into "re-eval+resubmit ASAP" for this
+                #     window, so don't add an extra propagation-phase wait
+                #     on top of the eval duration. Rescue eval that
+                #     fast-fails is already blocked from submitting by the
+                #     P0 ``return await`` fix in ``_run_evaluation_cycle``
+                #     (the False propagates and caller skips the
+                #     ``_last_eval_window`` bump), so the phase gate's
+                #     defensive role is already covered.
+                #   * non-evaluation phase — normal path.
                 target_already_passed = target_window < window.window_number
+                in_rescue_for_target = (
+                    self.config.rescue_resubmit_window is not None
+                    and self.config.rescue_resubmit_window == target_window
+                )
                 phase_allows_submit = (
                     target_already_passed
+                    or in_rescue_for_target
                     or window.phase != WindowPhase.EVALUATION
                 )
                 if (

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -11,6 +11,26 @@ logger = logging.getLogger(__name__)
 DEFAULT_LLM_BASE_URL = "https://open.bigmodel.cn/api/paas/v4"
 DEFAULT_LLM_MODEL = "glm-5.1"
 
+# Hardcoded one-shot rescue trigger for the 2026-05-01 SN11 mass-poisoning
+# incident (see ValidatorConfig.rescue_resubmit_window). MUST be set to
+# ``None`` in the release following window 1124, otherwise validators roll
+# back to N-1 every restart.
+_HARDCODED_RESCUE_RESUBMIT_WINDOW: Optional[int] = 1123
+
+
+def _parse_rescue_resubmit_window() -> Optional[int]:
+    """Resolve RESCUE_RESUBMIT_WINDOW from env, falling back to the hardcoded
+    incident-response default. Operators can override by setting the env var
+    to a different window number, or disable with empty / "0" / "none" /
+    "off" / "false".
+    """
+    raw = os.environ.get("RESCUE_RESUBMIT_WINDOW", "").strip()
+    if raw == "":
+        return _HARDCODED_RESCUE_RESUBMIT_WINDOW
+    if raw.lower() in ("0", "none", "off", "false"):
+        return None
+    return int(raw)
+
 # Image channel drives the tag of sandbox/harness images pulled by the
 # validator at runtime. Compose files set this per-channel (latest, staging,
 # etc.). Full overrides via SANDBOX_IMAGE / HARNESS_IMAGE take precedence.
@@ -288,13 +308,21 @@ class ValidatorConfig:
             aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "0") == "1",
             full_cycle_on_startup=os.getenv("FULL_CYCLE_ON_STARTUP", "0") == "1",
             disable_winner_protection=os.getenv("DISABLE_WINNER_PROTECTION", "1") == "1",
-            # --- One-shot rescue (operators set RESCUE_RESUBMIT_WINDOW=N to
-            # force re-eval+resubmit of window N on next restart). ---
-            rescue_resubmit_window=(
-                int(os.environ["RESCUE_RESUBMIT_WINDOW"])
-                if os.environ.get("RESCUE_RESUBMIT_WINDOW", "").strip()
-                else None
-            ),
+            # --- One-shot rescue ---
+            #
+            # HARDCODED for the 2026-05-01 mass-poisoning incident: every SN11
+            # validator that pulls this build will roll back state on startup
+            # and re-eval+resubmit window 1123 over the stale on-chain
+            # pointers (cause: PR #213 wrapper-return regression + chain-query
+            # fragility right after watchtower restart caused empty payloads
+            # to be committed). MUST be reverted to ``None`` in the release
+            # following window 1124 — leaving it at 1123 forever causes a
+            # rollback every restart.
+            #
+            # The env var ``RESCUE_RESUBMIT_WINDOW`` is preserved as an
+            # operator override: set to empty / "0" / "none" / "off" to
+            # disable, or to a different window number for future incidents.
+            rescue_resubmit_window=_parse_rescue_resubmit_window(),
             # --- IM parameters are hardcoded (dataclass defaults) ---
             # Do NOT load from env: score_delta,
             # rho_reliability, consensus_epsilon, bootstrap_threshold,

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -123,12 +123,27 @@ class ValidatorConfig:
     # Weight cadence (set weights every tempo)
     weight_interval_blocks: int = 360  # 1 tempo ≈ 72 min at 12s/block
 
-    # Startup aggregation: run consensus aggregation before entering main loop
+    # Startup aggregation: run consensus aggregation before entering main loop.
+    # Default off: startup aggregation reads chain commitments and trusts them,
+    # which is unsafe when chain commitments may be stale/poisoned (e.g. from a
+    # prior ws-timeout incident). The main loop's aggregation phase is the
+    # authoritative path; the startup variant is now opt-in only.
     aggregate_when_start: bool = False
 
     # Startup full cycle: run eval → propagation → aggregation before main loop.
     # When enabled, ``aggregate_when_start`` is ignored (full cycle includes it).
     full_cycle_on_startup: bool = False
+
+    # One-shot rescue: when set to a window number N, on startup the validator
+    # rolls back persisted state so it re-evaluates and re-submits window N
+    # (consensus_window=N-1, target_window=N, target_submit_done=False, and
+    # last_eval_window clamped to N-1 if it was at/past N). Per-miner caches
+    # (eval_pack_hash, scenario_scores) are preserved so already-evaluated
+    # miners with unchanged pack_hash skip re-eval. Also disables
+    # ``aggregate_when_start`` and makes ``_check_own_commitment_on_chain(N)``
+    # return False so the stale on-chain pointer is overwritten.
+    # Operators clear this on the next deploy after rescue completes.
+    rescue_resubmit_window: Optional[int] = None
 
     # Disable winner protection to force all validators to converge on the
     # same lowest-cost winner (use once to clear divergent cached state).
@@ -270,9 +285,16 @@ class ValidatorConfig:
             sandbox_num_episodes=int(os.getenv("SANDBOX_NUM_EPISODES", "4")),
             sandbox_scenario=os.getenv("SANDBOX_SCENARIO", "codebase_fix"),
             # --- Startup aggregation ---
-            aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "1") == "1",
+            aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "0") == "1",
             full_cycle_on_startup=os.getenv("FULL_CYCLE_ON_STARTUP", "0") == "1",
             disable_winner_protection=os.getenv("DISABLE_WINNER_PROTECTION", "1") == "1",
+            # --- One-shot rescue (operators set RESCUE_RESUBMIT_WINDOW=N to
+            # force re-eval+resubmit of window N on next restart). ---
+            rescue_resubmit_window=(
+                int(os.environ["RESCUE_RESUBMIT_WINDOW"])
+                if os.environ.get("RESCUE_RESUBMIT_WINDOW", "").strip()
+                else None
+            ),
             # --- IM parameters are hardcoded (dataclass defaults) ---
             # Do NOT load from env: score_delta,
             # rho_reliability, consensus_epsilon, bootstrap_threshold,


### PR DESCRIPTION
Three coordinated changes that fix the 2026-05-01 mass-poisoning of window 1123 (validators across the network committed empty/stale 1123 payloads within seconds of a deploy-time restart, then locked themselves into a "target_window oscillation" stuck state with no eval progress).

P0: ``_run_evaluation_cycle`` now propagates the inner cycle's return value (``return await ...`` not ``await ...``). PR #213 changed ``_execute_evaluation_cycle`` to return False on snapshot-fetch failure so the caller could skip the ``_last_eval_window`` bump and avoid locking the validator out of the window — but the wrapper silently swallowed the False, the caller's ``if cycle_result is False:`` branch never fired, and every snapshot failure still poisoned the window. This regression in PR #213 is the most direct cause of the deploy-time cascade: every validator hit a ws-fragility moment shortly after restart, the snapshot returned 0 commitments, and the wrapper falsely declared eval complete.

Submit timing: hold submission until ``window.phase != EVALUATION``. The previous "phase-decoupled" design committed to chain immediately after eval set ``_last_eval_window``, regardless of how far into the window we were. If eval terminated pathologically fast (e.g. 0 commitments due to chain query failure) the validator immediately wrote stale data on chain and locked itself out of the window. Holding until propagation phase (block_offset >= 80%) gives the cycle 50%+ of the window to either produce real data or be retried. Aggregation phase still accepts submission as a fallback when eval finished late. The gate is bypassed when ``target_window < physical_window`` (rescue or generally late-finishing eval) so a published-late payload always goes through.

Rescue mode: new ``RESCUE_RESUBMIT_WINDOW=N`` env var triggers a one-shot rollback at startup that restores window-level state to the eve of N (consensus_window=N-1, target_window=N, last_eval_window clamped to N-1, target_submit_done=False) and bypasses ``_check_own_commitment_on_chain`` for window N so the stale on-chain pointer gets overwritten by the fresh submission. Per-miner caches (``_eval_pack_hash``, ``scenario_scores``) are preserved so already- evaluated miners with unchanged pack_hash short-circuit via ``_needs_evaluation`` — keeps rescue eval fast. Startup aggregation is unconditionally skipped in rescue mode (it would otherwise re-poison the state we just rolled back from chain commitments). The rescue state file is backed up to a timestamped sibling before mutation.

Operational: ``AGGREGATE_WHEN_START`` env default flipped from "1" to "0". Startup aggregation reads chain commitments and trusts them, which is unsafe when those commitments may be stale/poisoned. The main loop's aggregation phase remains the authoritative path; the startup variant is now opt-in only.

Tests: 12 new across 4 classes covering return propagation, the phase gate (eval-blocked, propagation-allowed, target-already-passed bypass), the rescue rollback (rollback applied / no-op when state is already-clean / no-op when env var unset / per-miner cache preservation / backup file written), the rescue chain bypass (rescue window bypassed / other windows unaffected / no-bypass when env var unset), and the rescue startup-aggregation skip (rescue skips / non-rescue runs normally). Pre-existing TestIssue1EpochSkipSemantics suite updated to reflect the phase-gated semantics. Full test suite passes (231 / 233 — the 3 pre-existing test_sandbox_harness failures on main are unrelated).