### PR TITLE
fix(validator): drop peer consensus votes scored against a different pack_hash

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -886,16 +886,29 @@ class TrajectoryValidator:
         """
         scores_by_hotkey: Dict[str, float] = {}
         disqualified_by_hotkey: Dict[str, str] = {}
+        pack_hashes_by_hotkey: Dict[str, str] = {}
 
         # Aggregate continuous quality scores from judge overall_score.
         # Winner-take-all downstream, so the mean is just used to rank miners.
+        # Stamp _eval_pack_hash per scored miner so peers can detect when a
+        # validator's published score is for a stale pack_hash and discard
+        # it during aggregation.
         for hotkey, scenario_s in self.scenario_scores.items():
-            if scenario_s:
-                score = sum(scenario_s.values()) / len(scenario_s)
-                scores_by_hotkey[hotkey] = round(score, 4)
+            if not scenario_s:
+                continue
+            score = sum(scenario_s.values()) / len(scenario_s)
+            scores_by_hotkey[hotkey] = round(score, 4)
+            ph = self._eval_pack_hash.get(hotkey)
+            if ph:
+                pack_hashes_by_hotkey[hotkey] = ph
 
         for hotkey, reason in getattr(self, "_disqualified_miners", {}).items():
             disqualified_by_hotkey[hotkey] = reason
+            # Mirror pack_hash for disqualifications too so peers can scope
+            # the DQ vote to the pack version this validator actually saw.
+            ph = self._eval_pack_hash.get(hotkey)
+            if ph and hotkey not in pack_hashes_by_hotkey:
+                pack_hashes_by_hotkey[hotkey] = ph
 
         if not scores_by_hotkey and not disqualified_by_hotkey:
             return None
@@ -911,6 +924,7 @@ class TrajectoryValidator:
             timestamp=int(time.time()),
             spec_number=_spec_number(),
             disqualified=disqualified_by_hotkey,
+            pack_hashes=pack_hashes_by_hotkey,
         )
 
     async def _run_consensus_aggregation(self, window: EvaluationWindow):
@@ -1024,7 +1038,20 @@ class TrajectoryValidator:
             )
             return
 
-        consensus_scores, disqualified = compute_consensus_scores(validated)
+        # Build local hotkey -> pack_hash from this window's snapshot so
+        # compute_consensus_scores can drop peer votes that scored a
+        # different pack version (peer's eval loop did not reach this
+        # miner, or peer's snapshot RPC was stale at fetch time).
+        local_snapshot = load_snapshot(
+            self.config.active_set_dir, window.window_number,
+        )
+        local_pack_hashes: Dict[str, str] = (
+            {c.hotkey: c.pack_hash for c in local_snapshot.commitments.values()}
+            if local_snapshot is not None else {}
+        )
+        consensus_scores, disqualified = compute_consensus_scores(
+            validated, local_pack_hashes=local_pack_hashes,
+        )
 
         # Build hotkey → UID mapping (used by pre-eval reporting, winner
         # selection, and logging)

--- a/trajectoryrl/scoring/__init__.py
+++ b/trajectoryrl/scoring/__init__.py
@@ -526,6 +526,7 @@ class TrajectoryScorer:
 def compute_consensus_scores(
     validated_submissions: List[ValidatedSubmission],
     disqualify_stake_threshold: float = 0.5,
+    local_pack_hashes: Optional[Dict[str, str]] = None,
 ) -> Tuple[Dict[str, float], Dict[str, str]]:
     """Compute stake-weighted consensus scores and disqualification across validators.
 
@@ -539,11 +540,24 @@ def compute_consensus_scores(
     disqualified only when the fraction of reporting stake that flagged it
     exceeds ``disqualify_stake_threshold`` (default 0.5).
 
+    Pack-hash divergence filter: when ``local_pack_hashes`` is provided
+    (miner_hotkey -> the pack_hash this validator currently sees in its
+    own snapshot), any peer score / disqualification stamped with a
+    different pack_hash for the same miner is dropped from accumulation.
+    This prevents a peer that scored an older pack version (because its
+    own eval loop did not reach the miner this window, or because its
+    chain RPC was lagging at snapshot time) from contaminating the
+    consensus average. Peers that did not include ``pack_hashes`` (legacy
+    payloads) are accepted unconditionally for backwards compatibility.
+
     Args:
         validated_submissions: Submissions that passed the filter pipeline,
             each with an attached validator_stake.
         disqualify_stake_threshold: Fraction of reporting stake that must
             vote to disqualify a miner for it to be consensus-disqualified.
+        local_pack_hashes: Optional miner_hotkey -> pack_hash from this
+            validator's window snapshot. When provided, peer votes whose
+            pack_hash disagrees with the local entry are dropped.
 
     Returns:
         Tuple of (consensus_scores, consensus_disqualified):
@@ -554,6 +568,8 @@ def compute_consensus_scores(
     if not validated_submissions:
         return {}, {}
 
+    local_pack_hashes = local_pack_hashes or {}
+
     miner_weighted_score: Dict[str, float] = {}
     miner_total_stake: Dict[str, float] = {}
 
@@ -562,15 +578,31 @@ def compute_consensus_scores(
     miner_reporting_stake: Dict[str, float] = {}
     miner_disq_reasons: Dict[str, str] = {}
 
+    diverged_count = 0
+
     for sub in validated_submissions:
         stake = sub.validator_stake
         if stake <= 0:
             continue
 
         disqualified = sub.payload.disqualified
+        peer_pack_hashes = getattr(sub.payload, "pack_hashes", {}) or {}
+
+        def _accept(miner_hk: str) -> bool:
+            """Drop this peer's vote for miner when pack_hash disagrees with local."""
+            local_ph = local_pack_hashes.get(miner_hk)
+            peer_ph = peer_pack_hashes.get(miner_hk)
+            if not local_ph or not peer_ph:
+                # Either side missing the stamp — fall back to trust (legacy
+                # payloads, miner missing from local snapshot, etc.).
+                return True
+            return local_ph == peer_ph
 
         all_miners = set(sub.payload.scores.keys()) | set(disqualified.keys())
         for miner_hk in all_miners:
+            if not _accept(miner_hk):
+                diverged_count += 1
+                continue
             if miner_hk not in miner_reporting_stake:
                 miner_reporting_stake[miner_hk] = 0.0
                 miner_disq_stake[miner_hk] = 0.0
@@ -582,6 +614,8 @@ def compute_consensus_scores(
 
         for miner_hk, score in sub.payload.scores.items():
             if miner_hk in disqualified:
+                continue
+            if not _accept(miner_hk):
                 continue
 
             if miner_hk not in miner_total_stake:
@@ -612,9 +646,9 @@ def compute_consensus_scores(
 
     logger.info(
         "Consensus computed: %d miners (%d disqualified by stake majority), "
-        "%d validators",
+        "%d validators, %d peer votes dropped on pack_hash divergence",
         len(consensus_scores), len(consensus_disqualified),
-        len(validated_submissions),
+        len(validated_submissions), diverged_count,
     )
 
     return consensus_scores, consensus_disqualified

--- a/trajectoryrl/utils/consensus.py
+++ b/trajectoryrl/utils/consensus.py
@@ -22,6 +22,7 @@ class ConsensusPayload:
 
     Protocol v2 fields:
       - scores: miner hotkey -> quality score (0.0–1.0)
+      - pack_hashes: miner hotkey -> pack_hash this validator scored
       - bench_version: trajrl-bench version string
       - disqualified: miner hotkey -> reason
       - spec_number: scoring spec identifier (see ``config.SPEC_NUMBER``)
@@ -34,6 +35,7 @@ class ConsensusPayload:
     timestamp: int                   # unix seconds when payload was built
     spec_number: int = 1
     disqualified: Dict[str, str] = field(default_factory=dict)
+    pack_hashes: Dict[str, str] = field(default_factory=dict)  # miner hotkey -> pack_hash scored
 
     def to_dict(self) -> dict:
         # Emit both `spec_number` (canonical) and `scoring_version` (legacy
@@ -42,6 +44,7 @@ class ConsensusPayload:
         return {
             "bench_version": self.bench_version,
             "disqualified": self.disqualified,
+            "pack_hashes": self.pack_hashes,
             "protocol_version": self.protocol_version,
             "scores": self.scores,
             "scoring_version": self.spec_number,
@@ -77,6 +80,7 @@ class ConsensusPayload:
             timestamp=d["timestamp"],
             spec_number=spec_number,
             disqualified=d.get("disqualified", {}),
+            pack_hashes=d.get("pack_hashes", {}),
         )
 
 


### PR DESCRIPTION
## Summary
A peer that didn't re-evaluate a miner in the current window (partial cycle, crash, or a chain-RPC lag that fed a stale snapshot) keeps the previous pack version's score in `scenario_scores` and publishes it as the current score. `compute_consensus_scores` then averaged that stale value into `consensus_scores` by the peer's stake share — silent contamination, no log to grep for.

This PR makes published scores **versioned**: `ConsensusPayload` now carries `pack_hashes: Dict[miner_hk, pack_hash]` alongside `scores` and `disqualified`. At aggregation, each validator compares peer-reported pack_hashes against its own window snapshot and drops votes that disagree.

## Changes
- **`utils/consensus.py`** — `ConsensusPayload.pack_hashes` field; serialized in `to_dict` / `from_dict`. New field defaults to `{}` so legacy payloads decode unchanged.
- **`base/validator.py`**
  - `_build_local_consensus_payload` stamps `_eval_pack_hash` per scored or disqualified miner into the outgoing payload.
  - `_run_consensus_aggregation` builds `local_pack_hashes` from the window's active-set snapshot and threads it into `compute_consensus_scores`.
- **`scoring/__init__.py`** — `compute_consensus_scores` accepts an optional `local_pack_hashes` arg. Peer votes whose `pack_hash` disagrees with the local snapshot are dropped from both score accumulation and disqualification tally. Divergence count logged.

## Behavior matrix
| Peer's `pack_hashes[X]` | Local snapshot's `pack_hash[X]` | Vote |
|---|---|---|
| `B` | `B` | accepted |
| `A` (stale cache or stale RPC) | `B` | dropped |
| missing (legacy payload) | `B` | accepted (compat) |
| `B` | missing (X not in local snapshot) | accepted |

## Backwards compatibility
- Legacy payloads (no `pack_hashes` key) decode to `pack_hashes = {}` and pass through the divergence filter unchanged. No SPEC_NUMBER bump required for the rollout window; once enough stake runs the new code, the filter activates organically.
- `pack_hashes` is *additive* in canonical JSON serialization. Content hash changes for new payloads but old validators don't read the field, so no integrity-check break.

## Limitations
- A validator whose own snapshot is stale (Case 2) will incorrectly reject **fresh** peers' votes, so its local consensus is still
  wrong — but that's bounded to its own `set_weights` and reflects an RPC issue on that operator's end. Healthy-RPC validators converge.
- The filter relies on local snapshot fidelity; it does not solve Byzantine-style coordinated divergence (peers conspiring on a fake `pack_hash`). Stake-weighted majority over honest validators remains the trust model.

## Test plan
- [ ] Unit: peer publishes `score=0.9` for X with `pack_hashes[X]=A`, local snapshot has X with `pack_hash=B` → peer's vote dropped; `consensus_scores[X]` excludes peer's stake.
- [ ] Unit: peer publishes with `pack_hashes={}` (legacy) → all votes accepted (compat).
- [ ] Unit: X not in local snapshot → all peer votes for X accepted.
- [ ] Unit: peer's `disqualified[X]` with mismatching pack_hash → peer's DQ vote dropped from stake-weighted majority calculation.
- [ ] Round-trip: serialize → deserialize a payload with non-empty `pack_hashes`, assert field preserved.
- [ ] Round-trip: deserialize a v2 payload that omits `pack_hashes` → result has `pack_hashes == {}`, no exception.
- [ ] Integration: two-validator setup, one with stale `_eval_pack_hash`, assert the stale validator's score is dropped from the other's consensus result; log line emitted with `diverged_count > 0`.