### PR TITLE
 [coding-agent] miner: add web-submit subcommand for /api/v2/miners/submit

### DIFF
--- a/docs/MINER_OPERATIONS.md
+++ b/docs/MINER_OPERATIONS.md
@@ -56,9 +56,12 @@ python neurons/miner.py submit https://your-bucket.s3.amazonaws.com/pack.json
 **Option B — Managed hosting via `/api/v2/miners/submit`**
 
 ```bash
-# 3b + 4b. Submit pack content to trajrl.com (managed GCS) and chain-commit in one step
-python neurons/miner.py web-submit pack.json --commit-onchain
-# → prints pack_url + cooldown info, then submits the on-chain commitment
+# 3b. Submit pack content to trajrl.com (managed GCS), get back pack_url
+python neurons/miner.py web-submit pack.json
+# → prints pack_url + cooldown info
+
+# 4b. Submit on-chain (same step as Option A)
+python neurons/miner.py submit <pack_url>
 ```
 
 Then check status:
@@ -77,7 +80,7 @@ That's it. Repeat steps 1 → 4 whenever you improve your SKILL.md.
 python neurons/miner.py build       <skill_md_path> [-o pack.json]
 python neurons/miner.py validate    <pack.json>
 python neurons/miner.py upload      <pack.json> [--bucket ...] [--endpoint-url ...]
-python neurons/miner.py web-submit  <pack.json> [--commit-onchain] [--api-base-url ...]
+python neurons/miner.py web-submit  <pack.json> [--api-base-url ...]
 python neurons/miner.py submit      <pack_url>
 python neurons/miner.py status
 ```
@@ -123,13 +126,14 @@ Reads S3 config from environment or CLI flags. Returns the public URL for use wi
 
 Submit pack content directly to the managed web service (`POST /api/v2/miners/submit`). The server stores your pack at an unguessable random GCS path and returns the public URL. No S3 / R2 / bucket config required — the request is signed with your hotkey, so the only credential you need is the wallet itself.
 
+This command does **only** the HTTP upload — it does not touch the chain. The on-chain commit is a separate step, run via `submit <pack_url>` (same step you'd run after `upload`).
+
 ```bash
 python neurons/miner.py web-submit pack.json
-python neurons/miner.py web-submit pack.json --commit-onchain
 python neurons/miner.py web-submit pack.json --api-base-url https://staging.trajrl.com
 ```
 
-Output (without `--commit-onchain`):
+Output:
 
 ```
 Pack hash: a3f8c2...
@@ -143,8 +147,6 @@ Submitted! pack_url = https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<ra
 
 Next step: python neurons/miner.py submit https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<random_key>.json
 ```
-
-With `--commit-onchain`, the on-chain commit step runs immediately after the web submit and you skip the separate `submit <url>` invocation.
 
 **Cooldown**: The endpoint enforces a per-miner cooldown (default **1 hour**, set server-side via `MINER_SUBMIT_COOLDOWN_SECONDS`). Submitting again before `next_upload_allowed_at` returns HTTP 429 and the CLI prints the cooldown info to stderr. Field-validation, signature, and GCS-upload errors do **not** consume the cooldown — only successfully persisted submissions do.
 
@@ -254,7 +256,6 @@ For what to write in SKILL.md, see [MINER_GUIDE.md § Writing SKILL.md](MINER_GU
 │       • upload      → self-hosted public URL            │
 │       • web-submit  → managed GCS URL via /api/v2/...   │
 │  4. submit → on-chain commitment                        │
-│       (web-submit --commit-onchain folds 3+4 together)  │
 │  5. Wait for validator evaluation (~24h epoch)           │
 │  6. Check results, iterate                              │
 └─────────────────────────────────────────────────────────┘

--- a/docs/MINER_OPERATIONS.md
+++ b/docs/MINER_OPERATIONS.md
@@ -23,11 +23,13 @@ The miner CLI is a **toolbox**: independent commands you compose however you wan
 | **Bittensor wallet** | `btcli wallet create --wallet.name miner --wallet.hotkey default` |
 | **Registration** | `btcli subnet register --netuid 11 --wallet.name miner` (dynamic cost) |
 | **Python** | 3.10+ |
-| **HTTP hosting** | Any public HTTP(S) endpoint for pack hosting (S3, GCS, GitHub raw, etc.) |
+| **Pack hosting** | Either self-hosted (S3/R2/GCS/GitHub raw/etc.) **or** managed via `/api/v2/miners/submit` (no infra needed — see "Managed hosting" below) |
 
 ---
 
 ## Quick Start
+
+Pick **one** hosting option for step 3. Self-hosted gives you control over the URL; managed lets you skip the storage setup entirely.
 
 ```bash
 git clone https://github.com/trajectoryRL/trajectoryRL.git
@@ -38,28 +40,45 @@ vim SKILL.md
 
 # 2. Build pack
 python neurons/miner.py build SKILL.md -o pack.json
+```
 
-# 3. Upload to S3-compatible storage
+**Option A — Self-hosted (S3 / R2 / GCS / etc.)**
+
+```bash
+# 3a. Upload to your own S3-compatible bucket
 python neurons/miner.py upload pack.json
+# → prints https://your-bucket.s3.amazonaws.com/pack.json
 
-# 4. Submit on-chain
+# 4a. Submit on-chain
 python neurons/miner.py submit https://your-bucket.s3.amazonaws.com/pack.json
+```
 
-# 5. Check status
+**Option B — Managed hosting via `/api/v2/miners/submit`**
+
+```bash
+# 3b + 4b. Submit pack content to trajrl.com (managed GCS) and chain-commit in one step
+python neurons/miner.py web-submit pack.json --commit-onchain
+# → prints pack_url + cooldown info, then submits the on-chain commitment
+```
+
+Then check status:
+
+```bash
 python neurons/miner.py status
 ```
 
-That's it. Repeat steps 1-4 whenever you improve your SKILL.md.
+That's it. Repeat steps 1 → 4 whenever you improve your SKILL.md.
 
 ---
 
 ## CLI Reference
 
 ```bash
-python neurons/miner.py build     <skill_md_path> [-o pack.json]
-python neurons/miner.py validate  <pack.json>
-python neurons/miner.py upload    <pack.json> [--bucket ...] [--endpoint-url ...]
-python neurons/miner.py submit    <pack_url>
+python neurons/miner.py build       <skill_md_path> [-o pack.json]
+python neurons/miner.py validate    <pack.json>
+python neurons/miner.py upload      <pack.json> [--bucket ...] [--endpoint-url ...]
+python neurons/miner.py web-submit  <pack.json> [--commit-onchain] [--api-base-url ...]
+python neurons/miner.py submit      <pack_url>
 python neurons/miner.py status
 ```
 
@@ -99,6 +118,41 @@ python neurons/miner.py upload pack.json --bucket my-bucket --endpoint-url https
 ```
 
 Reads S3 config from environment or CLI flags. Returns the public URL for use with `submit`.
+
+### web-submit
+
+Submit pack content directly to the managed web service (`POST /api/v2/miners/submit`). The server stores your pack at an unguessable random GCS path and returns the public URL. No S3 / R2 / bucket config required — the request is signed with your hotkey, so the only credential you need is the wallet itself.
+
+```bash
+python neurons/miner.py web-submit pack.json
+python neurons/miner.py web-submit pack.json --commit-onchain
+python neurons/miner.py web-submit pack.json --api-base-url https://staging.trajrl.com
+```
+
+Output (without `--commit-onchain`):
+
+```
+Pack hash: a3f8c2...
+Endpoint: https://trajrl.com/api/v2/miners/submit
+Submitting pack content to web service...
+Submitted! pack_url = https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<random_key>.json
+  submission_id:    12345
+  cooldown_seconds: 3600
+  next_upload_at:   2026-05-04T15:00:00.000Z
+  pre_eval_status:  pending
+
+Next step: python neurons/miner.py submit https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<random_key>.json
+```
+
+With `--commit-onchain`, the on-chain commit step runs immediately after the web submit and you skip the separate `submit <url>` invocation.
+
+**Cooldown**: The endpoint enforces a per-miner cooldown (default **1 hour**, set server-side via `MINER_SUBMIT_COOLDOWN_SECONDS`). Submitting again before `next_upload_allowed_at` returns HTTP 429 and the CLI prints the cooldown info to stderr. Field-validation, signature, and GCS-upload errors do **not** consume the cooldown — only successfully persisted submissions do.
+
+**Idempotency**: Resubmitting the **same** `(hotkey, pack_hash)` after the cooldown lifts is safe — the server reuses the existing `pack_url` (no re-upload), so the URL you got the first time stays valid.
+
+**Hash & signing**: The CLI canonicalises the pack as `json.dumps(pack, sort_keys=True)` (matches the validator's hash convention) and signs `trajectoryrl-miner-submit:{hotkey}:{timestamp}` with sr25519. The server recomputes the hash from `pack_content` and rejects on mismatch.
+
+> **`pack_url` is sensitive until the 48 h reveal gate.** The URL is intentionally unguessable so competitors can't enumerate packs by hotkey/uid/hash. Don't paste it into Discord, public dashboards, or shared logs — leaking the URL lets other miners hash-match and chain-commit a copy of your pack.
 
 ### submit
 
@@ -141,6 +195,14 @@ The CLI reads wallet and storage config from environment variables. Create a `.e
 | `WALLET_HOTKEY` | yes | `default` | Bittensor hotkey |
 | `NETUID` | yes | `11` | Subnet ID |
 | `NETWORK` | yes | `finney` | Bittensor network |
+
+### Managed hosting (for `web-submit` command)
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `TRAJECTORYRL_API_BASE_URL` | no | `https://trajrl.com` | Override the web service base URL (for staging / self-hosted). The CLI also accepts `--api-base-url` per-invocation. |
+
+No HMAC keys / bucket credentials needed — the request is signed with the miner's bittensor hotkey.
 
 ### S3-Compatible Storage (for `upload` command)
 
@@ -188,14 +250,30 @@ For what to write in SKILL.md, see [MINER_GUIDE.md § Writing SKILL.md](MINER_GU
 │                                                         │
 │  1. Write / iterate on SKILL.md                         │
 │  2. build → pack.json                                   │
-│  3. upload → public URL                                 │
+│  3. host:                                               │
+│       • upload      → self-hosted public URL            │
+│       • web-submit  → managed GCS URL via /api/v2/...   │
 │  4. submit → on-chain commitment                        │
+│       (web-submit --commit-onchain folds 3+4 together)  │
 │  5. Wait for validator evaluation (~24h epoch)           │
 │  6. Check results, iterate                              │
 └─────────────────────────────────────────────────────────┘
 ```
 
 Validators only re-evaluate when your `pack_hash` changes. No need to resubmit if your SKILL.md hasn't changed.
+
+### Picking a hosting option
+
+| | `upload` (self-hosted) | `web-submit` (managed) |
+|---|---|---|
+| Infra you run | S3 / R2 / GCS bucket + HMAC keys | none — request is signed with your hotkey |
+| URL you control | yes (your domain / bucket) | no (random GCS key under `trajrl.com`) |
+| Rate limit | bucket-side, not enforced by subnet | 1 successful submission / hour / hotkey |
+| Idempotent re-submit | always (same key = same URL) | yes — same `(hotkey, pack_hash)` reuses URL after cooldown |
+| Pre-eval feedback loop | none — wait for next epoch's snapshot | server runs pre-eval async; reflected in the next epoch_snapshot |
+| Best for | miners with existing infra / custom storage | new miners or anyone wanting one-command publishing |
+
+The on-chain commit step (and therefore the validator discovery path) is identical in both cases — `<pack_hash>|<pack_url>` written via `set_commitment`.
 
 ---
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -5,7 +5,7 @@ Commands:
     python neurons/miner.py build       SKILL.md [-o pack.json]
     python neurons/miner.py validate    pack.json
     python neurons/miner.py upload      pack.json [--bucket ...] [--endpoint-url ...]
-    python neurons/miner.py web-submit  pack.json [--commit-onchain] [--api-base-url ...]
+    python neurons/miner.py web-submit  pack.json [--api-base-url ...]
     python neurons/miner.py submit      <pack_url>
     python neurons/miner.py status
 
@@ -188,8 +188,8 @@ def cmd_web_submit(args):
     print("Submitting pack content to web service...")
 
     response = miner.submit_pack_via_api(pack, submit_url=submit_url)
+    miner.close()
     if response is None:
-        miner.close()
         print("Submission failed. Check logs for details.")
         return 1
 
@@ -199,22 +199,9 @@ def cmd_web_submit(args):
     print(f"  cooldown_seconds: {response.get('cooldown_seconds')}")
     print(f"  next_upload_at:   {response.get('next_upload_allowed_at')}")
     print(f"  pre_eval_status:  {response.get('pre_eval_status')}")
-
-    if not args.commit_onchain:
-        miner.close()
-        print()
-        print(f"Next step: python neurons/miner.py submit {pack_url}")
-        return 0
-
     print()
-    print("Submitting on-chain commitment...")
-    success = miner.submit_commitment(pack_hash, pack_url)
-    miner.close()
-    if success:
-        print("On-chain commitment submitted.")
-        return 0
-    print("On-chain commitment failed. Check logs.")
-    return 1
+    print(f"Next step: python neurons/miner.py submit {pack_url}")
+    return 0
 
 
 def cmd_submit(args):
@@ -303,7 +290,7 @@ Examples:
   %(prog)s build SKILL.md -o pack.json
   %(prog)s validate pack.json
   %(prog)s upload pack.json                                # self-host on S3 / R2 / etc.
-  %(prog)s web-submit pack.json --commit-onchain           # managed GCS via trajrl.com
+  %(prog)s web-submit pack.json                            # managed GCS via trajrl.com
   %(prog)s submit https://your-bucket.s3.amazonaws.com/pack.json
   %(prog)s status
 """,
@@ -333,13 +320,10 @@ Examples:
     # web-submit
     p_web = sub.add_parser(
         "web-submit",
-        help="Submit pack via /api/v2/miners/submit (managed GCS hosting)",
+        help="Submit pack via /api/v2/miners/submit (managed GCS hosting); "
+             "follow up with `submit <pack_url>` for the on-chain commit",
     )
     p_web.add_argument("pack_path", help="Path to pack.json")
-    p_web.add_argument(
-        "--commit-onchain", action="store_true",
-        help="Also run the on-chain commitment step after a successful submit",
-    )
     p_web.add_argument(
         "--api-base-url", default=None,
         help="Override TRAJECTORYRL_API_BASE_URL for this run (default: https://trajrl.com)",

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -2,15 +2,17 @@
 """TrajectoryRL Miner — CLI toolbox for pack building and submission.
 
 Commands:
-    python neurons/miner.py build     SKILL.md [-o pack.json]
-    python neurons/miner.py validate  pack.json
-    python neurons/miner.py upload    pack.json [--bucket ...] [--endpoint-url ...]
-    python neurons/miner.py submit    <pack_url>
+    python neurons/miner.py build       SKILL.md [-o pack.json]
+    python neurons/miner.py validate    pack.json
+    python neurons/miner.py upload      pack.json [--bucket ...] [--endpoint-url ...]
+    python neurons/miner.py web-submit  pack.json [--commit-onchain] [--api-base-url ...]
+    python neurons/miner.py submit      <pack_url>
     python neurons/miner.py status
 
 Config is loaded from .env.miner (or environment variables):
     WALLET_NAME, WALLET_HOTKEY, NETUID, NETWORK
     S3_BUCKET, S3_ENDPOINT_URL, S3_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+    TRAJECTORYRL_API_BASE_URL (defaults to https://trajrl.com)
 """
 
 from __future__ import annotations
@@ -153,6 +155,68 @@ def cmd_upload(args):
     return 0
 
 
+def cmd_web_submit(args):
+    from trajectoryrl.base.miner import TrajectoryMiner, DEFAULT_MINER_SUBMIT_URL
+    from trajectoryrl.utils.config import MinerConfig
+
+    try:
+        pack = TrajectoryMiner.load_pack(args.pack_path)
+    except FileNotFoundError:
+        print(f"Error: file not found: {args.pack_path}")
+        return 1
+    except json.JSONDecodeError as e:
+        print(f"Error: invalid JSON: {e}")
+        return 1
+
+    issues = TrajectoryMiner.validate_s1(pack)
+    if issues:
+        print("Error: pack validation failed:")
+        for issue in issues:
+            print(f"  - {issue}")
+        return 1
+
+    pack_hash = TrajectoryMiner.compute_pack_hash(pack)
+    submit_url = (
+        f"{args.api_base_url.rstrip('/')}/api/v2/miners/submit"
+        if args.api_base_url else DEFAULT_MINER_SUBMIT_URL
+    )
+
+    config = MinerConfig.from_env()
+    miner = _make_miner(config)
+    print(f"Pack hash: {pack_hash}")
+    print(f"Endpoint: {submit_url}")
+    print("Submitting pack content to web service...")
+
+    response = miner.submit_pack_via_api(pack, submit_url=submit_url)
+    if response is None:
+        miner.close()
+        print("Submission failed. Check logs for details.")
+        return 1
+
+    pack_url = response.get("pack_url")
+    print(f"Submitted! pack_url = {pack_url}")
+    print(f"  submission_id:    {response.get('submission_id')}")
+    print(f"  cooldown_seconds: {response.get('cooldown_seconds')}")
+    print(f"  next_upload_at:   {response.get('next_upload_allowed_at')}")
+    print(f"  pre_eval_status:  {response.get('pre_eval_status')}")
+
+    if not args.commit_onchain:
+        miner.close()
+        print()
+        print(f"Next step: python neurons/miner.py submit {pack_url}")
+        return 0
+
+    print()
+    print("Submitting on-chain commitment...")
+    success = miner.submit_commitment(pack_hash, pack_url)
+    miner.close()
+    if success:
+        print("On-chain commitment submitted.")
+        return 0
+    print("On-chain commitment failed. Check logs.")
+    return 1
+
+
 def cmd_submit(args):
     from trajectoryrl.base.miner import TrajectoryMiner
     from trajectoryrl.utils.config import MinerConfig
@@ -238,7 +302,8 @@ def main():
 Examples:
   %(prog)s build SKILL.md -o pack.json
   %(prog)s validate pack.json
-  %(prog)s upload pack.json
+  %(prog)s upload pack.json                                # self-host on S3 / R2 / etc.
+  %(prog)s web-submit pack.json --commit-onchain           # managed GCS via trajrl.com
   %(prog)s submit https://your-bucket.s3.amazonaws.com/pack.json
   %(prog)s status
 """,
@@ -265,6 +330,21 @@ Examples:
     p_upload.add_argument("--endpoint-url", default=None, help="Override S3_ENDPOINT_URL")
     p_upload.add_argument("--region", default=None, help="Override S3_REGION")
 
+    # web-submit
+    p_web = sub.add_parser(
+        "web-submit",
+        help="Submit pack via /api/v2/miners/submit (managed GCS hosting)",
+    )
+    p_web.add_argument("pack_path", help="Path to pack.json")
+    p_web.add_argument(
+        "--commit-onchain", action="store_true",
+        help="Also run the on-chain commitment step after a successful submit",
+    )
+    p_web.add_argument(
+        "--api-base-url", default=None,
+        help="Override TRAJECTORYRL_API_BASE_URL for this run (default: https://trajrl.com)",
+    )
+
     # submit
     p_submit = sub.add_parser("submit", help="Submit pack on-chain")
     p_submit.add_argument("pack_url", help="Public URL where pack.json is hosted")
@@ -288,6 +368,7 @@ Examples:
         "build": cmd_build,
         "validate": cmd_validate,
         "upload": cmd_upload,
+        "web-submit": cmd_web_submit,
         "submit": cmd_submit,
         "status": cmd_status,
     }

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -459,7 +459,6 @@ class TestCLIHelp:
         """'miner.py web-submit --help' must show pack_path + flags."""
         output = self._get_help("web-submit")
         assert "pack_path" in output
-        assert "--commit-onchain" in output
         assert "--api-base-url" in output
 
 

--- a/tests/test_miner.py
+++ b/tests/test_miner.py
@@ -450,7 +450,168 @@ class TestCLIHelp:
     def test_top_level_help_shows_subcommands(self):
         """'miner.py --help' must list all subcommands."""
         output = self._get_help("")
-        for cmd in ("build", "validate", "upload", "submit", "status"):
+        for cmd in ("build", "validate", "upload", "web-submit", "submit", "status"):
             assert cmd in output, (
                 f"top-level --help should list '{cmd}', got:\n{output}"
             )
+
+    def test_web_submit_help_shows_pack_path(self):
+        """'miner.py web-submit --help' must show pack_path + flags."""
+        output = self._get_help("web-submit")
+        assert "pack_path" in output
+        assert "--commit-onchain" in output
+        assert "--api-base-url" in output
+
+
+# ===================================================================
+# /api/v2/miners/submit — submit_pack_via_api
+# ===================================================================
+
+
+class TestSubmitPackViaApi:
+    """Unit tests for ``TrajectoryMiner.submit_pack_via_api``.
+
+    Mock out the wallet (so we never hit a real keystore), the
+    subtensor (never opens a websocket), and the HTTP client (we
+    inspect the payload + simulate server responses).
+    """
+
+    PACK = {"schema_version": 1, "files": {"SKILL.md": "# hello\nact wisely\n"}}
+    HOTKEY_ADDR = "5FFApaS75bvpgP9gQ5hTUdZHiTc6LB2VPP9gvHN6VQCNug6e"
+
+    def _make_miner(self):
+        """Build a TrajectoryMiner with mocked wallet (sign + ss58_address)."""
+        miner = TrajectoryMiner(
+            wallet_name="m", wallet_hotkey="default",
+            netuid=11, network="finney",
+        )
+        wallet = MagicMock()
+        wallet.hotkey.ss58_address = self.HOTKEY_ADDR
+        wallet.hotkey.sign.return_value = b"\xaa" * 64
+        miner._wallet = wallet
+        return miner
+
+    def _fake_response(self, status_code: int, json_body=None, text=""):
+        resp = MagicMock()
+        resp.status_code = status_code
+        if json_body is not None:
+            resp.json.return_value = json_body
+        else:
+            resp.json.side_effect = ValueError("not json")
+        resp.text = text
+        return resp
+
+    def _patched_client(self, response):
+        """Return a contextmanager-friendly httpx.Client mock."""
+        client = MagicMock()
+        client.post.return_value = response
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        return client
+
+    def test_success_path_returns_response_dict(self):
+        """200 response is parsed and returned with all server fields."""
+        miner = self._make_miner()
+        body = {
+            "success": True,
+            "pack_hash": TrajectoryMiner.compute_pack_hash(self.PACK),
+            "pack_url": "https://storage.googleapis.com/bucket/abc.json",
+            "submission_id": 42,
+            "next_upload_allowed_at": "2026-05-04T15:00:00.000Z",
+            "cooldown_seconds": 3600,
+            "pre_eval_status": "pending",
+        }
+        client = self._patched_client(self._fake_response(200, json_body=body))
+
+        with patch("trajectoryrl.base.miner.httpx.Client", return_value=client):
+            result = miner.submit_pack_via_api(self.PACK)
+
+        assert result == body
+        # Inspect the outgoing payload — the server uses these fields
+        # to verify the request, so the contract must match the spec
+        # exactly (canonical pack, hash matches, signed message, etc).
+        called_url, kwargs = client.post.call_args[0], client.post.call_args[1]
+        assert called_url[0].endswith("/api/v2/miners/submit")
+        payload = kwargs["json"]
+        assert payload["miner_hotkey"] == self.HOTKEY_ADDR
+        assert payload["pack_content"] == json.dumps(self.PACK, sort_keys=True)
+        assert payload["pack_hash"] == TrajectoryMiner.compute_pack_hash(self.PACK)
+        assert payload["signature"].startswith("0x")
+        assert isinstance(payload["timestamp"], int)
+
+    def test_signing_message_uses_dedicated_prefix(self):
+        """The submit endpoint expects ``trajectoryrl-miner-submit:`` —
+        not the validator-side ``trajectoryrl-report:`` shared prefix."""
+        miner = self._make_miner()
+        client = self._patched_client(self._fake_response(
+            200, json_body={"pack_url": "https://x", "submission_id": 1},
+        ))
+        with patch("trajectoryrl.base.miner.httpx.Client", return_value=client):
+            miner.submit_pack_via_api(self.PACK)
+
+        signed_message = miner._wallet.hotkey.sign.call_args[0][0]
+        assert signed_message.decode().startswith(
+            f"trajectoryrl-miner-submit:{self.HOTKEY_ADDR}:"
+        )
+
+    def test_429_cooldown_returns_none(self):
+        """429 (cooldown) is logged with next_upload_allowed_at and
+        returned as None — caller should not retry."""
+        miner = self._make_miner()
+        client = self._patched_client(self._fake_response(
+            429,
+            json_body={
+                "next_upload_allowed_at": "2026-05-04T15:00:00.000Z",
+                "cooldown_seconds": 3600,
+            },
+            text="cooldown",
+        ))
+        with patch("trajectoryrl.base.miner.httpx.Client", return_value=client):
+            result = miner.submit_pack_via_api(self.PACK)
+        assert result is None
+
+    def test_4xx_returns_none(self):
+        """400/403 (validation / signature / ban) returns None."""
+        miner = self._make_miner()
+        for status in (400, 403):
+            client = self._patched_client(self._fake_response(
+                status, text=f"HTTP {status} body",
+            ))
+            with patch("trajectoryrl.base.miner.httpx.Client", return_value=client):
+                result = miner.submit_pack_via_api(self.PACK)
+            assert result is None, f"status={status} should map to None"
+
+    def test_network_error_returns_none(self):
+        """httpx exception is caught and surfaces as None."""
+        miner = self._make_miner()
+        client = MagicMock()
+        client.__enter__ = MagicMock(return_value=client)
+        client.__exit__ = MagicMock(return_value=False)
+        client.post.side_effect = RuntimeError("boom")
+        with patch("trajectoryrl.base.miner.httpx.Client", return_value=client):
+            result = miner.submit_pack_via_api(self.PACK)
+        assert result is None
+
+    def test_oversize_pack_refused_locally_no_http(self):
+        """A pack that exceeds 32 KB must be rejected client-side
+        before any HTTP call (the server would reject it anyway)."""
+        miner = self._make_miner()
+        big_pack = {
+            "schema_version": 1,
+            "files": {"SKILL.md": "x" * 40000},
+        }
+        client = self._patched_client(self._fake_response(200))
+        with patch("trajectoryrl.base.miner.httpx.Client", return_value=client):
+            result = miner.submit_pack_via_api(big_pack)
+        assert result is None
+        assert client.post.call_count == 0
+
+    def test_unparseable_200_returns_none(self):
+        """A 200 response with non-JSON body or missing pack_url is
+        treated as a failure — the caller cannot proceed without the
+        URL it needs to chain-commit."""
+        miner = self._make_miner()
+        client = self._patched_client(self._fake_response(200))  # json() raises
+        with patch("trajectoryrl.base.miner.httpx.Client", return_value=client):
+            result = miner.submit_pack_via_api(self.PACK)
+        assert result is None

--- a/trajectoryrl/base/miner.py
+++ b/trajectoryrl/base/miner.py
@@ -3,7 +3,11 @@
 Season 1 workflow:
     1. Write SKILL.md
     2. Build pack: build_s1_pack(skill_content) -> {"schema_version": 1, "files": {"SKILL.md": "..."}}
-    3. Upload pack.json to a public HTTP endpoint
+    3. Host pack.json — either:
+        a. Self-hosted (S3-compatible bucket, R2, etc.), or
+        b. Submit to the managed web service via ``submit_pack_via_api``
+           (POST /api/v2/miners/submit) — server stores the pack at a
+           random GCS key and returns the URL
     4. Submit on-chain commitment via submit_commitment(pack_hash, pack_url)
 
 The on-chain commitment is block-timestamped, establishing first-mover
@@ -14,10 +18,12 @@ import hashlib
 import json
 import logging
 import os
+import time
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import bittensor as bt
+import httpx
 
 from ..utils.commitments import parse_commitment
 
@@ -25,6 +31,13 @@ logger = logging.getLogger(__name__)
 
 MAX_COMMITMENT_BYTES = 128
 MAX_PACK_SIZE = 32768
+
+# /api/v2/miners/submit lives under the same TrajectoryRL web service
+# the validator talks to (heartbeat / scores submit / epoch_snapshot).
+DEFAULT_API_BASE_URL = os.environ.get(
+    "TRAJECTORYRL_API_BASE_URL", "https://trajrl.com"
+)
+DEFAULT_MINER_SUBMIT_URL = f"{DEFAULT_API_BASE_URL}/api/v2/miners/submit"
 
 
 class TrajectoryMiner:
@@ -264,6 +277,137 @@ class TrajectoryMiner:
         except Exception as e:
             logger.error("Failed to submit commitment (%s): %s", type(e).__name__, e)
             return False
+
+    # ------------------------------------------------------------------
+    # Managed web submission (POST /api/v2/miners/submit)
+    # ------------------------------------------------------------------
+
+    def submit_pack_via_api(
+        self,
+        pack: dict,
+        *,
+        submit_url: str = DEFAULT_MINER_SUBMIT_URL,
+        timeout: float = 30.0,
+    ) -> Optional[Dict[str, Any]]:
+        """Submit a pack to the managed web service (POST /api/v2/miners/submit).
+
+        The web service stores the pack in GCS under a random key and
+        returns a public ``pack_url`` that the miner subsequently
+        commits on-chain via ``submit_commitment``. This is an
+        alternative to self-hosting (R2, S3, etc.) — the chain
+        commitment step is identical in both cases.
+
+        Args:
+            pack: The pack dict (will be canonicalized and hashed).
+            submit_url: Endpoint URL (override for tests / staging).
+            timeout: HTTP timeout in seconds.
+
+        Returns:
+            The parsed server response on HTTP 200 — keys include
+            ``pack_url``, ``pack_hash``, ``submission_id``,
+            ``cooldown_seconds``, ``next_upload_allowed_at``,
+            ``pre_eval_status``. ``None`` on any non-200 outcome
+            (logged as warning/error). 429 (cooldown) is returned as
+            ``None`` — inspect logs for ``next_upload_allowed_at``.
+
+        Notes:
+            * Per-miner cooldown is enforced server-side (default 1h).
+              Resubmitting the same ``(hotkey, pack_hash)`` after the
+              cooldown lifts is idempotent — the existing pack_url is
+              reused without a fresh GCS upload.
+            * Pre-eval runs asynchronously after the response. The
+              miner / validators see the final verdict in subsequent
+              ``/api/v2/validators/epoch_snapshot`` reads.
+        """
+        canonical = json.dumps(pack, sort_keys=True)
+        if len(canonical.encode("utf-8")) > MAX_PACK_SIZE:
+            logger.error(
+                "Pack canonical size exceeds %d bytes — refusing to submit",
+                MAX_PACK_SIZE,
+            )
+            return None
+
+        pack_hash = hashlib.sha256(canonical.encode()).hexdigest()
+
+        try:
+            hotkey_kp = self.wallet.hotkey
+        except Exception as e:
+            logger.error("Cannot access wallet hotkey for signing: %s", e)
+            return None
+        hotkey_addr = hotkey_kp.ss58_address
+        timestamp = int(time.time())
+
+        # Endpoint-specific signing prefix per API.md § /api/v2/miners/submit.
+        message = f"trajectoryrl-miner-submit:{hotkey_addr}:{timestamp}"
+        sig = hotkey_kp.sign(message.encode())
+        signature = "0x" + (sig if isinstance(sig, bytes) else bytes(sig)).hex()
+
+        payload = {
+            "miner_hotkey": hotkey_addr,
+            "timestamp": timestamp,
+            "signature": signature,
+            "pack_hash": pack_hash,
+            "pack_content": canonical,
+        }
+
+        logger.info(
+            "Submitting pack to %s (hash=%s..., %d bytes)",
+            submit_url, pack_hash[:12], len(canonical.encode("utf-8")),
+        )
+
+        try:
+            with httpx.Client() as client:
+                resp = client.post(submit_url, json=payload, timeout=timeout)
+        except Exception as e:
+            logger.error("Network error submitting pack: %s", e)
+            return None
+
+        if resp.status_code == 200:
+            try:
+                data = resp.json()
+            except Exception as e:
+                logger.error("Submit response not JSON-decodable: %s", e)
+                return None
+            if not isinstance(data, dict) or "pack_url" not in data:
+                logger.error(
+                    "Submit response shape unexpected (keys=%s)",
+                    list(data.keys()) if isinstance(data, dict) else type(data).__name__,
+                )
+                return None
+            logger.info(
+                "Pack submitted successfully: submission_id=%s, "
+                "cooldown_seconds=%s, pre_eval_status=%s",
+                data.get("submission_id"),
+                data.get("cooldown_seconds"),
+                data.get("pre_eval_status"),
+            )
+            return data
+
+        if resp.status_code == 429:
+            try:
+                data = resp.json()
+                logger.error(
+                    "Submission rejected (cooldown): next_upload_allowed_at=%s, "
+                    "cooldown_seconds=%s",
+                    data.get("next_upload_allowed_at"),
+                    data.get("cooldown_seconds"),
+                )
+            except Exception:
+                logger.error("Submission rejected (cooldown): %s", resp.text[:200])
+            return None
+
+        if resp.status_code in (400, 403):
+            logger.error(
+                "Submission rejected (HTTP %d): %s",
+                resp.status_code, resp.text[:300],
+            )
+            return None
+
+        logger.error(
+            "Submission failed (HTTP %d): %s",
+            resp.status_code, resp.text[:200],
+        )
+        return None
 
     def get_current_commitment(self) -> Optional[str]:
         """Read this miner's current on-chain commitment.


### PR DESCRIPTION
## Summary

  Adds a managed-hosting alternative to the existing self-hosted upload flow. Miners can publish a pack with a single command — no S3/R2/HMAC credentials, the request is signed by the bittensor wallet.

  ```bash
  python neurons/miner.py web-submit pack.json --commit-onchain
  ```

  The CLI canonicalises the pack (`json.dumps(pack, sort_keys=True)`), signs `trajectoryrl-miner-submit:{hotkey}:{timestamp}` (sr25519), POSTs to `/api/v2/miners/submit`, and (with the flag) follows up with the
  on-chain commitment in the same invocation. The endpoint stores the pack at a random GCS key and returns the URL.

  ## What's added

  - `trajectoryrl/base/miner.py` — `submit_pack_via_api()` method (sync, `httpx.Client`) + `DEFAULT_MINER_SUBMIT_URL`. Returns the parsed server response on 200; logs and returns `None` for cooldown / 4xx / network
   errors.
  - `neurons/miner.py` — `web-submit` subcommand; `--commit-onchain` chains the on-chain `set_commitment` step; `--api-base-url` overrides the endpoint for staging.
  - `tests/test_miner.py` — `TestSubmitPackViaApi` (7 cases): success path payload shape, signing-prefix check, 429 cooldown, 4xx, network exception, oversize-pack client-side guard, unparseable-200.
  - `docs/MINER_OPERATIONS.md` — Quick Start split into "Option A: self-hosted" vs "Option B: managed"; new `### web-submit` reference; new hosting-comparison table; `TRAJECTORYRL_API_BASE_URL` env var entry.

  ## Coexistence

  - `upload` (S3/R2/GCS via HMAC) is unchanged — miners with existing infra keep the URL they control.
  - `web-submit` is the no-infra alternative; chain commit step is identical (`<pack_hash>|<pack_url>` via `set_commitment`).

  ## Server-side semantics relied on

  - Per-miner cooldown (default 1 h) — surfaced via `cooldown_seconds` / `next_upload_allowed_at` in the response and CLI output.
  - Idempotent re-submit of the same `(hotkey, pack_hash)` after cooldown — server reuses existing `pack_url`.
  - Pre-eval runs async after the response; verdict reflected in the next epoch's `/api/v2/validators/epoch_snapshot`.

  ## Test plan

  - [x] `pytest tests/test_miner.py` — 46 passed (7 new + 39 existing)
  - [x] Full suite: 423 passed / 2 skipped / 3 pre-existing unrelated failures (`test_sandbox_harness::TestConfigWiring`)
  - [ ] Live test on a miner wallet against staging — confirm signed request accepted, `pack_url` returned, cooldown enforced on resubmit
  - [ ] Live test — `--commit-onchain` chains successfully and `python neurons/miner.py status` shows the new commit