### PR TITLE
[coding-agent] top-N re-check: wipe leader cache at eval cycle start

### DIFF
--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -3703,3 +3703,147 @@ class TestRunEvaluationCycleReturnPropagation:
         )
 
 
+class TestTopNRecheck:
+    """Tests for the anti-cheese top-N cache wipe at eval cycle start.
+
+    Mirrors the lightweight validator factory used by TestPerScenarioEvalState
+    so each test is self-contained with the minimum state needed by
+    `_wipe_top_n_for_recheck` and `_save_eval_state`.
+    """
+
+    def _make_validator(self):
+        v = TrajectoryValidator.__new__(TrajectoryValidator)
+        v.scenario_scores = {}
+        v._eval_pack_hash = {}
+        v.last_eval_block = {}
+        v.last_eval_window = {}
+        v._eval_counts = {}
+        v.latest_token_usage = {}
+        v.latest_model_usage = {}
+        v._save_eval_state = MagicMock()
+        return v
+
+    def _seed(self, v, hotkey, scores):
+        v.scenario_scores[hotkey] = dict(scores)
+        v._eval_pack_hash[hotkey] = f"hash_{hotkey}"
+        v.last_eval_block[hotkey] = 100
+        v.last_eval_window[hotkey] = 10
+        v._eval_counts[hotkey] = 1
+        v.latest_token_usage[hotkey] = {"client_escalation": {"input_tokens": 1}}
+        v.latest_model_usage[hotkey] = {"client_escalation": [{"name": "x"}]}
+
+    def test_wipes_top_3_by_mean(self):
+        v = self._make_validator()
+        # Means: hk_a=0.9, hk_b=0.8, hk_c=0.7, hk_d=0.6, hk_e=0.5
+        for hk, mean in [
+            ("hk_a", 0.9), ("hk_b", 0.8), ("hk_c", 0.7),
+            ("hk_d", 0.6), ("hk_e", 0.5),
+        ]:
+            self._seed(v, hk, {"s1": mean, "s2": mean})
+
+        wiped = v._wipe_top_n_for_recheck(window_number=42)
+
+        assert sorted(wiped) == ["hk_a", "hk_b", "hk_c"]
+        assert "hk_a" not in v.scenario_scores
+        assert "hk_b" not in v.scenario_scores
+        assert "hk_c" not in v.scenario_scores
+        assert v.scenario_scores["hk_d"] == {"s1": 0.6, "s2": 0.6}
+        assert v.scenario_scores["hk_e"] == {"s1": 0.5, "s2": 0.5}
+
+    def test_no_active_set_filter(self):
+        """Selection is from scenario_scores directly, not filtered by
+        any external active-set parameter. (Regression check that the
+        signature is window_number-only.)"""
+        v = self._make_validator()
+        for hk, mean in [("hk_a", 0.9), ("hk_b", 0.8), ("hk_c", 0.7)]:
+            self._seed(v, hk, {"s1": mean})
+
+        wiped = v._wipe_top_n_for_recheck(window_number=42)
+
+        assert sorted(wiped) == ["hk_a", "hk_b", "hk_c"]
+        # Active commitments are not consulted; method takes only window_number.
+
+    def test_tiebreak_by_hotkey_ascending(self):
+        v = self._make_validator()
+        # All four hotkeys have mean 0.8. Top 3 must be the lex-smallest.
+        for hk in ["hk_d", "hk_a", "hk_c", "hk_b"]:
+            self._seed(v, hk, {"s1": 0.8})
+
+        wiped = v._wipe_top_n_for_recheck(window_number=42)
+
+        assert wiped == ["hk_a", "hk_b", "hk_c"]
+        assert "hk_d" in v.scenario_scores
+
+    def test_fewer_than_n_candidates(self):
+        v = self._make_validator()
+        self._seed(v, "hk_a", {"s1": 0.9})
+        self._seed(v, "hk_b", {"s1": 0.8})
+
+        wiped = v._wipe_top_n_for_recheck(window_number=42)
+
+        assert sorted(wiped) == ["hk_a", "hk_b"]
+        assert v.scenario_scores == {}
+
+    def test_empty_cache_noop(self):
+        v = self._make_validator()
+
+        wiped = v._wipe_top_n_for_recheck(window_number=42)
+
+        assert wiped == []
+        v._save_eval_state.assert_not_called()
+
+    def test_skips_hotkeys_with_empty_scenario_dict(self):
+        """A hotkey present in scenario_scores but with an empty inner dict
+        must not be selectable (mean is undefined; treat as no cache)."""
+        v = self._make_validator()
+        v.scenario_scores["hk_empty"] = {}
+        self._seed(v, "hk_a", {"s1": 0.5})
+
+        wiped = v._wipe_top_n_for_recheck(window_number=42)
+
+        assert wiped == ["hk_a"]
+        assert "hk_empty" in v.scenario_scores
+
+    def test_wipe_clears_all_state_stores(self):
+        v = self._make_validator()
+        self._seed(v, "hk_a", {"s1": 0.9})
+
+        v._wipe_top_n_for_recheck(window_number=42)
+
+        for store_name in (
+            "scenario_scores", "_eval_pack_hash",
+            "last_eval_block", "last_eval_window",
+            "_eval_counts", "latest_token_usage", "latest_model_usage",
+        ):
+            assert "hk_a" not in getattr(v, store_name), (
+                f"{store_name} still contains hk_a after wipe"
+            )
+
+    def test_post_wipe_needs_evaluation_returns_true(self):
+        """After wipe, _needs_evaluation should return True for the wiped
+        hotkey on its (unchanged) pack_hash — confirming the wipe actually
+        re-triggers evaluation."""
+        v = self._make_validator()
+        # _needs_evaluation calls self._get_miner_logger; stub it.
+        v._get_miner_logger = MagicMock(return_value=MagicMock())
+        self._seed(v, "hk_a", {"s1": 0.9})
+        original_pack_hash = v._eval_pack_hash["hk_a"]
+
+        assert v._needs_evaluation("hk_a", original_pack_hash, current_window=42) is False
+
+        v._wipe_top_n_for_recheck(window_number=42)
+
+        assert v._needs_evaluation("hk_a", original_pack_hash, current_window=42) is True
+
+    def test_save_called_once_per_invocation(self):
+        v = self._make_validator()
+        for hk, mean in [("hk_a", 0.9), ("hk_b", 0.8), ("hk_c", 0.7)]:
+            self._seed(v, hk, {"s1": mean})
+
+        v._wipe_top_n_for_recheck(window_number=42)
+
+        # One save covers all N wipes (vs N saves if we'd called the
+        # per-miner _drop_miner_eval_state primitive in a loop).
+        assert v._save_eval_state.call_count == 1
+
+

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -29,7 +29,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import bittensor as bt
 import docker.errors
 
-from ..utils.config import ValidatorConfig
+from ..utils.config import TOP_N_RECHECK, ValidatorConfig
 from ..utils.sandbox_harness import TrajectorySandboxHarness, SandboxEvaluationResult
 from ..scoring import TrajectoryScorer
 from ..utils.github import PackFetcher
@@ -587,6 +587,52 @@ class TrajectoryValidator:
                 changed = True
         if changed:
             self._save_eval_state()
+
+    def _wipe_top_n_for_recheck(self, window_number: int) -> List[str]:
+        """Clear cached scores for the top-N miners by mean scenario score
+        so they are forced to re-evaluate this window.
+
+        Anti-cheese: a one-off lucky cached score gets re-verified before
+        influencing consensus. Selection is from the in-memory
+        ``scenario_scores`` cache directly — not filtered to this window's
+        active set, so a top miner briefly absent from the snapshot still
+        has its stale cached score wiped.
+
+        Returns the hotkeys whose state was wiped (for logging / tests).
+        """
+        if TOP_N_RECHECK <= 0:
+            return []
+
+        candidates = [
+            (hk, sum(sc.values()) / len(sc))
+            for hk, sc in self.scenario_scores.items()
+            if sc
+        ]
+        if not candidates:
+            return []
+
+        candidates.sort(key=lambda x: (-x[1], x[0]))
+        top = candidates[:TOP_N_RECHECK]
+
+        for hk, _ in top:
+            for store in (
+                self.scenario_scores,
+                self._eval_pack_hash,
+                self.last_eval_block,
+                self.last_eval_window,
+                self._eval_counts,
+                self.latest_token_usage,
+                self.latest_model_usage,
+            ):
+                store.pop(hk, None)
+        self._save_eval_state()
+
+        logger.info(
+            "Top-%d re-check (window %d): wiped cache for %s",
+            TOP_N_RECHECK, window_number,
+            ", ".join(f"{hk[:8]}(mean={m:.4f})" for hk, m in top),
+        )
+        return [hk for hk, _ in top]
 
     # ------------------------------------------------------------------
     # Eval state update
@@ -1830,6 +1876,14 @@ class TrajectoryValidator:
             logger.warning("No active miners with valid commitments!")
             await self._set_fallback_weights()
             return
+
+        # Anti-cheese: force re-eval of the local top-N so a one-off lucky
+        # cached score doesn't keep influencing consensus. Gated on
+        # non-empty active set — when the runtime filter removes every
+        # miner the cycle short-circuits to fallback/burn anyway, so
+        # wiping cache here would just discard signal we'd want for the
+        # next window's consensus payload.
+        self._wipe_top_n_for_recheck(window.window_number)
 
         # 4. Evaluate miners (scenarios selected by sandbox image).
         # Pack-hash dedup is handled inside the loop via `pack_first_seen`

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -42,6 +42,12 @@ SPEC_NUMBER = 7
 # removed after one validator release cycle.
 SCORING_VERSION = SPEC_NUMBER
 
+# At the start of each eval window, wipe cached scores for the local top-N
+# miners (ranked by mean scenario score) so they are forced to re-evaluate
+# this window. Anti-cheese: a one-off lucky cached score gets re-verified
+# before influencing consensus. Set to 0 to disable.
+TOP_N_RECHECK = 3
+
 
 @dataclass
 class ValidatorConfig:


### PR DESCRIPTION
Adds a per-window anti-cheese pass: at the start of _execute_evaluation_cycle (after the snapshot is acquired and the empty-active-commitments early return), the validator wipes its cached scenario_scores for the local top-N miners (ranked by mean scenario score, tiebreak by hotkey ascending). The wiped hotkeys are then naturally re-evaluated by the existing per-miner loop via the cleared `_eval_pack_hash` -> `_needs_evaluation` returns True path.

Cost: at most N extra LLM evals per validator per window. Anti-cheese guard: a one-off lucky cached score gets re-verified before influencing consensus (cf. miner-131 incident: cached 0.6375 from sandbox v3.0-ish vs fresh 0.0594 under sandbox 3.4.0 -- the unchanged pack_hash kept the stale score alive across windows until manually cleared).

Gating: the wipe runs only when active_commitments is non-empty. When the runtime filter removes every miner the cycle short-circuits to _set_fallback_weights (mirror OWNER_UID weights or burn to OWNER_UID) and no eval will run, so wiping cache there would discard signal we'd want for the next non-empty window's consensus payload without producing fresh data.

- TOP_N_RECHECK = 3 hardcoded in trajectoryrl/utils/config.py (set to 0 to disable). No env override, no operator-facing knob.
- _wipe_top_n_for_recheck selects from in-memory scenario_scores directly. A top miner not in this window's active set is still wiped from cache but is not re-evaluated this cycle (would need a chain query for pack_url and would override operator policy in the runtime-filter case -- out of scope).
- One _save_eval_state call covers all N wipes (vs N saves if we'd looped the per-miner _drop_miner_eval_state primitive).
- No new persistent state. Restart inside a window may re-fire the wipe on the (now-current) top-N -- at most ~N extra evals worst case, no correctness impact.

Tests: TestTopNRecheck (9 tests) covering selection by mean, hotkey tiebreak, fewer-than-N, empty cache, empty inner dict skip, all-stores wipe, post-wipe _needs_evaluation regression, single-save-per-invocation. Full suite: 393 passed / 2 skipped (pre-existing test_sandbox_harness failures on main excluded).