### PR TITLE
[coding-agent] switch eval snapshot to /api/v2/validators/epoch_snapshot

### DIFF
--- a/docs/INCENTIVE_MECHANISM.md
+++ b/docs/INCENTIVE_MECHANISM.md
@@ -209,13 +209,33 @@ while running:
 
 ### Deterministic Active-Set Snapshot
 
-Each target window persists a frozen miner set as `active_set_window_{N}.json`:
+The eval target set for epoch N is fetched once per cycle from `POST /api/v2/validators/epoch_snapshot` (see VALIDATOR_OPERATIONS.md for the request shape). The endpoint absorbs the on-chain commitment scan and the per-miner pre-eval pipeline; its response is **immutable** for a given epoch — every validator that calls with `epoch_number=N` gets byte-identical bytes regardless of when they call. Cross-validator determinism follows directly from this guarantee, not from any local filter the validator applies.
+
+Each entry comes back with `pre_eval_status ∈ {passed, failed}` plus `pre_eval_reason` for failures. Failed entries are rejection-submitted as `(rejected=true, score=weight=0)` and **never enter the eval loop**; passed entries proceed to scenario evaluation. Runtime-only filters (validator permit, blacklist) are applied live on top of the snapshot — those are dynamic and intentionally outside the immutable freeze.
+
+#### Local cache & restart behavior
+
+The successful response is mirrored to disk so a validator restart inside epoch N resumes without another HTTP round-trip:
 
 ```
-active_set_window_N = { commitment | commitment.block_number < window_start(N) }
+{ACTIVE_SET_DIR or /var/lib/trajectoryrl/active_sets/}/active_set_window_{N}.json
 ```
 
-This makes evaluation inputs restart-safe and cross-validator consistent (within accepted polling-granularity overwrite races). Runtime-only filters such as validator permit and blacklist are still applied live, outside snapshot materialization.
+Per cycle:
+
+1. `load_snapshot(active_set_dir, N)` — read the file from disk.
+2. Hit → return cached → **no API call**.
+3. Miss / unparseable → `fetch_epoch_snapshot(N)` and persist on success.
+
+Practical consequences:
+
+| Scenario | Behavior |
+|---|---|
+| Container restart mid-epoch (volume intact) | reuse cache, 0 API calls |
+| Volume wiped or first cycle in a new epoch | one API fetch, then cache reused for the rest of the epoch |
+| Crash before the first cycle wrote the cache | one API fetch on restart |
+
+Because the API guarantees byte-identical output per epoch, "reuse cache" and "re-fetch from API" are equivalent paths — the cache is purely a round-trip optimization, never a divergence source. Rejection-row submissions for failed entries fire on every cycle (including the first cycle after restart); the dashboard deduplicates by `(validator_hotkey, miner_hotkey, epoch_number)`, so re-firing is idempotent. The validator keeps the most recent four `active_set_window_*.json` files and prunes older ones on each save.
 
 ### Evaluation Rate-Limiting
 
@@ -308,22 +328,21 @@ Each validator maintains a per-validator persistent table `pack_first_seen[pack_
 
 **Paraphrase defense**: pre-v5.1 the validator ran a pairwise NCD comparison among all active packs. NCD has known false positives/negatives near the threshold and shared the on-chain `block_number` rotation problem. As of v5.1 paraphrase defense is delegated to **Winner Protection's δ threshold + score-based competition**: a paraphrased copy must beat the current winner by at least δ to take over emissions, the same bar a genuine improvement faces. The NCD library functions in `trajectoryrl/utils/ncd.py` are kept for tooling but no longer gate evaluation.
 
-### 4. Pre-Eval Gate (Platform API)
+### 4. Pre-Eval Gate (baked into the epoch snapshot)
 
-**Enforcement**: Before evaluating a miner's pack (and again during aggregation), validators call the platform pre-eval API to check whether the submission is allowed. Miners flagged by the platform (banned, hardcoded packs detected server-side) are disqualified before spending evaluation resources.
+**Enforcement**: Pre-eval is no longer a per-miner HTTP call from the validator. The platform runs the gate (ban list, server-side hardcoded-pack detection, hash-uniqueness, etc.) before each epoch's `cutoff_time` and stamps the verdict directly onto the epoch_snapshot — every entry returned by `/api/v2/validators/epoch_snapshot` carries `pre_eval_status ∈ {passed, failed}` and (for failures) `pre_eval_reason`.
 
 **Prevents**:
-- Known-bad packs from consuming validator evaluation budget
-- Banned miners from participating after being flagged
-- Pack-switch escapes (aggregation re-checks using epoch_number to resolve the pack that was active during the evaluation window)
+- Known-bad packs from consuming validator evaluation budget (failed entries skip the eval loop entirely).
+- Banned miners from participating after being flagged.
+- Pack-switch escapes — the snapshot freezes the pack that was active at the epoch's cutoff_time, so a mid-epoch pack swap cannot dodge the gate.
 
 **How it works**:
-- **Evaluation phase**: Each miner is checked via `pre_eval(hotkey, pack_hash, pack_url)` before episodes run. Rejected miners are marked disqualified and skipped.
-- **Aggregation phase**: All miners in the consensus set are re-checked via `pre_eval(hotkey, epoch_number)`. Miners rejected since evaluation are disqualified before winner selection.
-- **Fail-open**: If the API is unreachable, validators fall back to cached results or proceed without gating (validators remain self-sufficient).
-- **Caching**: Responses are cached by `(hotkey, identifier)` to handle transient API failures.
+- **One source, one fetch**: validators read the snapshot once at the start of an eval cycle (see "Deterministic Active-Set Snapshot" above). Failed entries are rejection-submitted (`rejected=true, score=weight=0`) and excluded from the eval loop; passed entries proceed to scenario evaluation.
+- **No per-miner HTTP fan-out**: the legacy per-miner `/api/v2/miners/pre-eval` calls (both the eval-loop check and the aggregation-phase re-check) are gone — they are redundant with the snapshot's frozen verdict.
+- **No client-side fallback**: if the snapshot endpoint is unreachable for a whole epoch, the validator does not eval that epoch and falls through to fallback weights. There is no chain-side or cached pre-eval to "fail-open" against.
 
-Controlled by `TRAJECTORYRL_PRE_EVAL_ENABLED` (default: enabled).
+Cross-validator determinism is mechanical: every validator gets byte-identical entries for the same epoch, so disqualification is identical across the consensus set without any voting or reconciliation step.
 
 ### 5. Validator-Side Evaluation
 

--- a/docs/MINER_OPERATIONS.md
+++ b/docs/MINER_OPERATIONS.md
@@ -39,17 +39,68 @@ vim SKILL.md
 # 2. Build pack
 python neurons/miner.py build SKILL.md -o pack.json
 
-# 3. Upload to S3-compatible storage
+# 3a. Self-host: upload to your own S3-compatible storage
 python neurons/miner.py upload pack.json
+#    OR
+# 3b. Web submit: POST to the subnet's hosted endpoint (no hosting required)
+#    See "Path B" below for the curl recipe; returns a pack_url to use in step 4
 
 # 4. Submit on-chain
-python neurons/miner.py submit https://your-bucket.s3.amazonaws.com/pack.json
+python neurons/miner.py submit <pack_url>
 
 # 5. Check status
 python neurons/miner.py status
 ```
 
 That's it. Repeat steps 1-4 whenever you improve your SKILL.md.
+
+---
+
+## Two submission paths
+
+| Path | What you operate | Where the pack lives | Reveal | Use this when |
+|------|-----------------|----------------------|--------|---------------|
+| **A. Self-host + chain commit** | An HTTP host (S3/GCS/GH/own server) for `pack.json` | Your bucket | Public on chain immediately (commit URL is on-chain) | You already have hosting and want full control |
+| **B. Web submit (recommended for new miners)** | Just the miner CLI, no hosting | Subnet's GCS at an unguessable random key | URL hidden 48 h; commit on-chain still required for discovery | You want the easiest path; you don't want to run hosting |
+
+Both paths produce the same on-chain artifact: `set_commitment(pack_hash | url)`. The difference is who hosts the pack content.
+
+### Path A — chain commit (classic)
+
+```bash
+python neurons/miner.py build  SKILL.md -o pack.json
+python neurons/miner.py upload pack.json                       # to your S3/GCS
+python neurons/miner.py submit https://your-bucket/pack.json   # set_commitment on chain
+```
+
+### Path B — web submit (preferred)
+
+```bash
+# 1. Build pack locally (same as Path A)
+python neurons/miner.py build SKILL.md -o pack.json
+
+# 2. POST pack to the subnet's hosted submit endpoint (signed with your hotkey).
+#    The endpoint stores the pack at an unguessable random GCS path and
+#    returns the `pack_url` to use on-chain.
+curl -X POST https://trajrl.com/api/v2/miners/submit \
+  -H 'content-type: application/json' \
+  -d "$(jq -n --slurpfile pack pack.json \
+              --arg miner_hotkey "$MINER_HOTKEY" \
+              --arg ts "$(date +%s)" \
+              --arg sig "$(sign 'trajectoryrl-miner-submit:'"$MINER_HOTKEY"':'"$ts")" \
+              --arg hash "$(sha256_canonical pack.json)" \
+        '{ miner_hotkey: $miner_hotkey, timestamp: ($ts | tonumber),
+           signature: $sig, pack_hash: $hash, pack_content: ($pack[0] | tostring) }')"
+
+# Response → { pack_url: "https://storage.googleapis.com/.../pack.json", ... }
+
+# 3. Commit on-chain with the returned pack_url
+python neurons/miner.py submit <pack_url_from_response>
+```
+
+The `submit` endpoint immediately validates your signature, hash and pack format, kicks off pre-eval asynchronously, and returns the `pack_url`. Web-source URLs are not exposed in any other API for **48 hours** (the "reveal gate"), so a competitor can't simply scrape the dashboard to harvest your fresh SKILL.md.
+
+Full request/response spec for `/api/v2/miners/submit` is in [`trajectoryrl.web/API.md`](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md).
 
 ---
 
@@ -188,14 +239,17 @@ For what to write in SKILL.md, see [MINER_GUIDE.md § Writing SKILL.md](MINER_GU
 │                                                         │
 │  1. Write / iterate on SKILL.md                         │
 │  2. build → pack.json                                   │
-│  3. upload → public URL                                 │
-│  4. submit → on-chain commitment                        │
+│  3. either upload (Path A) or POST web-submit (Path B)  │
+│     → public pack_url                                   │
+│  4. submit → on-chain commitment (pack_hash | pack_url) │
 │  5. Wait for validator evaluation (~24h epoch)           │
 │  6. Check results, iterate                              │
 └─────────────────────────────────────────────────────────┘
 ```
 
-Validators only re-evaluate when your `pack_hash` changes. No need to resubmit if your SKILL.md hasn't changed.
+Validators only re-evaluate when your `pack_hash` changes. No need to resubmit if your SKILL.md hasn't changed. **However**, if you want to remain in the active eval set you must keep your on-chain commitment alive — the snapshot endpoint excludes packs whose `refresh_time` (the rolling activity stamp) is older than 48 hours. The sync service refreshes this stamp every 5 min for any commitment still on chain, so as long as you don't deregister you stay active.
+
+Re-submitting the same `(hotkey, pack_hash)` to `/api/v2/miners/submit` (Path B) within 1h is rate-limited by the cooldown; outside the cooldown it just bumps `refresh_time` without re-running the pipeline.
 
 ---
 
@@ -247,6 +301,8 @@ Use the testee transcript + judge feedback together to debug failure modes and i
 ## References
 
 - **Season 1 Guide**: [MINER_GUIDE.md](MINER_GUIDE.md) — scoring, sandbox, SKILL.md writing, anti-gaming rules
+- **Validator side**: [VALIDATOR_OPERATIONS.md](VALIDATOR_OPERATIONS.md) — how validators consume the eval set you submit to
 - **Incentive Mechanism**: [INCENTIVE_MECHANISM.md](INCENTIVE_MECHANISM.md) — consensus protocol, winner selection
 - **Scoring & Evaluation**: [EVALUATION_S1.md](EVALUATION_S1.md) — pack schema, scoring formula
+- **Web API spec**: [API.md](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md) — full request/response for `/api/v2/miners/submit` and other endpoints
 - **Benchmark**: [trajrl-bench](https://github.com/trajectoryRL/trajrl-bench) — scenarios, JUDGE.md, local testing

--- a/docs/VALIDATOR_OPERATIONS.md
+++ b/docs/VALIDATOR_OPERATIONS.md
@@ -1,0 +1,214 @@
+# Validator Operations Guide
+
+**Subnet**: SN11 (TrajectoryRL)
+**Season**: 1 (Self-Learning Agents)
+
+> For consensus protocol, winner selection, and reward distribution, see [INCENTIVE_MECHANISM.md](INCENTIVE_MECHANISM.md).
+> For miner-side flow (pack hosting, submission), see [MINER_OPERATIONS.md](MINER_OPERATIONS.md).
+
+---
+
+## What you do as a validator
+
+Each epoch (~24 h, 7200 chain blocks):
+
+1. **Pull the eval target set** from the subnet's snapshot endpoint
+2. **Evaluate** each `(miner_hotkey, pack_hash)` whose `pre_eval_status = 'passed'` — run the trajrl-bench harness against the pack
+3. **Submit scores** for the epoch
+4. **Set on-chain weights** at the epoch boundary
+
+Steps 1 and 3 are HTTP calls to the subnet's web service. The actual evaluation in step 2 runs locally on your hardware (sandbox + LLM + judge).
+
+This guide covers step 1 — the **epoch_snapshot** API.
+
+---
+
+## The single source of truth: `/api/v2/validators/epoch_snapshot`
+
+Validators **no longer query Bittensor commitments directly** at epoch start, and **no longer call `/api/v2/miners/pre-eval` per miner**. Both responsibilities are absorbed into the `epoch_snapshot` endpoint.
+
+```
+POST https://trajrl.com/api/v2/validators/epoch_snapshot
+Content-Type: application/json
+
+{
+  "epoch_number": 1234,
+  "validator_hotkey": "5FFA…",
+  "timestamp": 1714000000,
+  "signature": "0xabc…"
+}
+```
+
+`signature` is sr25519 over `"trajectoryrl-snapshot:{validator_hotkey}:{timestamp}"` (5-min drift tolerance). **Signature is required** — the response includes `pack_url` for each entry, and for web-submitted packs that URL is sensitive (random GCS key) until its 48 h reveal gate.
+
+### Response
+
+```json
+{
+  "epoch_number": 1234,
+  "built_at": "2026-05-04T12:05:00.000Z",
+  "window_start": 8092800,
+  "cutoff_block": 8092080,
+  "cutoff_time": "2026-05-04T12:00:00.000Z",
+  "eligible_start_time": "2026-05-02T12:00:00.000Z",
+  "inactivity_window_hours": 48,
+  "snapshot_block": 8092105,
+  "entries": [
+    {
+      "uid": 42,
+      "hotkey": "5GrwvaEF…",
+      "pack_hash": "abc123…",
+      "pack_url": "https://storage.googleapis.com/.../pack.json",
+      "refresh_time": "2026-05-04T08:00:00.000Z",
+      "pre_eval_status": "passed",
+      "pre_eval_reason": null
+    },
+    {
+      "uid": 88,
+      "hotkey": "5HBE…",
+      "pack_hash": "deadbeef…",
+      "pack_url": "https://…",
+      "refresh_time": "2026-05-04T09:30:00.000Z",
+      "pre_eval_status": "failed",
+      "pre_eval_reason": "hardcoded"
+    }
+  ]
+}
+```
+
+### What each entry tells you
+
+- `pre_eval_status: "passed"` → run the full eval on this `(hotkey, pack_hash)`
+- `pre_eval_status: "failed"` → submit a score row with `rejected: true`, `rejection_stage: "integrity_check"`, `rejection_detail: <pre_eval_reason>`. **Don't run the eval.**
+
+Pipeline failure reasons you may see in `pre_eval_reason`:
+
+| Reason | Cause |
+|---|---|
+| `download failed after 3 retries: <err>` | miner's self-hosted URL is unreachable |
+| `invalid_pack_json: missing or empty files.SKILL.md` | malformed pack |
+| `hash_mismatch` / `invalid_pack_json` | claimed `pack_hash` doesn't match content |
+| `pack_hash owned by <hotkey>` | uniqueness check (legacy multi-miner same pack) |
+| `coldkey banned until <iso>` | miner's ownerkey accumulated 4+ failed packs in 30 days |
+| `too similar (sim=X) to <hotkey>` | NCD copy detection (currently disabled by default) |
+| `hardcoded` / 7 LLM red-line categories | LLM detected benchmark/runtime overfitting |
+
+### Determinism guarantees
+
+- The snapshot is **immutable per epoch**: every validator gets byte-identical bytes, regardless of when they call.
+- The snapshot is **precomputed** by the subnet's sync worker as soon as `cutoff_time` passes (≈ 2.4 h before `window_start` of the requested epoch). The endpoint is a pure DB read.
+- Sort order is `(refresh_time ASC, hotkey ASC)`.
+
+---
+
+## Cutoff and eligibility window
+
+For epoch `N` the snapshot includes rows whose `refresh_time` falls in:
+
+```
+[ cutoff_time − 48h ,   cutoff_time )
+
+cutoff_time = block→time(window_start(N) − 720)
+            = aggregation_start(N−1)
+            = window_start(N) − 2.4h
+```
+
+- **Upper bound** (`cutoff_time`): rows refreshed at or after this point are deferred to the next epoch's snapshot. The 2.4 h gap is the contract with the sync worker — every row that lands before cutoff is guaranteed to have its full check pipeline complete before epoch N's eval phase opens.
+- **Lower bound** (`eligible_start_time = cutoff_time − 48h`): rows refreshed earlier than this are considered abandoned and excluded.
+
+A miner stays in the eval set as long as either (a) their on-chain commitment is still on chain and the sync worker is bumping their `refresh_time` every 5 min, or (b) they re-submit via `/api/v2/miners/submit` within the 48 h window.
+
+---
+
+## Signed-request example
+
+`signature` is sr25519 over `trajectoryrl-snapshot:{validator_hotkey}:{timestamp}`. This endpoint uses its own dedicated prefix (distinct from the `trajectoryrl-report` prefix that `/api/v2/miners/pre-eval` and `/api/v2/scores/submit` share).
+
+Python (using `bittensor` wallet API):
+
+```python
+import time, json, requests
+from bittensor import wallet
+
+w = wallet(name="validator", hotkey="default")
+hotkey = w.hotkey.ss58_address
+timestamp = int(time.time())
+message = f"trajectoryrl-snapshot:{hotkey}:{timestamp}"
+signature = "0x" + w.hotkey.sign(message.encode()).hex()
+
+r = requests.post(
+    "https://trajrl.com/api/v2/validators/epoch_snapshot",
+    json={
+        "epoch_number": 1234,
+        "validator_hotkey": hotkey,
+        "timestamp": timestamp,
+        "signature": signature,
+    },
+    timeout=15,
+)
+r.raise_for_status()
+snapshot = r.json()
+for e in snapshot["entries"]:
+    if e["pre_eval_status"] == "passed":
+        # run eval against e["pack_hash"] / e["pack_url"]
+        ...
+    else:
+        # submit a rejected score row
+        ...
+```
+
+---
+
+## Failure modes & retries
+
+| Status | Meaning | What to do |
+|---|---|---|
+| 200 | snapshot returned | proceed to eval phase |
+| 400 | `epoch_number` missing/invalid | check request body |
+| 401 | auth fields missing | include validator_hotkey + timestamp + signature |
+| 403 | hotkey not on-chain validator OR signature invalid | re-derive signature; check hotkey registration |
+| 404 | `Snapshot for epoch N is not available yet` | sync worker hasn't built it yet — retry on next cycle (~5 min) |
+
+The endpoint is the **only** source for the eval set, so on any non-200 the validator should wait and retry on its next iteration. The eval phase covers roughly the first 80 % of the window (≈ 19 h of a 24 h window), giving wide retry headroom. There is no client-side fallback to a chain query.
+
+A validator that cannot reach this endpoint for an entire epoch will not eval that epoch and falls through to its existing fallback weights behavior (set_weights to subnet-owner UID, miner emissions burned).
+
+---
+
+## Recommended validator loop
+
+```python
+import time
+
+while True:
+    target_epoch = next_unevaluated_epoch()       # local state
+
+    while True:
+        try:
+            snap = fetch_epoch_snapshot(target_epoch)   # HTTP call
+            break
+        except SnapshotNotReady:
+            time.sleep(300)                              # ~5 min then retry
+        except (NetworkError, AuthError) as e:
+            log_and_alert(e); time.sleep(60); continue
+
+    for entry in snap["entries"]:
+        if entry["pre_eval_status"] == "passed":
+            score = run_full_eval(entry)
+            submit_score(entry, score)
+        else:
+            submit_rejection(entry, reason=entry["pre_eval_reason"])
+
+    set_on_chain_weights(target_epoch)            # at end of epoch
+```
+
+The full request/response spec for `/api/v2/validators/epoch_snapshot` (including processing flow, determinism guarantees, and error codes) is in [`trajectoryrl.web/API.md`](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md).
+
+---
+
+## References
+
+- **API spec**: [API.md (POST /api/v2/validators/epoch_snapshot)](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md)
+- **Incentive Mechanism**: [INCENTIVE_MECHANISM.md](INCENTIVE_MECHANISM.md) — consensus protocol, winner selection
+- **Score submission**: [API.md (POST /api/v2/scores/submit)](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md) — how to report eval results
+- **Heartbeat & log upload**: [API.md (POST /api/v2/validators/heartbeat, POST /api/validators/logs/upload)](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md)

--- a/tests/test_eval_snapshot.py
+++ b/tests/test_eval_snapshot.py
@@ -3,11 +3,13 @@
 from trajectoryrl.utils.commitments import MinerCommitment
 from trajectoryrl.utils.eval_snapshot import (
     DEFAULT_RETENTION,
+    EpochSnapshotEntry,
     EvalSnapshot,
     load_snapshot,
     save_snapshot,
     snapshot_path,
     take_snapshot,
+    take_snapshot_from_api,
 )
 
 
@@ -90,3 +92,98 @@ def test_save_snapshot_prunes_old_files(tmp_path):
 
 def test_load_snapshot_missing_file_returns_none(tmp_path):
     assert load_snapshot(tmp_path, 99) is None
+
+
+def _api_response(entries):
+    return {
+        "epoch_number": 1234,
+        "built_at": "2026-05-04T12:05:00.000Z",
+        "window_start": 8092800,
+        "cutoff_block": 8092080,
+        "cutoff_time": "2026-05-04T12:00:00.000Z",
+        "eligible_start_time": "2026-05-02T12:00:00.000Z",
+        "inactivity_window_hours": 48,
+        "snapshot_block": 8092105,
+        "entries": entries,
+    }
+
+
+def _entry(uid, hk, ph, status, reason=None, refresh="2026-05-04T08:00:00.000Z"):
+    return {
+        "uid": uid,
+        "hotkey": hk,
+        "pack_hash": ph,
+        "pack_url": f"https://example.com/{uid}.json",
+        "refresh_time": refresh,
+        "pre_eval_status": status,
+        "pre_eval_reason": reason,
+    }
+
+
+def test_take_snapshot_from_api_splits_passed_and_failed():
+    api = _api_response([
+        _entry(10, "hk_a", "a" * 64, "passed"),
+        _entry(11, "hk_b", "b" * 64, "failed", reason="hardcoded"),
+        _entry(12, "hk_c", "c" * 64, "passed"),
+    ])
+    snap = take_snapshot_from_api(api, window_number=1234)
+
+    # Passed entries land in commitments keyed by uid.
+    assert sorted(snap.commitments.keys()) == [10, 12]
+    assert snap.commitments[10].hotkey == "hk_a"
+    assert snap.commitments[12].pack_hash == "c" * 64
+
+    # Failed entry surfaces in pre_eval_failed keyed by hotkey,
+    # carrying the reason for downstream rejection submission.
+    assert set(snap.pre_eval_failed.keys()) == {"hk_b"}
+    assert snap.pre_eval_failed["hk_b"].pre_eval_reason == "hardcoded"
+
+    # window_start / snapshot_block come from the API response.
+    assert snap.window_start == 8092800
+    assert snap.snapshot_block == 8092105
+
+
+def test_take_snapshot_from_api_assigns_index_as_block_number():
+    """``block_number`` is synthesised from each passed entry's index in the
+    API-sorted ``entries`` list so the existing ``pack_first_seen``
+    tiebreak (sort by ``(block_number, hotkey)``) stays deterministic
+    across validators receiving the same byte-identical response."""
+    api = _api_response([
+        _entry(10, "hk_a", "a" * 64, "passed"),
+        _entry(11, "hk_b", "b" * 64, "failed", reason="hash_mismatch"),
+        _entry(12, "hk_c", "c" * 64, "passed"),
+        _entry(13, "hk_d", "d" * 64, "passed"),
+    ])
+    snap = take_snapshot_from_api(api, window_number=1234)
+    # Failed entry consumes index 1; passed entries get 0, 2, 3.
+    assert snap.commitments[10].block_number == 0
+    assert snap.commitments[12].block_number == 2
+    assert snap.commitments[13].block_number == 3
+
+
+def test_take_snapshot_from_api_drops_unknown_status():
+    api = _api_response([
+        _entry(10, "hk_a", "a" * 64, "passed"),
+        _entry(11, "hk_b", "b" * 64, "pending"),  # not 'passed' or 'failed'
+    ])
+    snap = take_snapshot_from_api(api, window_number=1234)
+    assert list(snap.commitments.keys()) == [10]
+    assert "hk_b" not in snap.pre_eval_failed
+
+
+def test_save_and_load_round_trip_with_pre_eval_failed(tmp_path):
+    api = _api_response([
+        _entry(10, "hk_a", "a" * 64, "passed"),
+        _entry(11, "hk_b", "b" * 64, "failed", reason="hardcoded"),
+    ])
+    snap = take_snapshot_from_api(api, window_number=42)
+
+    save_snapshot(snap, tmp_path)
+    loaded = load_snapshot(tmp_path, 42)
+
+    assert loaded is not None
+    assert sorted(loaded.commitments.keys()) == [10]
+    assert "hk_b" in loaded.pre_eval_failed
+    assert loaded.pre_eval_failed["hk_b"].pre_eval_reason == "hardcoded"
+
+

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1076,59 +1076,99 @@ class TestFetchAllCommitmentsResilience:
 
 
 class TestAcquireWindowSnapshotGuard:
-    """Tests for _acquire_window_snapshot's behavior when chain query fails.
+    """Tests for ``_acquire_window_snapshot``'s behavior when the
+    ``/api/v2/validators/epoch_snapshot`` fetch fails.
 
-    A failed chain query (fetch_all_commitments returns None) MUST NOT be
-    persisted as an "empty active set" snapshot — that locks the validator
-    into a no-eval state for the rest of the ~24h window.
+    A failed fetch (``fetch_epoch_snapshot`` returns None or raises
+    ``SnapshotNotReady``) MUST NOT be persisted as an "empty active
+    set" snapshot — that locks the validator into a no-eval state for
+    the rest of the ~24h window.
     """
 
-    def test_does_not_save_snapshot_when_fetch_returns_none(self, tmp_path):
-        """When fetch_all_commitments returns None, _acquire_window_snapshot
-        must return None and must NOT call save_snapshot — so the next loop
-        iteration (or restart) can re-attempt the fetch instead of being
-        locked by a poisoned cache file."""
+    def _make_stub_validator(self, tmp_path):
         from trajectoryrl.base import validator as validator_module
-        from trajectoryrl.utils.eval_snapshot import EvalSnapshot
 
-        # Build a minimal stub validator that exposes the methods/attrs
-        # _acquire_window_snapshot needs, without going through the full
-        # TrajectoryValidator constructor.
         validator = MagicMock()
         validator.config.active_set_dir = str(tmp_path)
         validator.config.netuid = 11
-        validator.config.inactivity_blocks = 120
-        validator.subtensor = MagicMock()
-        validator.metagraph = MagicMock()
+        validator.wallet = MagicMock()
 
-        # Bind the real _acquire_window_snapshot onto our stub.
         validator._acquire_window_snapshot = (
             validator_module.TrajectoryValidator._acquire_window_snapshot.__get__(
                 validator
             )
         )
+        return validator, validator_module
 
-        # Build a minimal EvaluationWindow-like object (the method only reads
-        # window_number and window_start from it).
+    def test_does_not_save_snapshot_when_fetch_returns_none(self, tmp_path):
+        """When fetch_epoch_snapshot returns None,
+        _acquire_window_snapshot must return None and must NOT call
+        save_snapshot — so the next loop iteration (or restart) can
+        re-attempt the fetch instead of being locked by a poisoned
+        cache file."""
+        import asyncio
+
+        validator, validator_module = self._make_stub_validator(tmp_path)
+
         window = MagicMock()
         window.window_number = 1123
         window.window_start = 8085600
 
+        async def _fake_fetch(*args, **kwargs):
+            return None
+
         with patch.object(
-            validator_module, "fetch_all_commitments", return_value=None,
+            validator_module, "fetch_epoch_snapshot", side_effect=_fake_fetch,
         ) as fetch_mock, patch.object(
             validator_module, "save_snapshot",
         ) as save_mock, patch.object(
             validator_module, "load_snapshot", return_value=None,
         ):
-            result = validator._acquire_window_snapshot(window, current_block=8085614)
+            result = asyncio.run(
+                validator._acquire_window_snapshot(
+                    window, current_block=8085614,
+                )
+            )
 
         assert fetch_mock.called
         assert result is None, "should return None to signal caller to fall back"
         assert not save_mock.called, (
-            "must NOT persist a snapshot when chain query failed — "
+            "must NOT persist a snapshot when API fetch failed — "
             "would poison the cache and block the next ~24h window"
         )
+
+    def test_does_not_save_snapshot_when_fetch_raises_not_ready(self, tmp_path):
+        """When the endpoint replies 404 (sync worker hasn't built the
+        snapshot yet), ``fetch_epoch_snapshot`` raises ``SnapshotNotReady``;
+        ``_acquire_window_snapshot`` must propagate that as a None
+        return without persisting anything."""
+        import asyncio
+
+        validator, validator_module = self._make_stub_validator(tmp_path)
+        from trajectoryrl.utils.status_reporter import SnapshotNotReady
+
+        window = MagicMock()
+        window.window_number = 1123
+        window.window_start = 8085600
+
+        async def _fake_fetch(*args, **kwargs):
+            raise SnapshotNotReady(1123)
+
+        with patch.object(
+            validator_module, "fetch_epoch_snapshot", side_effect=_fake_fetch,
+        ), patch.object(
+            validator_module, "save_snapshot",
+        ) as save_mock, patch.object(
+            validator_module, "load_snapshot", return_value=None,
+        ):
+            result = asyncio.run(
+                validator._acquire_window_snapshot(
+                    window, current_block=8085614,
+                )
+            )
+
+        assert result is None
+        assert not save_mock.called
 
 
 # ===================================================================

--- a/tools/analyze_consensus.py
+++ b/tools/analyze_consensus.py
@@ -39,7 +39,6 @@ from trajectoryrl.utils.commitments import (
     fetch_validator_consensus_commitments, decode_dual_address,
 )
 from trajectoryrl.scoring import compute_consensus_scores
-from trajectoryrl.utils.status_reporter import pre_eval
 from trajectoryrl.utils.winner_state import (
     WinnerState, select_winner_with_protection,
 )
@@ -270,44 +269,6 @@ async def run(args):
     # ---- 6. Compute consensus scores -----------------------------------------
     consensus_scores, consensus_disqualified = compute_consensus_scores(validated)
 
-    # ---- 6b. Pre-eval gate (mirrors production aggregation) -----------------
-    # Production calls pre_eval for every miner in consensus_scores after
-    # computing scores and before winner selection (validator.py:919). Off by
-    # default in this analyzer; opt in with --use-pre-eval. Read-only — we
-    # don't replicate the production submit_eval side-effect.
-    if args.use_pre_eval:
-        miners_to_check = list(consensus_scores.keys())
-        print(
-            f"\n  Running pre-eval gate against {len(miners_to_check)} miner(s) "
-            f"(epoch_number={target_window}, unsigned)..."
-        )
-        sem = asyncio.Semaphore(8)
-
-        async def _limited_pre_eval(hk: str):
-            async with sem:
-                return await pre_eval(
-                    hk, epoch_number=target_window, wallet=None,
-                )
-
-        pre_eval_results = await asyncio.gather(*(
-            _limited_pre_eval(hk) for hk in miners_to_check
-        ))
-
-        pre_eval_disqualified = 0
-        pre_eval_unreachable = 0
-        for miner_hk, result in zip(miners_to_check, pre_eval_results):
-            if result is None:
-                pre_eval_unreachable += 1
-                continue
-            if not result.get("allowed", True):
-                reason = result.get("reason", "unknown")
-                consensus_disqualified[miner_hk] = f"pre_eval:{reason}"
-                pre_eval_disqualified += 1
-        print(
-            f"  Pre-eval: {pre_eval_disqualified}/{len(miners_to_check)} "
-            f"disqualified, {pre_eval_unreachable} unreachable (failed open)"
-        )
-
     # Filter disqualified miners from scores before winner selection
     eligible_scores = {
         hk: s for hk, s in consensus_scores.items()
@@ -445,15 +406,6 @@ def main():
             f"stake-weighted majority emerges (default: validator's "
             f"trajectoryrl.utils.config.SPEC_NUMBER, or "
             f"{SPEC_NUMBER_FALLBACK} if unavailable)."
-        ),
-    )
-    parser.add_argument(
-        "--use-pre-eval", action="store_true",
-        help=(
-            "Call the aggregator pre-eval API for every miner in the consensus "
-            "scores (mirrors production aggregation). Miners rejected by the "
-            "server are added to the disqualified set before winner selection. "
-            "Default: off."
         ),
     )
     args = parser.parse_args()

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -84,10 +84,12 @@ from ..utils.commitments import (
     is_consensus_commitment, parse_consensus_commitment,
 )
 from ..utils.eval_snapshot import (
-    EvalSnapshot, take_snapshot, load_snapshot, save_snapshot,
+    EvalSnapshot, take_snapshot, take_snapshot_from_api,
+    load_snapshot, save_snapshot,
 )
 from ..utils.status_reporter import (
-    heartbeat, pre_eval, submit_eval, upload_eval_logs, upload_cycle_logs,
+    heartbeat, submit_eval, upload_eval_logs, upload_cycle_logs,
+    fetch_epoch_snapshot, SnapshotNotReady,
 )
 from ..utils.llm_judge import PackIntegrityJudge, TrajectoryJudge
 from .. import __version__
@@ -979,82 +981,16 @@ class TrajectoryValidator:
 
         consensus_scores, disqualified = compute_consensus_scores(validated)
 
-        # Build hotkey → UID mapping (used by pre-eval reporting, winner
-        # selection, and logging)
+        # Build hotkey → UID mapping (used by winner selection and logging).
         hk_to_uid: Dict[str, int] = {}
         for uid in range(len(self.metagraph.hotkeys)):
             hk_to_uid[self.metagraph.hotkeys[uid]] = uid
 
-        # Pre-eval gate during aggregation: disqualify miners rejected by the
-        # platform before selecting a winner.  Uses epoch_number so the server
-        # resolves the pack that was active during this window (prevents
-        # pack-switch escapes).
-        if os.getenv("TRAJECTORYRL_PRE_EVAL_ENABLED", "1") != "0":
-            current_block = self.subtensor.get_current_block()
-            miners_to_check = list(consensus_scores.keys())
-
-            if miners_to_check:
-                sem = asyncio.Semaphore(8)
-
-                async def _limited_pre_eval(hk: str):
-                    async with sem:
-                        return await pre_eval(
-                            hk, epoch_number=window.window_number,
-                            wallet=self.wallet,
-                        )
-
-                results = await asyncio.gather(*(
-                    _limited_pre_eval(miner_hk)
-                    for miner_hk in miners_to_check
-                ))
-
-                pre_eval_disqualified = 0
-                for miner_hk, pre_eval_result in zip(miners_to_check, results):
-                    if pre_eval_result is not None and not pre_eval_result.get("allowed", True):
-                        reason = pre_eval_result.get("reason", "unknown")
-                        disqualified[miner_hk] = f"pre_eval:{reason}"
-                        pre_eval_disqualified += 1
-                        _stage = "integrity_check" if reason == "hardcoded" else "pack_fetch"
-                        _detail = (
-                            f"pre-eval rejected: {reason}"
-                            + (
-                                f", banned_until={pre_eval_result['banned_until']}"
-                                if "banned_until" in pre_eval_result
-                                else ""
-                            )
-                        )
-                        logger.info(
-                            "Window %d: miner %s pre-eval rejected during "
-                            "aggregation (reason=%s) — marked disqualified",
-                            window.window_number, miner_hk[:8], reason,
-                        )
-                        asyncio.ensure_future(
-                            submit_eval(
-                                self.wallet,
-                                miner_hotkey=miner_hk,
-                                miner_uid=hk_to_uid.get(miner_hk, -1),
-                                block_height=current_block,
-                                score=0.0,
-                                weight=0.0,
-                                qualified=False,
-                                pack_url=pre_eval_result.get("pack_url", ""),
-                                pack_hash=pre_eval_result.get("pack_hash", ""),
-                                llm_base_url=self._judge_base_url,
-                                llm_model=self._judge_model,
-                                rejected=True,
-                                rejection_stage=_stage,
-                                rejection_detail=_detail,
-                                spec_number=_spec_number(),
-                                epoch_number=window.window_number,
-                                **self._harness_metadata(),
-                            )
-                        )
-                if pre_eval_disqualified:
-                    logger.info(
-                        "Window %d: %d miner(s) disqualified by pre-eval "
-                        "during aggregation",
-                        window.window_number, pre_eval_disqualified,
-                    )
+        # No pre-eval gate here: the per-epoch snapshot already excluded
+        # failed miners from every validator's ``commitments``, so a
+        # failed miner cannot appear in ``consensus_scores``. Their
+        # rejection rows were submitted at eval-cycle start (see
+        # ``_dispatch_pre_eval_rejections``).
 
         self._consensus_window = window.window_number
 
@@ -1840,24 +1776,35 @@ class TrajectoryValidator:
         # 2. Acquire the window-N active-set snapshot.
         #
         # Each window has exactly one snapshot
-        # (``active_set_window_{N}.json``) freezing the deterministic
-        # commitment subset for that window (commit_block < window_start
-        # and not stale). The snapshot is the source of truth for the
+        # (``active_set_window_{N}.json``) frozen by
+        # ``/api/v2/validators/epoch_snapshot``. The endpoint absorbs
+        # the on-chain commitment scan and the per-miner pre-eval
+        # pipeline; its bytes are byte-identical across validators for
+        # a given epoch. The snapshot is the source of truth for the
         # remainder of the cycle: cross-validator consistency comes
-        # from chain commit_block, restart consistency from the file.
+        # from the API freeze, restart consistency from the local file.
         #
         # On the first cycle inside a window the file is absent, so we
-        # build it from a fresh chain query and persist immediately.
-        # On subsequent cycles (same window) the file hits and we
-        # avoid the chain round-trip entirely.
+        # fetch from the API and persist immediately. On subsequent
+        # cycles (same window) the file hits and we avoid the HTTP
+        # round-trip entirely.
         window = compute_window(current_block, self._window_config)
-        snapshot = self._acquire_window_snapshot(window, current_block)
+        snapshot = await self._acquire_window_snapshot(window, current_block)
         if snapshot is None:
             # Snapshot acquisition failed (chain query unreachable even after
             # reconnect retry). Returning False signals the outer loop NOT to
             # mark this window as evaluated, so the next iteration can retry
             # instead of locking the validator out of this ~24h window.
             return False
+
+        # Surface pre-eval failures from the snapshot as rejection
+        # submissions (no eval is run for these miners). The snapshot
+        # itself comes back to us only after the eval cycle has run;
+        # firing here ensures the dashboard sees the rejection rows
+        # at the same offset every window.
+        self._dispatch_pre_eval_rejections(
+            snapshot, current_block, window.window_number,
+        )
 
         # Per-validator runtime filters (validator_permit, blacklist)
         # are dynamic and applied on top of the frozen snapshot every
@@ -1869,6 +1816,7 @@ class TrajectoryValidator:
         logger.info(
             f"Window {window.window_number} snapshot: "
             f"{len(snapshot.commitments)} eligible, "
+            f"{len(snapshot.pre_eval_failed)} pre-eval rejected, "
             f"{len(active_commitments)} after runtime filter"
         )
 
@@ -1895,7 +1843,7 @@ class TrajectoryValidator:
         evaluated_count = 0
         attempted_count = 0
         skipped_interval_count = 0
-        rejected_pre_eval_count = 0
+        rejected_pre_eval_count = len(snapshot.pre_eval_failed)
         copy_rejected_count = 0
         total_eligible = len(active_commitments)
         logger.info(
@@ -1966,58 +1914,11 @@ class TrajectoryValidator:
                 self._drop_miner_eval_state(hotkey)
                 continue
 
-            # Pre-eval gate: ask the server whether this miner's submission
-            # is allowed before spending LLM tokens on a full evaluation.
-            # Controlled by TRAJECTORYRL_PRE_EVAL_ENABLED (default: 1).
-            # Fail-open on network/API errors so validators are self-sufficient.
-            if os.getenv("TRAJECTORYRL_PRE_EVAL_ENABLED", "1") != "0":
-                pre_eval_result = await pre_eval(
-                    hotkey,
-                    commitment.pack_hash,
-                    commitment.pack_url,
-                    wallet=self.wallet,
-                )
-                if pre_eval_result is not None and not pre_eval_result.get("allowed", True):
-                    rejected_pre_eval_count += 1
-                    reason = pre_eval_result.get("reason", "unknown")
-                    logger.info(
-                        f"[{miner_idx}/{total_eligible}] Miner {uid} ({hotkey[:8]}): "
-                        f"pre-eval rejected (reason={reason}) — skipping eval"
-                    )
-                    _stage = "integrity_check" if reason == "hardcoded" else "pack_fetch"
-                    _detail = (
-                        f"pre-eval rejected: {reason}"
-                        + (
-                            f", banned_until={pre_eval_result['banned_until']}"
-                            if "banned_until" in pre_eval_result
-                            else ""
-                        )
-                    )
-                    asyncio.ensure_future(
-                        submit_eval(
-                            self.wallet,
-                            miner_hotkey=hotkey,
-                            miner_uid=uid,
-                            block_height=current_block,
-                            score=0.0,
-                            weight=0.0,
-                            qualified=False,
-                            pack_url=commitment.pack_url,
-                            pack_hash=commitment.pack_hash,
-                            llm_base_url=self._judge_base_url,
-                            llm_model=self._judge_model,
-                            rejected=True,
-                            rejection_stage=_stage,
-                            rejection_detail=_detail,
-                            spec_number=_spec_number(),
-                            epoch_number=window_number,
-                            **self._harness_metadata(),
-                        )
-                    )
-                    self._disqualified_miners[hotkey] = f"pre_eval_rejected:{reason}"
-                    self._drop_miner_eval_state(hotkey)
-                    continue
-
+            # No per-miner pre-eval call here: the epoch_snapshot already
+            # encodes pre-eval verdicts. Failed entries are surfaced via
+            # ``snapshot.pre_eval_failed`` and rejection-submitted at the
+            # cycle's start (see ``_dispatch_pre_eval_rejections``); only
+            # passed entries reach this loop.
             needs_eval = self._needs_evaluation(
                 hotkey, commitment.pack_hash, window_number
             )
@@ -2281,63 +2182,126 @@ class TrajectoryValidator:
             active[uid] = commitment
         return active
 
-    def _acquire_window_snapshot(
+    async def _acquire_window_snapshot(
         self,
         window: EvaluationWindow,
         current_block: int,
     ) -> Optional[EvalSnapshot]:
-        """Load or build the active-set snapshot for ``window``.
+        """Load or fetch the active-set snapshot for ``window``.
 
         Order of operations:
 
         1. Try to load ``active_set_window_{N}.json``. A successful
            load is the fast path for any non-first cycle in window N
            (and for restart recovery within the same window).
-        2. On miss, query the chain once and apply the deterministic
-           filters (``commit_block < window_start`` plus stale-age vs
-           window_start). Persist the result so subsequent cycles in
-           the same window hit the cache.
+        2. On miss, fetch the snapshot from
+           ``/api/v2/validators/epoch_snapshot``. The endpoint freezes
+           an immutable per-epoch snapshot that already absorbs the
+           on-chain commitment scan and the per-miner pre-eval pipeline,
+           so the validator no longer queries the chain or calls
+           ``/api/v2/miners/pre-eval`` here. Persist the result so
+           subsequent cycles in the same window hit the cache.
 
-        Returns the snapshot, or None if there are no eligible
-        commitments at all (caller should fall back to owner weights).
+        Returns the snapshot, or None if the API is unreachable / the
+        snapshot has not been built yet (caller should retry next
+        cycle without locking the validator out of this window).
         """
         snapshot = load_snapshot(self.config.active_set_dir, window.window_number)
         if snapshot is not None:
             return snapshot
 
         logger.info(
-            "Window %d: building active-set snapshot from chain "
+            "Window %d: fetching epoch_snapshot from API "
             "(window_start=%d, current_block=%d)",
             window.window_number, window.window_start, current_block,
         )
-        raw = fetch_all_commitments(
-            self.subtensor,
-            self.config.netuid,
-            self.metagraph,
-            reconnect=lambda: self._reconnect_subtensor(
-                f"[snapshot window {window.window_number}] "
-            ),
-        )
-        if raw is None:
-            # Chain query failed even after reconnect retry. Returning None
-            # without persisting lets the next loop iteration (or restart)
-            # re-attempt the fetch instead of being locked by a poisoned
-            # cache file for the rest of the ~24h window.
+        try:
+            api_response = await fetch_epoch_snapshot(
+                epoch_number=window.window_number,
+                wallet=self.wallet,
+            )
+        except SnapshotNotReady:
+            logger.warning(
+                "Window %d: epoch_snapshot not yet built by sync worker — "
+                "will retry on next cycle",
+                window.window_number,
+            )
+            return None
+        if api_response is None:
+            # Network/auth failure. Returning None without persisting
+            # lets the next loop iteration retry instead of being
+            # locked by a poisoned cache file for the rest of the
+            # ~24h window.
             logger.error(
-                "Window %d: chain query for commitments failed; "
+                "Window %d: epoch_snapshot fetch failed; "
                 "skipping snapshot persistence so the next cycle can retry",
                 window.window_number,
             )
             return None
-        snapshot = take_snapshot(
-            raw,
+
+        snapshot = take_snapshot_from_api(
+            api_response,
             window_number=window.window_number,
-            window_start=window.window_start,
-            snapshot_block=current_block,
-            inactivity_blocks=self.config.inactivity_blocks,
         )
         save_snapshot(snapshot, self.config.active_set_dir)
         return snapshot
+
+    def _dispatch_pre_eval_rejections(
+        self,
+        snapshot: EvalSnapshot,
+        current_block: int,
+        window_number: int,
+    ) -> None:
+        """Submit rejection rows for snapshot entries flagged ``failed``.
+
+        The epoch_snapshot endpoint already ran the pre-eval pipeline
+        for each (hotkey, pack_hash); failed entries arrive with a
+        ``pre_eval_status='failed'`` and the verdict reason. We surface
+        each as a rejection submission (``rejected=True``,
+        ``score=weight=0``) so downstream consumers see the same shape
+        of row that the legacy per-miner ``pre_eval`` path produced.
+
+        Idempotency: this is invoked once per eval cycle. Re-running
+        the same cycle would re-submit identical rows — the dashboard
+        deduplicates by ``(validator_hotkey, miner_hotkey,
+        epoch_number)`` so duplicate sends are safe.
+        """
+        if not snapshot.pre_eval_failed:
+            return
+        self._disqualified_miners = getattr(self, "_disqualified_miners", {})
+        for entry in snapshot.pre_eval_failed.values():
+            reason = entry.pre_eval_reason or "unknown"
+            stage = "integrity_check" if reason == "hardcoded" else "pack_fetch"
+            detail = f"pre-eval rejected: {reason}"
+            self._get_miner_logger(entry.hotkey).info(
+                "Window %d: pre-eval failed (reason=%s) — submitting rejection",
+                window_number, reason,
+            )
+            asyncio.ensure_future(
+                submit_eval(
+                    self.wallet,
+                    miner_hotkey=entry.hotkey,
+                    miner_uid=entry.uid,
+                    block_height=current_block,
+                    score=0.0,
+                    weight=0.0,
+                    qualified=False,
+                    pack_url=entry.pack_url,
+                    pack_hash=entry.pack_hash,
+                    llm_base_url=self._judge_base_url,
+                    llm_model=self._judge_model,
+                    rejected=True,
+                    rejection_stage=stage,
+                    rejection_detail=detail,
+                    spec_number=_spec_number(),
+                    epoch_number=window_number,
+                    **self._harness_metadata(),
+                )
+            )
+            self._disqualified_miners[entry.hotkey] = (
+                f"pre_eval_rejected:{reason}"
+            )
+            self._drop_miner_eval_state(entry.hotkey)
 
     # ------------------------------------------------------------------
     # UID re-registration tracking

--- a/trajectoryrl/utils/eval_snapshot.py
+++ b/trajectoryrl/utils/eval_snapshot.py
@@ -2,32 +2,31 @@
 
 Each evaluation window is anchored at ``window_start = global_anchor +
 window_number * window_length``. At the start of a window, every
-validator queries the chain for all miner commitments and freezes the
-subset that is deterministic across validators:
+validator fetches the deterministic eval target set from the subnet's
+``/api/v2/validators/epoch_snapshot`` endpoint (see
+``status_reporter.fetch_epoch_snapshot``). The endpoint already does
+the on-chain commitment scan and the per-miner pre-eval pipeline, so
+validators no longer query the chain or call ``/api/v2/miners/pre-eval``
+directly at this stage.
 
-    snapshot[uid] = commitment   iff   commitment.block_number < window_start
+The API response is byte-identical for a given epoch across all
+validators (``epoch_summary.eval_snapshot`` is frozen the first time
+sync runs after cutoff). We mirror it onto disk as
+``active_set_window_{N}.json`` so a restart inside the same window N
+rehydrates without a fresh HTTP round-trip; if the file is absent or
+malformed, we re-fetch from the endpoint.
 
-The ``block_number`` field is sourced from the chain (see
-``commitments._get_commitment_block``), so two validators that build
-the snapshot at any time strictly after ``window_start`` and before the
-next miner overwrite produce byte-identical snapshots. Both the lower
-bound (any block in window N) and the upper bound (a brief race when a
-miner overwrites mid-poll) are accepted as the per-validator polling
-granularity error documented in the redesign plan.
+Each API entry carries ``pre_eval_status`` (``passed`` / ``failed``).
+We split the entries into:
 
-The snapshot is persisted to ``active_set_window_{N}.json`` so that a
-restart inside the same window N rehydrates the exact same evaluation
-set without re-querying the chain. If the file is absent on restart,
-the validator rebuilds best-effort from the current chain state and
-the same ``block_number < window_start`` filter; the result is
-identical for any commitment that was not overwritten in the meantime.
-
-Stale-age filtering (``inactivity_blocks``) is applied at snapshot
-time relative to ``window_start`` rather than ``current_block`` so the
-snapshot remains stable for the entire window even if it is taken
-late. Per-validator runtime filters (validator_permit, blacklist) are
-intentionally NOT baked into the snapshot — those are dynamic and must
-be re-evaluated against the live metagraph on every cycle.
+* ``commitments`` — passed entries, exposed as ``MinerCommitment``
+  values keyed by UID. ``block_number`` is synthesised from the API
+  entry's index in the (refresh_time-sorted) ``entries`` list, so the
+  downstream ``pack_first_seen`` tiebreak (which sorts by
+  ``(block_number, hotkey)``) stays deterministic across validators.
+* ``pre_eval_failed`` — failed entries, exposed as ``EpochSnapshotEntry``
+  values keyed by hotkey. The validator submits a rejection row for
+  each (no eval is run).
 """
 
 from __future__ import annotations
@@ -36,15 +35,14 @@ import json
 import logging
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from .commitments import MinerCommitment
 
 logger = logging.getLogger(__name__)
 
-SNAPSHOT_FORMAT_VERSION = 1
 SNAPSHOT_FILE_PATTERN = re.compile(r"^active_set_window_(\d+)\.json$")
 
 # How many recent window snapshots to keep on disk, including the
@@ -53,19 +51,45 @@ DEFAULT_RETENTION = 4
 
 
 @dataclass(frozen=True)
+class EpochSnapshotEntry:
+    """One row from the ``/api/v2/validators/epoch_snapshot`` response.
+
+    ``pre_eval_status`` is either ``"passed"`` or ``"failed"``.
+    ``pre_eval_reason`` is populated only on failures (mirrors the
+    server-side ``eval_reason`` column — e.g. ``"hardcoded"``,
+    ``"hash_mismatch"``, ``"banned until ..."``).
+    """
+
+    uid: int
+    hotkey: str
+    pack_hash: str
+    pack_url: str
+    refresh_time: str
+    pre_eval_status: str
+    pre_eval_reason: Optional[str]
+
+
+@dataclass(frozen=True)
 class EvalSnapshot:
     """Frozen evaluation set for a single window.
 
-    ``commitments`` is keyed by UID. ``window_start`` is the chain
-    block at the beginning of the window. ``snapshot_block`` records
-    the block height observed when the snapshot was built (purely
-    informational — does not affect determinism).
+    ``commitments`` is keyed by UID and contains only entries whose
+    ``pre_eval_status == "passed"``. ``pre_eval_failed`` is keyed by
+    hotkey and contains the raw API rows for failed entries — the
+    validator submits a rejection row per failed entry without running
+    the eval.
+
+    ``window_start`` is the chain block at the beginning of the window.
+    ``snapshot_block`` records the API-reported ``snapshot_block``
+    (latest synced chain height when the server built the snapshot) —
+    informational only.
     """
 
     window_number: int
     window_start: int
     snapshot_block: int
     commitments: Dict[int, MinerCommitment]
+    pre_eval_failed: Dict[str, EpochSnapshotEntry] = field(default_factory=dict)
 
     def hotkeys(self) -> List[str]:
         """Sorted hotkey list — useful for cross-validator diff logs."""
@@ -80,6 +104,13 @@ def take_snapshot(
     inactivity_blocks: Optional[int] = None,
 ) -> EvalSnapshot:
     """Filter ``raw_commitments`` to the deterministic window-N set.
+
+    .. deprecated::
+        The chain-side snapshot path is superseded by
+        ``take_snapshot_from_api`` (the ``/api/v2/validators/epoch_snapshot``
+        endpoint absorbs the on-chain query and the per-miner pre-eval
+        pipeline). Retained for tests and as a fallback shim until the
+        follow-up cleanup removes ``fetch_all_commitments`` entirely.
 
     Two filters are applied — both reference ``window_start``, never
     ``snapshot_block``, so the result is invariant under polling-time
@@ -106,8 +137,9 @@ def take_snapshot(
         eligible[uid] = commitment
 
     logger.info(
-        "Window %d snapshot: %d eligible (filtered %d in-window, %d stale) "
-        "from %d raw commitments at block %d (window_start=%d)",
+        "Window %d snapshot (legacy chain path): %d eligible "
+        "(filtered %d in-window, %d stale) from %d raw commitments "
+        "at block %d (window_start=%d)",
         window_number, len(eligible), dropped_in_window, dropped_stale,
         len(raw_commitments), snapshot_block, window_start,
     )
@@ -116,6 +148,106 @@ def take_snapshot(
         window_start=window_start,
         snapshot_block=snapshot_block,
         commitments=eligible,
+    )
+
+
+def take_snapshot_from_api(
+    api_response: Dict[str, Any],
+    window_number: int,
+) -> EvalSnapshot:
+    """Build an ``EvalSnapshot`` from a parsed epoch_snapshot response.
+
+    The API guarantees ``entries`` is sorted ``(refresh_time ASC,
+    hotkey ASC)`` and is byte-identical across validators for a given
+    epoch. We use the per-entry index as the synthesised
+    ``MinerCommitment.block_number`` so the validator's existing
+    ``pack_first_seen`` tiebreak (sorted by ``(block_number, hotkey)``)
+    remains deterministic across validators.
+
+    Failed-pre-eval entries are split into ``pre_eval_failed`` and not
+    placed in ``commitments``. The validator surfaces them as rejection
+    submissions (``rejected=True``) without running the eval.
+    """
+    entries_raw = api_response.get("entries", [])
+    if not isinstance(entries_raw, list):
+        raise ValueError(
+            f"epoch_snapshot response 'entries' is not a list: "
+            f"{type(entries_raw).__name__}"
+        )
+
+    window_start = int(api_response.get("window_start", 0))
+    snapshot_block = int(api_response.get("snapshot_block", 0))
+
+    commitments: Dict[int, MinerCommitment] = {}
+    pre_eval_failed: Dict[str, EpochSnapshotEntry] = {}
+    passed_count = 0
+    failed_count = 0
+    skipped_malformed = 0
+
+    for index, raw in enumerate(entries_raw):
+        try:
+            uid = int(raw["uid"])
+            hotkey = str(raw["hotkey"])
+            pack_hash = str(raw["pack_hash"])
+            pack_url = str(raw["pack_url"])
+            refresh_time = str(raw.get("refresh_time", ""))
+            status = str(raw.get("pre_eval_status", ""))
+            reason = raw.get("pre_eval_reason")
+            if reason is not None:
+                reason = str(reason)
+        except (KeyError, TypeError, ValueError) as e:
+            logger.warning(
+                "epoch_snapshot entry %d: malformed (%s): %r",
+                index, e, raw,
+            )
+            skipped_malformed += 1
+            continue
+
+        entry = EpochSnapshotEntry(
+            uid=uid,
+            hotkey=hotkey,
+            pack_hash=pack_hash,
+            pack_url=pack_url,
+            refresh_time=refresh_time,
+            pre_eval_status=status,
+            pre_eval_reason=reason,
+        )
+
+        if status == "passed":
+            commitments[uid] = MinerCommitment(
+                uid=uid,
+                hotkey=hotkey,
+                pack_hash=pack_hash,
+                pack_url=pack_url,
+                # Deterministic per-entry ordering for pack_first_seen
+                # tiebreak — see module docstring.
+                block_number=index,
+                raw=f"{pack_hash}|{pack_url}",
+            )
+            passed_count += 1
+        elif status == "failed":
+            pre_eval_failed[hotkey] = entry
+            failed_count += 1
+        else:
+            logger.warning(
+                "epoch_snapshot entry %d (uid=%d, hk=%s…): "
+                "unexpected pre_eval_status=%r — ignoring",
+                index, uid, hotkey[:8], status,
+            )
+            skipped_malformed += 1
+
+    logger.info(
+        "Window %d snapshot from API: %d passed, %d failed, "
+        "%d malformed (window_start=%d, snapshot_block=%d)",
+        window_number, passed_count, failed_count, skipped_malformed,
+        window_start, snapshot_block,
+    )
+    return EvalSnapshot(
+        window_number=window_number,
+        window_start=window_start,
+        snapshot_block=snapshot_block,
+        commitments=commitments,
+        pre_eval_failed=pre_eval_failed,
     )
 
 
@@ -142,7 +274,6 @@ def save_snapshot(
     directory.mkdir(parents=True, exist_ok=True)
 
     payload = {
-        "version": SNAPSHOT_FORMAT_VERSION,
         "window_number": snapshot.window_number,
         "window_start": snapshot.window_start,
         "snapshot_block": snapshot.snapshot_block,
@@ -157,6 +288,18 @@ def save_snapshot(
             }
             for c in snapshot.commitments.values()
         ],
+        "pre_eval_failed": [
+            {
+                "uid": e.uid,
+                "hotkey": e.hotkey,
+                "pack_hash": e.pack_hash,
+                "pack_url": e.pack_url,
+                "refresh_time": e.refresh_time,
+                "pre_eval_status": e.pre_eval_status,
+                "pre_eval_reason": e.pre_eval_reason,
+            }
+            for e in snapshot.pre_eval_failed.values()
+        ],
     }
 
     target = snapshot_path(directory, snapshot.window_number)
@@ -165,8 +308,12 @@ def save_snapshot(
         json.dump(payload, f, indent=2, sort_keys=True)
     os.replace(tmp, target)
     logger.info(
-        "Saved active-set snapshot for window %d (%d commitments) → %s",
-        snapshot.window_number, len(snapshot.commitments), target,
+        "Saved active-set snapshot for window %d "
+        "(%d passed, %d failed) → %s",
+        snapshot.window_number,
+        len(snapshot.commitments),
+        len(snapshot.pre_eval_failed),
+        target,
     )
 
     _prune_old_snapshots(directory, snapshot.window_number, retention)
@@ -177,8 +324,9 @@ def load_snapshot(directory, window_number: int) -> Optional[EvalSnapshot]:
     """Load the snapshot for ``window_number``, or None if missing/invalid.
 
     Missing file is the common case (first cycle in a fresh window) and
-    is logged at debug level. A malformed file logs a warning and
-    returns None; the caller is expected to rebuild from the chain.
+    is logged at debug level. A malformed file or a file written in a
+    previous (incompatible) format logs a warning and returns None;
+    the caller is expected to re-fetch from the API.
     """
     path = snapshot_path(directory, window_number)
     if not path.exists():
@@ -194,14 +342,6 @@ def load_snapshot(directory, window_number: int) -> Optional[EvalSnapshot]:
 
     if not isinstance(data, dict):
         logger.warning("Snapshot %s has invalid root type %s", path, type(data))
-        return None
-
-    file_version = data.get("version")
-    if file_version != SNAPSHOT_FORMAT_VERSION:
-        logger.warning(
-            "Snapshot %s has unsupported format version %r (expected %d)",
-            path, file_version, SNAPSHOT_FORMAT_VERSION,
-        )
         return None
 
     try:
@@ -242,15 +382,45 @@ def load_snapshot(directory, window_number: int) -> Optional[EvalSnapshot]:
             )
             continue
 
+    pre_eval_failed: Dict[str, EpochSnapshotEntry] = {}
+    raw_failed = data.get("pre_eval_failed", [])
+    if isinstance(raw_failed, list):
+        for entry in raw_failed:
+            try:
+                hotkey = str(entry["hotkey"])
+                reason = entry.get("pre_eval_reason")
+                if reason is not None:
+                    reason = str(reason)
+                pre_eval_failed[hotkey] = EpochSnapshotEntry(
+                    uid=int(entry["uid"]),
+                    hotkey=hotkey,
+                    pack_hash=str(entry["pack_hash"]),
+                    pack_url=str(entry["pack_url"]),
+                    refresh_time=str(entry.get("refresh_time", "")),
+                    pre_eval_status=str(entry.get("pre_eval_status", "failed")),
+                    pre_eval_reason=reason,
+                )
+            except (KeyError, TypeError, ValueError) as e:
+                logger.warning(
+                    "Snapshot %s: skipping malformed pre_eval_failed entry "
+                    "(%s): %r", path, e, entry,
+                )
+                continue
+
     snapshot = EvalSnapshot(
         window_number=loaded_window,
         window_start=window_start,
         snapshot_block=snapshot_block,
         commitments=commitments,
+        pre_eval_failed=pre_eval_failed,
     )
     logger.info(
-        "Loaded active-set snapshot for window %d (%d commitments) ← %s",
-        snapshot.window_number, len(snapshot.commitments), path,
+        "Loaded active-set snapshot for window %d "
+        "(%d passed, %d failed) ← %s",
+        snapshot.window_number,
+        len(snapshot.commitments),
+        len(snapshot.pre_eval_failed),
+        path,
     )
     return snapshot
 

--- a/trajectoryrl/utils/status_reporter.py
+++ b/trajectoryrl/utils/status_reporter.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 _BASE_URL = os.getenv("TRAJECTORYRL_API_BASE_URL", "https://trajrl.com")
 DEFAULT_HEARTBEAT_URL = f"{_BASE_URL}/api/v2/validators/heartbeat"
 DEFAULT_SUBMIT_URL = f"{_BASE_URL}/api/v2/scores/submit"
-DEFAULT_PRE_EVAL_URL = f"{_BASE_URL}/api/v2/miners/pre-eval"
+DEFAULT_EPOCH_SNAPSHOT_URL = f"{_BASE_URL}/api/v2/validators/epoch_snapshot"
 DEFAULT_LOGS_UPLOAD_URL = f"{_BASE_URL}/api/validators/logs/upload"
 DEFAULT_CYCLE_LOGS_URL = f"{_BASE_URL}/api/validators/logs/cycle"
 
@@ -87,129 +87,107 @@ async def heartbeat(
         return False
 
 
-# Cache keyed by (miner_hotkey, identifier) → last valid pre-eval response.
-_pre_eval_cache: Dict[tuple, Dict[str, Any]] = {}
+class SnapshotNotReady(Exception):
+    """Raised when /api/v2/validators/epoch_snapshot returns 404 for the
+    requested epoch (sync worker hasn't built it yet). Caller should
+    retry on the next loop iteration without treating this as a hard
+    failure."""
 
 
-def _is_valid_pre_eval_response(data: Any) -> bool:
-    """Check that the response has the expected pre-eval format."""
-    return isinstance(data, dict) and "allowed" in data
-
-
-async def pre_eval(
-    miner_hotkey: str,
-    pack_hash: Optional[str] = None,
-    pack_url: Optional[str] = None,
+async def fetch_epoch_snapshot(
+    epoch_number: int,
+    wallet,
     *,
-    epoch_number: Optional[int] = None,
-    wallet=None,
-    pre_eval_url: str = DEFAULT_PRE_EVAL_URL,
+    snapshot_url: str = DEFAULT_EPOCH_SNAPSHOT_URL,
+    timeout: float = 15.0,
 ) -> Optional[Dict[str, Any]]:
-    """Call the pre-eval API to check whether a miner's submission is allowed.
+    """Fetch the eval target set for ``epoch_number`` from trajrl.com.
 
-    Supports two query modes:
-      - By pack_hash: checks a specific pack (used during per-miner evaluation)
-      - By epoch_number: server resolves the most recently submitted pack in
-        that epoch (used during aggregation to avoid pack-switch escapes)
-
-    At least one of pack_hash or epoch_number must be provided.
-
-    Signing is optional — the v2 endpoint is read-only. When wallet is
-    provided, the request is signed for auditability.
-
-    Uses a local cache so that when the API is unreachable or returns an
-    unexpected format, the last known-good response is used instead of
-    blindly failing open.
+    The endpoint is the validator's only source for the eval set: it
+    absorbs both the on-chain commitment query and per-miner pre-eval
+    (each entry comes back with ``pre_eval_status`` baked in). The
+    snapshot is precomputed by the sync worker and frozen — every
+    validator gets byte-identical bytes for the same epoch.
 
     Args:
-        miner_hotkey: Miner hotkey to check.
-        pack_hash: Pack hash submitted by the miner. Required if
-            epoch_number is not provided.
-        pack_url: Pack download URL (optional context for the server).
-        epoch_number: Epoch/window number. When provided, the server
-            returns the eval result for the miner's most recently
-            submitted pack in that epoch.
-        wallet: bt.Wallet with accessible hotkey for signing (optional).
-        pre_eval_url: Pre-eval API endpoint.
+        epoch_number: Epoch (window) number for which to fetch the
+            snapshot. Non-negative integer.
+        wallet: bt.Wallet with accessible hotkey for signing. Signing
+            is required by the endpoint because the response includes
+            sensitive ``pack_url`` values for web-source submissions.
+        snapshot_url: Endpoint URL (override for tests).
+        timeout: HTTP timeout in seconds.
 
     Returns:
-        Parsed response dict on success or from cache, or None only if the
-        request failed AND no cached result exists (fail-open).
-    """
-    if pack_hash is None and epoch_number is None:
-        logger.warning("pre_eval: neither pack_hash nor epoch_number provided — failing open")
-        return None
+        Parsed response dict on HTTP 200 (with ``entries`` list, etc.).
+        ``None`` for any other outcome — 404 (snapshot not ready),
+        network error, auth/signature error, or unparseable JSON. The
+        caller is expected to retry on its next loop iteration.
 
-    cache_key = (miner_hotkey, pack_hash or f"epoch:{epoch_number}")
+    Raises:
+        SnapshotNotReady: When the server replies 404. Distinct from
+            ``None`` so callers that want to log "still building" vs.
+            "transient error" can differentiate. Currently the
+            validator path treats both as "skip this cycle, retry."
+    """
+    try:
+        hotkey_kp = wallet.hotkey
+    except Exception:
+        logger.error("fetch_epoch_snapshot: wallet hotkey not available")
+        return None
+    hotkey_addr = hotkey_kp.ss58_address
+    timestamp = int(time.time())
+
+    # The endpoint expects its own dedicated signing prefix
+    # (``trajectoryrl-snapshot``); other v2 endpoints use different
+    # prefixes (e.g. /api/v2/scores/submit uses ``trajectoryrl-submit``,
+    # /api/v2/validators/heartbeat uses ``trajectoryrl-heartbeat``).
+    message = f"trajectoryrl-snapshot:{hotkey_addr}:{timestamp}"
+    sig = hotkey_kp.sign(message.encode())
+    signature = "0x" + (sig if isinstance(sig, bytes) else bytes(sig)).hex()
 
     payload: Dict[str, Any] = {
-        "miner_hotkey": miner_hotkey,
+        "epoch_number": epoch_number,
+        "validator_hotkey": hotkey_addr,
+        "timestamp": timestamp,
+        "signature": signature,
     }
-    if pack_hash is not None:
-        payload["pack_hash"] = pack_hash
-    if epoch_number is not None:
-        payload["epoch_number"] = epoch_number
-    if pack_url is not None:
-        payload["pack_url"] = pack_url
-
-    if wallet is not None:
-        try:
-            hotkey_kp = wallet.hotkey
-            validator_hotkey = hotkey_kp.ss58_address
-            timestamp = int(time.time())
-            message = f"trajectoryrl-report:{validator_hotkey}:{timestamp}"
-            sig = hotkey_kp.sign(message.encode())
-            signature = "0x" + (sig if isinstance(sig, bytes) else bytes(sig)).hex()
-            payload["validator_hotkey"] = validator_hotkey
-            payload["timestamp"] = timestamp
-            payload["signature"] = signature
-        except Exception:
-            logger.debug("pre_eval: wallet hotkey not available, sending unsigned")
 
     try:
         async with httpx.AsyncClient() as client:
-            resp = await client.post(pre_eval_url, json=payload, timeout=10)
-        if resp.status_code == 200:
+            resp = await client.post(snapshot_url, json=payload, timeout=timeout)
+    except Exception as e:
+        logger.warning("fetch_epoch_snapshot error for epoch %d: %s", epoch_number, e)
+        return None
+
+    if resp.status_code == 200:
+        try:
             data = resp.json()
-            if _is_valid_pre_eval_response(data):
-                _pre_eval_cache[cache_key] = data
-                logger.info(
-                    "Pre-eval check passed: allowed=%s reason=%s",
-                    data.get("allowed"),
-                    data.get("reason", ""),
-                )
-                return data
+        except Exception as e:
             logger.warning(
-                "Pre-eval returned unexpected format (keys=%s)",
+                "fetch_epoch_snapshot epoch %d: response not JSON-decodable: %s",
+                epoch_number, e,
+            )
+            return None
+        if not isinstance(data, dict) or "entries" not in data:
+            logger.warning(
+                "fetch_epoch_snapshot epoch %d: unexpected payload shape (keys=%s)",
+                epoch_number,
                 list(data.keys()) if isinstance(data, dict) else type(data).__name__,
             )
-        else:
-            logger.warning(
-                "Pre-eval check failed: %d %s",
-                resp.status_code,
-                resp.text[:200],
-            )
-    except Exception as e:
-        logger.warning("Pre-eval check error: %s", e)
+            return None
+        return data
 
-    # API failed or returned bad data — fall back to cache.
-    cached = _pre_eval_cache.get(cache_key)
-    if cached is not None:
-        identifier = pack_hash[:12] if pack_hash else f"epoch:{epoch_number}"
+    if resp.status_code == 404:
         logger.info(
-            "Using cached pre-eval result for %s/%s: allowed=%s",
-            miner_hotkey[:8],
-            identifier,
-            cached.get("allowed"),
+            "fetch_epoch_snapshot epoch %d: snapshot not yet built (HTTP 404)",
+            epoch_number,
         )
-        return cached
+        raise SnapshotNotReady(epoch_number)
 
-    # No cache available — fail-open.
-    identifier = pack_hash[:12] if pack_hash else f"epoch:{epoch_number}"
     logger.warning(
-        "No cached pre-eval for %s/%s — failing open",
-        miner_hotkey[:8],
-        identifier,
+        "fetch_epoch_snapshot epoch %d: HTTP %d %s",
+        epoch_number, resp.status_code, resp.text[:200],
     )
     return None
 


### PR DESCRIPTION
Replace the chain-side commitment scan and per-miner pre-eval pipeline with a single fetch from /api/v2/validators/epoch_snapshot. The endpoint returns an immutable, byte-identical-per-epoch snapshot that already encodes pre-eval verdicts; validators read it once at cycle start and surface failed entries as rejection submissions.

Eval flow now:
  - cycle start: fetch snapshot, fire rejection rows for failed entries (_dispatch_pre_eval_rejections), eval-loop iterates only over passed entries
  - aggregation: no per-miner gate; failed miners cannot reach consensus_scores because no validator scored them

Removed:
  - eval-loop and aggregation-phase per-miner pre_eval HTTP fan-outs
  - trajectoryrl.utils.status_reporter.pre_eval and helpers
  - tools/analyze_consensus.py --use-pre-eval gate
  - TRAJECTORYRL_PRE_EVAL_ENABLED env var
  - SNAPSHOT_FORMAT_VERSION constant (the on-disk file is just a cache; if the API contract changes the code follows -- version management belongs to the codebase, not the cache file)

Docs:
  - INCENTIVE_MECHANISM.md "Deterministic Active-Set Snapshot" rewritten against the new API source + restart/cache behavior
  - INCENTIVE_MECHANISM.md "Pre-Eval Gate" rewritten against the snapshot-baked verdict (no more per-miner HTTP)
  - VALIDATOR_OPERATIONS.md signing prefix corrected to \`trajectoryrl-snapshot:\` (3 locations)