### PR TITLE
docs(miner-ops): rewrite to match shell_verifier eval architecture

### DIFF
--- a/docs/MINER_OPERATIONS.md
+++ b/docs/MINER_OPERATIONS.md
@@ -1,18 +1,19 @@
 # Miner Operations Guide
 
 **Subnet**: SN11 (TrajectoryRL)
-**Season**: 1 (Self-Learning Agents)
 
-> For scoring, sandbox environment, SKILL.md writing, and anti-gaming rules, see [MINER_GUIDE.md](MINER_GUIDE.md).
-> For mechanism design, see [INCENTIVE_MECHANISM.md](INCENTIVE_MECHANISM.md).
+> Live eval mechanics, active scenarios, and mission framing: <https://trajrl.com/rules>.
+> For mechanism design (consensus, winner selection), see [INCENTIVE_MECHANISM.md](INCENTIVE_MECHANISM.md).
 
 ---
 
 ## What Is Mining on TrajectoryRL?
 
-Mining means writing a **SKILL.md** — a knowledge document that teaches an AI agent how to explore, learn, and solve tasks in sandboxed environments. You're not running GPU workloads or a long-running daemon. You're doing agent instruction engineering.
+Mining means writing a **SKILL.md** — a scaffold that teaches a small open-source LLM how to solve scenario tasks (currently autonomous-coding tasks adapted from terminal-bench-2). You're not running GPU workloads or a long-running daemon. You're doing agent instruction engineering.
 
-The miner CLI is a **toolbox**: independent commands you compose however you want. Write your SKILL.md (manually, with an LLM, with your own automation), then use the CLI to build, upload, and submit.
+For each scenario, validators run the testee LLM (default: `qwen/qwen3.5-35b-a3b`) in a fresh container with your `SKILL.md` and the scenario's `INSTRUCTION.md`. The agent produces a deliverable file. A separate verifier container runs `pytest` against the deliverable and emits `passed/total` from a continuous CTRF report. Your pack's score is `Σ passed_i / total_i` across all active scenarios — range `[0, N]` for `N` scenarios.
+
+The miner CLI (`trajectoryrl-miner`) is a **toolbox**: independent commands you compose however you want. Write your SKILL.md (manually, with an LLM, with your own automation), then use the CLI to build, host, and submit.
 
 ---
 
@@ -23,54 +24,58 @@ The miner CLI is a **toolbox**: independent commands you compose however you wan
 | **Bittensor wallet** | `btcli wallet create --wallet.name miner --wallet.hotkey default` |
 | **Registration** | `btcli subnet register --netuid 11 --wallet.name miner` (dynamic cost) |
 | **Python** | 3.10+ |
-| **Pack hosting** | Either self-hosted (S3/R2/GCS/GitHub raw/etc.) **or** managed via `/api/v2/miners/submit` (no infra needed — see "Managed hosting" below) |
+| **Pack hosting** | Either self-hosted (S3 / R2 / GCS / GitHub raw / etc.) **or** managed via `/api/v2/miners/submit` (no infra needed — see "Managed hosting" below) |
 
 ---
 
 ## Quick Start
 
-Pick **one** hosting option for step 3. Self-hosted gives you control over the URL; managed lets you skip the storage setup entirely.
+Submission is three steps: **build** the pack, **host** it (one of two routes), then **commit** the URL on-chain.
 
 ```bash
 git clone https://github.com/trajectoryRL/trajectoryRL.git
-cd trajectoryRL
+cd trajectoryRL && pip install -e .
 
 # 1. Write your SKILL.md (use any method — manual, LLM, your own scripts)
 vim SKILL.md
 
 # 2. Build pack
-python neurons/miner.py build SKILL.md -o pack.json
+trajectoryrl-miner build SKILL.md -o pack.json
 ```
+
+For step 3 (hosting), pick **one** route. Both produce a public `pack_url`.
 
 **Option A — Self-hosted (S3 / R2 / GCS / etc.)**
 
 ```bash
 # 3a. Upload to your own S3-compatible bucket
-python neurons/miner.py upload pack.json
+trajectoryrl-miner upload pack.json
 # → prints https://your-bucket.s3.amazonaws.com/pack.json
 
-# 4a. Submit on-chain
-python neurons/miner.py submit https://your-bucket.s3.amazonaws.com/pack.json
+# 4a. Commit on-chain
+trajectoryrl-miner submit https://your-bucket.s3.amazonaws.com/pack.json
 ```
 
 **Option B — Managed hosting via `/api/v2/miners/submit`**
 
 ```bash
 # 3b. Submit pack content to trajrl.com (managed GCS), get back pack_url
-python neurons/miner.py web-submit pack.json
+trajectoryrl-miner web-submit pack.json
 # → prints pack_url + cooldown info
 
-# 4b. Submit on-chain (same step as Option A)
-python neurons/miner.py submit <pack_url>
+# 4b. Commit on-chain (same step as Option A)
+trajectoryrl-miner submit <pack_url>
 ```
 
 Then check status:
 
 ```bash
-python neurons/miner.py status
+trajectoryrl-miner status
 ```
 
 That's it. Repeat steps 1 → 4 whenever you improve your SKILL.md.
+
+> The CLI is also runnable as `python neurons/miner.py <command>` if you'd rather not install the entry point. Behaviour is identical.
 
 ---
 
@@ -78,7 +83,7 @@ That's it. Repeat steps 1 → 4 whenever you improve your SKILL.md.
 
 | Path | What you operate | Where the pack lives | Reveal | Use this when |
 |------|-----------------|----------------------|--------|---------------|
-| **A. Self-host + chain commit** | An HTTP host (S3/GCS/GH/own server) for `pack.json` | Your bucket | Public on chain immediately (commit URL is on-chain) | You already have hosting and want full control |
+| **A. Self-host + chain commit** | An HTTP host (S3 / GCS / GH / your own server) for `pack.json` | Your bucket | Public on chain immediately (commit URL is on-chain) | You already have hosting and want full control |
 | **B. Web submit (recommended for new miners)** | Just the miner CLI, no hosting | Subnet's GCS at an unguessable random key | URL hidden 48 h; commit on-chain still required for discovery | You want the easiest path; you don't want to run hosting |
 
 Both paths produce the same on-chain artifact: `set_commitment(pack_hash | url)`. The difference is who hosts the pack content.
@@ -86,37 +91,28 @@ Both paths produce the same on-chain artifact: `set_commitment(pack_hash | url)`
 ### Path A — chain commit (classic)
 
 ```bash
-python neurons/miner.py build  SKILL.md -o pack.json
-python neurons/miner.py upload pack.json                       # to your S3/GCS
-python neurons/miner.py submit https://your-bucket/pack.json   # set_commitment on chain
+trajectoryrl-miner build  SKILL.md -o pack.json
+trajectoryrl-miner upload pack.json                       # to your S3/GCS
+trajectoryrl-miner submit https://your-bucket/pack.json   # set_commitment on chain
 ```
 
 ### Path B — web submit (preferred)
 
 ```bash
 # 1. Build pack locally (same as Path A)
-python neurons/miner.py build SKILL.md -o pack.json
+trajectoryrl-miner build SKILL.md -o pack.json
 
 # 2. POST pack to the subnet's hosted submit endpoint (signed with your hotkey).
 #    The endpoint stores the pack at an unguessable random GCS path and
-#    returns the `pack_url` to use on-chain.
-curl -X POST https://trajrl.com/api/v2/miners/submit \
-  -H 'content-type: application/json' \
-  -d "$(jq -n --slurpfile pack pack.json \
-              --arg miner_hotkey "$MINER_HOTKEY" \
-              --arg ts "$(date +%s)" \
-              --arg sig "$(sign 'trajectoryrl-miner-submit:'"$MINER_HOTKEY"':'"$ts")" \
-              --arg hash "$(sha256_canonical pack.json)" \
-        '{ miner_hotkey: $miner_hotkey, timestamp: ($ts | tonumber),
-           signature: $sig, pack_hash: $hash, pack_content: ($pack[0] | tostring) }')"
-
-# Response → { pack_url: "https://storage.googleapis.com/.../pack.json", ... }
+#    returns the pack_url to use on-chain.
+trajectoryrl-miner web-submit pack.json
+# → Response: { pack_url: "https://storage.googleapis.com/.../pack.json", ... }
 
 # 3. Commit on-chain with the returned pack_url
-python neurons/miner.py submit <pack_url_from_response>
+trajectoryrl-miner submit <pack_url_from_response>
 ```
 
-The `submit` endpoint immediately validates your signature, hash and pack format, kicks off pre-eval asynchronously, and returns the `pack_url`. Web-source URLs are not exposed in any other API for **48 hours** (the "reveal gate"), so a competitor can't simply scrape the dashboard to harvest your fresh SKILL.md.
+The `web-submit` endpoint immediately validates your signature, hash and pack format, kicks off pre-eval asynchronously, and returns the `pack_url`. Web-source URLs are not exposed in any other API for **48 hours** (the "reveal gate"), so a competitor can't simply scrape the dashboard to harvest your fresh SKILL.md.
 
 Full request/response spec for `/api/v2/miners/submit` is in [`trajectoryrl.web/API.md`](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md).
 
@@ -125,20 +121,20 @@ Full request/response spec for `/api/v2/miners/submit` is in [`trajectoryrl.web/
 ## CLI Reference
 
 ```bash
-python neurons/miner.py build       <skill_md_path> [-o pack.json]
-python neurons/miner.py validate    <pack.json>
-python neurons/miner.py upload      <pack.json> [--bucket ...] [--endpoint-url ...]
-python neurons/miner.py web-submit  <pack.json> [--api-base-url ...]
-python neurons/miner.py submit      <pack_url>
-python neurons/miner.py status
+trajectoryrl-miner build       <skill_md_path> [-o pack.json]
+trajectoryrl-miner validate    <pack.json>
+trajectoryrl-miner upload      <pack.json> [--bucket ...] [--endpoint-url ...]
+trajectoryrl-miner web-submit  <pack.json> [--api-base-url ...]
+trajectoryrl-miner submit      <pack_url>
+trajectoryrl-miner status
 ```
 
 ### build
 
-Build a Season 1 pack from a SKILL.md file.
+Build a pack from a SKILL.md file.
 
 ```bash
-python neurons/miner.py build ./SKILL.md -o pack.json
+trajectoryrl-miner build ./SKILL.md -o pack.json
 ```
 
 Output:
@@ -156,7 +152,7 @@ Automatically validates schema + size. Fails if SKILL.md is empty or pack exceed
 Validate an existing pack.json locally (without submitting).
 
 ```bash
-python neurons/miner.py validate pack.json
+trajectoryrl-miner validate pack.json
 ```
 
 ### upload
@@ -164,8 +160,8 @@ python neurons/miner.py validate pack.json
 Upload pack.json to S3-compatible storage. Prints the public URL.
 
 ```bash
-python neurons/miner.py upload pack.json
-python neurons/miner.py upload pack.json --bucket my-bucket --endpoint-url https://storage.googleapis.com
+trajectoryrl-miner upload pack.json
+trajectoryrl-miner upload pack.json --bucket my-bucket --endpoint-url https://storage.googleapis.com
 ```
 
 Reads S3 config from environment or CLI flags. Returns the public URL for use with `submit`.
@@ -177,8 +173,8 @@ Submit pack content directly to the managed web service (`POST /api/v2/miners/su
 This command does **only** the HTTP upload — it does not touch the chain. The on-chain commit is a separate step, run via `submit <pack_url>` (same step you'd run after `upload`).
 
 ```bash
-python neurons/miner.py web-submit pack.json
-python neurons/miner.py web-submit pack.json --api-base-url https://staging.trajrl.com
+trajectoryrl-miner web-submit pack.json
+trajectoryrl-miner web-submit pack.json --api-base-url https://stage.trajrl.com
 ```
 
 Output:
@@ -193,7 +189,7 @@ Submitted! pack_url = https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<ra
   next_upload_at:   2026-05-04T15:00:00.000Z
   pre_eval_status:  pending
 
-Next step: python neurons/miner.py submit https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<random_key>.json
+Next step: trajectoryrl-miner submit https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<random_key>.json
 ```
 
 **Cooldown**: The endpoint enforces a per-miner cooldown (default **1 hour**, set server-side via `MINER_SUBMIT_COOLDOWN_SECONDS`). Submitting again before `next_upload_allowed_at` returns HTTP 429 and the CLI prints the cooldown info to stderr. Field-validation, signature, and GCS-upload errors do **not** consume the cooldown — only successfully persisted submissions do.
@@ -209,10 +205,10 @@ Next step: python neurons/miner.py submit https://storage.googleapis.com/<bucket
 Submit an on-chain commitment pointing to your hosted pack.
 
 ```bash
-python neurons/miner.py submit https://your-bucket.s3.amazonaws.com/pack.json
+trajectoryrl-miner submit https://your-bucket.s3.amazonaws.com/pack.json
 ```
 
-Fetches the pack from the URL, verifies the hash, and calls `set_commitment` on-chain. The on-chain block number establishes first-mover precedence.
+Fetches the pack from the URL, verifies the hash, and calls `set_commitment` on-chain. The on-chain block number establishes first-mover precedence and is the timestamp validators use for snapshot eligibility.
 
 > **Rate limit**: One commitment per ~100 blocks (~20 min) per hotkey.
 
@@ -221,7 +217,7 @@ Fetches the pack from the URL, verifies the hash, and calls `set_commitment` on-
 Show your current on-chain commitment.
 
 ```bash
-python neurons/miner.py status
+trajectoryrl-miner status
 ```
 
 Output:
@@ -259,10 +255,10 @@ No HMAC keys / bucket credentials needed — the request is signed with the mine
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `S3_BUCKET` | for upload | — | S3-compatible bucket name |
-| `S3_ENDPOINT_URL` | no | — | Custom endpoint for GCS/R2/MinIO |
+| `S3_ENDPOINT_URL` | no | — | Custom endpoint for GCS / R2 / MinIO |
 | `S3_REGION` | no | `us-east-1` | Bucket region |
-| `AWS_ACCESS_KEY_ID` | for upload | — | S3/GCS HMAC access key |
-| `AWS_SECRET_ACCESS_KEY` | for upload | — | S3/GCS HMAC secret key |
+| `AWS_ACCESS_KEY_ID` | for upload | — | S3 / GCS HMAC access key |
+| `AWS_SECRET_ACCESS_KEY` | for upload | — | S3 / GCS HMAC secret key |
 
 | Service | `S3_ENDPOINT_URL` | Credentials |
 |---------|-------------------|-------------|
@@ -273,7 +269,7 @@ No HMAC keys / bucket credentials needed — the request is signed with the mine
 
 ---
 
-## Pack Format (Season 1)
+## Pack Format
 
 ```json
 {
@@ -288,7 +284,7 @@ No HMAC keys / bucket credentials needed — the request is signed with the mine
 - Total pack JSON ≤ 32 KB
 - Content-addressed via SHA256: `sha256(json.dumps(pack, sort_keys=True))`
 
-For what to write in SKILL.md, see [MINER_GUIDE.md § Writing SKILL.md](MINER_GUIDE.md#writing-skillmd).
+For SKILL.md authoring patterns and what makes a pack score well, the canonical reference is the live eval mechanics page: <https://trajrl.com/rules>. The active scenario list, per-scenario test counts, and the scoring formula all live there.
 
 ---
 
@@ -304,33 +300,31 @@ For what to write in SKILL.md, see [MINER_GUIDE.md § Writing SKILL.md](MINER_GU
 │       • upload      → self-hosted public URL            │
 │       • web-submit  → managed GCS URL via /api/v2/...   │
 │  4. submit → on-chain commitment                        │
-│  5. Wait for validator evaluation (~24h epoch)           │
+│  5. Wait for validator evaluation (one epoch)           │
 │  6. Check results, iterate                              │
 └─────────────────────────────────────────────────────────┘
 ```
 
-Validators only re-evaluate when your `pack_hash` changes. No need to resubmit if your SKILL.md hasn't changed. **However**, if you want to remain in the active eval set you must keep your on-chain commitment alive — the snapshot endpoint excludes packs whose `refresh_time` (the rolling activity stamp) is older than 48 hours. The sync service refreshes this stamp every 5 min for any commitment still on chain, so as long as you don't deregister you stay active.
+Validators only re-evaluate when your `pack_hash` changes. No need to resubmit if your SKILL.md hasn't changed — your existing on-chain commitment carries you forward into every future epoch's eval set automatically (eligibility is driven by the chain commitment, not by an off-chain heartbeat).
 
-Re-submitting the same `(hotkey, pack_hash)` to `/api/v2/miners/submit` (Path B) within 1h is rate-limited by the cooldown; outside the cooldown it just bumps `refresh_time` without re-running the pipeline.
+### Submission timing — the freeze gap
 
-### Submission timing — the 2.4 h freeze gap
-
-The eval set for an epoch is **frozen 2.4 h before the epoch starts** (at `aggregation_start` of the previous epoch). A pack that lands inside that 2.4 h window is **not** in the upcoming epoch's snapshot — it gets evaluated in the *next* epoch instead.
+The eval set for an epoch is **frozen ahead of the epoch's start block** at `cutoff_time`, after which a new commitment is no longer eligible for that epoch's snapshot. Commitments that land inside the freeze window get evaluated in the **next** epoch instead.
 
 ```
-... ← previous epoch ──┬───── 2.4 h freeze gap ─────┐ epoch N starts ... eval runs ...
-                       ↑                            ↑
-                    cutoff for                     window_start(N)
+... ← previous epoch ──┬───── freeze gap ─────┐ epoch N starts ... eval runs ...
+                       ↑                      ↑
+                    cutoff for               window_start(N)
                     epoch N's snapshot
 ```
 
 Practical rules of thumb:
 
-- **Want to be evaluated this epoch?** Get your `set_commitment` (Path A) or `web-submit` (Path B) confirmed at least **~3 h before the next epoch boundary**. Anything later goes into the epoch after.
-- **Pack already on chain, no `pack_hash` change?** You don't need to do anything — the sync worker re-stamps `refresh_time` every ~5 min as long as the chain commitment is alive, so you stay in every future window.
-- **Switched packs late?** Pack swaps that miss the cutoff don't dodge anything — they simply land in the next snapshot. The frozen snapshot rule means validators evaluate the pack you had at cutoff, not the one you swap in mid-epoch.
+- **Want to be evaluated this epoch?** Get your `set_commitment` (Path A) or `web-submit` (Path B) confirmed at least a few hours before the next epoch boundary. Anything later goes into the epoch after.
+- **Pack already on chain, no `pack_hash` change?** You don't need to do anything — your commitment carries forward automatically.
+- **Switched packs late?** Pack swaps that miss the cutoff don't dodge anything; they simply land in the next snapshot. Validators evaluate the pack you had at cutoff, not the one you swap in mid-epoch.
 
-For the full window math (`cutoff_time`, `eligible_start_time`, `refresh_time` semantics), see [INCENTIVE_MECHANISM.md § Snapshot eligibility window](INCENTIVE_MECHANISM.md#snapshot-eligibility-window).
+For the full window math (`cutoff_time`, `window_start`, `commit_block` semantics), see [INCENTIVE_MECHANISM.md § Snapshot eligibility window](INCENTIVE_MECHANISM.md#snapshot-eligibility-window).
 
 ### Picking a hosting option
 
@@ -349,54 +343,70 @@ The on-chain commit step (and therefore the validator discovery path) is identic
 
 ## Local Testing
 
-Before submitting, test your SKILL.md locally with the evaluation harness:
+Before submitting on-chain, run the full evaluation harness against your SKILL.md locally. This is the same harness the production validator runs.
 
 ```bash
-git clone https://github.com/trajectoryRL/trajrl-bench.git
-cd trajrl-bench
-pip install -e ".[dev]"
-make build       # builds sandbox + hermes Docker images
-cp .env.example .env  # add your LLM API key
-make test-hermes      # runs one episode with real agent + real judge
+git clone https://github.com/trajectoryRL/trajectoryRL.git
+cd trajectoryRL && pip install -e .
+
+cp .env.validator.example .env.validator
+# Edit .env.validator: set LLM_API_KEY=sk-... and LLM_MODEL=qwen/qwen3.5-35b-a3b
+
+# Evaluate a SKILL.md directly
+python scripts/eval_pack.py --skill-md path/to/SKILL.md
+
+# Or evaluate a built pack.json
+python scripts/eval_pack.py --pack pack.json --json results.json -o ./eval_output
 ```
 
-Results are saved to `results/`. See the [trajrl-bench README](https://github.com/trajectoryRL/trajrl-bench) for more.
+The script auto-pulls the `sandbox-agent` base image and every per-scenario image in `SANDBOX_SCENARIOS` on first invocation. Output: per-scenario `passed/total` quality, per-scenario cost, final `Σ` score in `[0, N]`. Use `--json` to capture machine-readable results, `-o ./eval_output` to save full transcripts and verifier artifacts.
+
+Prereqs: Docker daemon running, an LLM API key (e.g. OpenRouter), ~10 GB free disk for the per-scenario images on first run.
+
+For scenario-level definitions (test files, fixture data, verifier code), see the [trajrl-bench](https://github.com/trajectoryRL/trajrl-bench) repo.
 
 ---
 
 ## Viewing Evaluation Results
 
-After each evaluation epoch (~24h), validators upload per-miner eval logs to the dashboard. Each log is a tar.gz containing:
+Validators upload per-miner eval logs after each epoch. Each log archive contains:
 
 ```
-SKILL.md                                 # miner's product
-JUDGE.md                                 # scoring rubric used
-metadata.json                            # final_score, mean_quality, delta, episode qualities
-world.json                               # company context + validator salt
-episodes/episode_N/
-  testee_transcript.txt                  # testee's session output
-  judge_transcript.txt                   # judge agent's grading session
-  evaluation.json                        # per-criterion scores + summary + strengths/weaknesses
-  episode.json                           # fixtures + instruction
+SKILL.md                                      # the pack content that was evaluated
+metadata.json                                 # final_score, mean_quality,
+                                              # scenario_qualities (per-scenario passed/total),
+                                              # scenario_costs_usd, total_cost_usd, pack_hash
+episodes/
+  scenario_<name>/                            # one directory per scenario
+    testee_transcript.txt                     # agent's session output
+    turns.jsonl                               # full hermes turn log
+    evaluation.json                           # verifier output (passed/total + ctrf payload)
+    ctrf.json                                 # standalone CTRF report from the verifier
 ```
 
-Retrieve your eval logs via `trajrl subnet logs` (see [trajrl CLI docs](https://pypi.org/project/trajrl/)):
+Retrieve eval logs via the `trajrl` CLI:
 
 ```bash
-trajrl subnet logs --miner <hotkey> --limit 5     # list recent evals
-trajrl subnet logs --eval-id <id> --show          # pretty-print summary
-trajrl subnet logs --eval-id <id> --dump-to ./    # extract full archive
+pip install trajrl
+trajrl logs --miner <hotkey> --limit 5     # list recent evals
+trajrl logs --eval-id <id> --show          # pretty-print summary
+trajrl logs --eval-id <id> --dump-to ./    # extract full archive
 ```
 
-Use the testee transcript + judge feedback together to debug failure modes and iterate on your SKILL.md.
+The dashboard surfaces the same data interactively:
+
+- **Per-pack breakdown**: `https://trajrl.com/miner/<hotkey>/pack/<pack_hash>`
+- **Live eval streaming**: `https://trajrl.com/live`
+- **Active scenarios + scoring formula**: `https://trajrl.com/rules`
+
+Use the `testee_transcript.txt` + the per-scenario `ctrf.json` together to debug failure modes and iterate on your SKILL.md.
 
 ---
 
 ## References
 
-- **Season 1 Guide**: [MINER_GUIDE.md](MINER_GUIDE.md) — scoring, sandbox, SKILL.md writing, anti-gaming rules
+- **Live eval mechanics**: <https://trajrl.com/rules> — active scenarios, scoring formula, mission framing
 - **Validator side**: [VALIDATOR_OPERATIONS.md](VALIDATOR_OPERATIONS.md) — how validators consume the eval set you submit to
 - **Incentive Mechanism**: [INCENTIVE_MECHANISM.md](INCENTIVE_MECHANISM.md) — consensus protocol, winner selection
-- **Scoring & Evaluation**: [EVALUATION_S1.md](EVALUATION_S1.md) — pack schema, scoring formula
-- **Web API spec**: [API.md](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md) — full request/response for `/api/v2/miners/submit` and other endpoints
-- **Benchmark**: [trajrl-bench](https://github.com/trajectoryRL/trajrl-bench) — scenarios, JUDGE.md, local testing
+- **Web API spec**: [trajectoryrl.web API.md](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md) — full request/response for `/api/v2/miners/submit` and other endpoints
+- **Benchmark**: [trajrl-bench](https://github.com/trajectoryRL/trajrl-bench) — scenario definitions, fixture data, verifier code


### PR DESCRIPTION
## Summary

The previous MINER_OPERATIONS.md was anchored on the retired Season 1 / self-learning-agents framing. The CLI surface, submission paths, hosting comparison, and 48 h reveal-gate language are all still accurate, but several major sections described an architecture that no longer exists.

**What changes**

- Drop Season 1 framing from the header. Point at https://trajrl.com/rules as the canonical live source of truth for eval mechanics, active scenarios, and scoring.
- Reframe \"What is mining\" around the current shell_verifier pipeline: scaffold a small open LLM through scenario containers, score = Σ passed/total via pytest CTRF in [0, N].
- Switch CLI examples to the `trajectoryrl-miner` entry point (pyproject script). Keep the `python neurons/miner.py` form as an alternative.
- Rewrite Local Testing: drop `make test-hermes` (trajrl-bench Season 1 harness), point at `python scripts/eval_pack.py --skill-md SKILL.md` which is the same harness production validators run.
- Rewrite Viewing Evaluation Results to match the actual current archive layout (SKILL.md / metadata.json / episodes/scenario_<name>/ with testee_transcript, turns.jsonl, evaluation.json, ctrf.json). Drop JUDGE.md, judge_transcript.txt, and the mean_quality + delta + episode_qualities keys.
- Drop refresh_time language from Typical Workflow. Eligibility now flows from the chain commitment alone (the off-chain heartbeat was retired with the append-only submissions refactor).
- Reframe the freeze-gap section in block-based terms (cutoff_time / window_start / commit_block) instead of the old 2.4 h time-based language.
- Trim References to surfaces that exist and are current. Drop pointers to MINER_GUIDE.md and EVALUATION_S1.md (both still on the Season 1 architecture; flagged for follow-up).

**What stays**

- Pack format (`{schema_version: 1, files: {SKILL.md}}`, 32 KB limit, sha256 canonical hash)
- CLI surface (build / validate / upload / web-submit / submit / status)
- Two-path submission comparison (self-host vs. managed GCS)
- 48 h reveal-gate language for web-submit URLs
- Wallet / network / S3 config tables
- Cooldown + idempotency semantics for `/api/v2/miners/submit`

## Follow-ups (not in this PR)

- `MINER_GUIDE.md` is still anchored on Season 1 (mock services, judge agent, /workspace/learned/, mean_quality * delta scoring). Needs the same treatment.
- `EVALUATION_S1.md` referenced from the old footer is presumably equally stale.

## Test plan

- [x] Verified pack format and 32 KB limit against `trajectoryrl/base/miner.py`
- [x] Verified CLI surface against `neurons/miner.py` argparse
- [x] Verified eval-log archive layout against `sandbox_harness.py:write_artifacts`
- [x] Verified current eval flow (1 episode/scenario, Σ passed/total) against `sandbox_harness.py` docstring
- [ ] Render check on GitHub once PR is open