### PR TITLE
harness: drop --max-turns 15, fall back to hermes default (90)

### DIFF
--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -824,7 +824,7 @@ class TrajectorySandboxHarness:
                 f"hermes chat -q {_shell_quote(harness_prompt)} "
                 f"-m {_shell_quote(self._testee_model)} "
                 "-t terminal,file,code_execution,memory "
-                "--quiet --yolo --max-turns 15; "
+                "--quiet --yolo; "
                 "chat_rc=$?; "
                 "hermes sessions export /workspace/turns.jsonl "
                 "2>/workspace/turns_export.err; "


### PR DESCRIPTION
## Summary
- Drop the explicit `--max-turns 15` flag from the per-episode `hermes chat` invocation in `sandbox_harness.py`.
- Hermes' built-in default is **90**, so this is effectively a 6× lift, not unlimited. The wall budget (`sandbox_timeout_per_episode = 600s`) remains the real spend governor.

## Why
Local replication on epoch 1129 against `qwen/qwen3.5-35b-a3b` (the production testee) shows the dominant fix-git failure mode is **premature exit** — the agent decides the task is complete and terminates after 13–45 seconds, well below both the 15-turn cap and the 600s wall. So 15 turns is *not* the binding constraint for the bimodal failures we're seeing.

For long-exploration scenarios (`path-tracing`, `db-wal-recovery`, `break-filter`, `vulnerable-secret`) where the model legitimately needs to read multiple files and iterate, the 15-turn cap can close the door before the trajectory ever reaches the `write_file` step that lands the artifact.

Background trajectory inspection details: see `TrajOS/TrajectoryRL/SubnetAnalysis/2026-05-07_fix_git_skill_synthesis.md`.

## Risk
- Per-episode wall time and LLM cost can rise on packs that do use more turns.
- Hard-bounded by the existing 600s `sandbox_timeout_per_episode`. No protocol or schema changes.
- No expected change for packs that already terminate early (most current packs).

## Test plan
- [ ] Run the local n=5 SKILL synth-v2 + n=3 e634 variance batch against this branch and compare per-scenario quality + Σ to the n=5/n=3 baseline already collected on `main` (data in `/tmp/eval_synth{2..6}` and `/tmp/eval_e634{,_2,_3}`).
- [ ] Verify no scenario sees a regression (within same-pack noise band ≈14% on Σ).
- [ ] Inspect a sample fix-git trajectory under the new cap to confirm whether trajectories that previously hit the 15-turn ceiling now run longer (and whether they actually transition to `write_file`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)