### PR TITLE
feat(validator): per-scenario progress streaming for /challenge page

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -45,6 +45,7 @@ from ..utils.trajrl_api import (
     fetch_current_epoch,
     fetch_current_winner,
     submit_challenge_score,
+    submit_scenario_progress,
     upload_eval_logs,
     upload_cycle_logs,
 )
@@ -794,6 +795,32 @@ class TrajectoryValidator:
             f"epoch_id={challenge_epoch_id}"
         )
 
+        # Per-scenario streaming hook for the live /challenge page.
+        # Off by default; enable with TRAJRL_SCENARIO_STREAMING=1 once
+        # the platform server's /scenario_progress endpoint is live.
+        # The eval runs inside run_in_executor so the callback fires on
+        # a worker thread; schedule the async POST back on the main loop
+        # via run_coroutine_threadsafe (fire-and-forget).
+        on_episode_done = None
+        if os.getenv("TRAJRL_SCENARIO_STREAMING") == "1":
+            loop = asyncio.get_running_loop()
+
+            def on_episode_done(episode, scenario_index, total_scenarios):
+                coro = submit_scenario_progress(
+                    self.wallet,
+                    challenge_epoch_id=challenge_epoch_id,
+                    miner_hotkey=commitment.hotkey,
+                    miner_uid=commitment.uid,
+                    scenario_name=episode.scenario,
+                    scenario_index=scenario_index,
+                    total_scenarios=total_scenarios,
+                    quality=episode.quality,
+                    cost_usd=episode.cost_usd,
+                    duration_s=episode.duration_s,
+                    timed_out=episode.timed_out,
+                )
+                asyncio.run_coroutine_threadsafe(coro, loop)
+
         outcome = await evaluate_miner_s1(
             harness=self._sandbox_harness,
             pack_fetcher=self.pack_fetcher,
@@ -801,6 +828,7 @@ class TrajectoryValidator:
             epoch_seed=self._challenge_seed(challenge_epoch_id, self.config.netuid),
             validator_salt=self._default_validator_salt(),
             mlog=mlog,
+            on_episode_done=on_episode_done,
         )
 
         if not outcome.success:

--- a/trajectoryrl/utils/miner_eval.py
+++ b/trajectoryrl/utils/miner_eval.py
@@ -25,11 +25,15 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 from .commitments import MinerCommitment
 from .github import PackFetcher
-from .sandbox_harness import SandboxEvaluationResult, TrajectorySandboxHarness
+from .sandbox_harness import (
+    SandboxEvaluationResult,
+    TrajectorySandboxHarness,
+    _EpisodeResult,
+)
 
 
 # Skip-reason taxonomy — kept stable for callers that branch on these values
@@ -60,6 +64,7 @@ async def evaluate_miner_s1(
     epoch_seed: int,
     validator_salt: str = "",
     mlog: Optional[logging.Logger] = None,
+    on_episode_done: Optional[Callable[[_EpisodeResult, int, int], None]] = None,
 ) -> MinerEvalOutcome:
     """Evaluate a single miner's pack via trajrl-bench (Season 1).
 
@@ -163,6 +168,7 @@ async def evaluate_miner_s1(
             epoch_seed=epoch_seed,
             pack_hash=commitment.pack_hash,
             validator_salt=validator_salt,
+            on_episode_done=on_episode_done,
         )
     except Exception as e:
         log.error("S1 evaluation failed: %s", e, exc_info=True)

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -36,7 +36,7 @@ import tarfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import docker
 from docker.models.containers import Container
@@ -614,7 +614,17 @@ class TrajectorySandboxHarness:
         epoch_seed: int,
         pack_hash: str = "",
         validator_salt: str = "",
+        on_episode_done: Optional[Callable[[_EpisodeResult, int, int], None]] = None,
     ) -> SandboxEvaluationResult:
+        """Run the multi-scenario session.
+
+        ``on_episode_done`` is an optional sync callback invoked from the
+        executor thread after each scenario completes, with
+        ``(episode, scenario_index, total_scenarios)``. Used by the
+        validator to fire-and-forget per-scenario progress to the
+        platform server (drives the live /challenge page). Failures in
+        the callback are caught and logged; they never abort the eval.
+        """
         salt = validator_salt or hashlib.sha256(
             f"{self.config.wallet_hotkey}:{self.config.netuid}".encode()
         ).hexdigest()[:16]
@@ -630,6 +640,7 @@ class TrajectorySandboxHarness:
             session_result = await loop.run_in_executor(
                 None, lambda: self._run_eval_sync(
                     skill_md, epoch_seed, salt, pack_hash,
+                    on_episode_done=on_episode_done,
                 ),
             )
         except Exception as e:
@@ -648,6 +659,7 @@ class TrajectorySandboxHarness:
 
     def _run_eval_sync(
         self, skill_md: str, epoch_seed: int, salt: str, pack_hash: str,
+        on_episode_done: Optional[Callable[[_EpisodeResult, int, int], None]] = None,
     ) -> _SessionResult:
         """One container per scenario, one episode each.
 
@@ -701,6 +713,7 @@ class TrajectorySandboxHarness:
             session_id, [s["name"] for s in scenario_specs],
         )
 
+        total = len(scenario_specs)
         for cell_index, spec in enumerate(scenario_specs):
             episode = self._run_episode(
                 session_id=session_id,
@@ -709,6 +722,14 @@ class TrajectorySandboxHarness:
                 spec=spec,
             )
             session_result.episodes.append(episode)
+            if on_episode_done is not None:
+                try:
+                    on_episode_done(episode, cell_index, total)
+                except Exception as e:
+                    logger.warning(
+                        "on_episode_done callback failed for %s: %s",
+                        episode.scenario, e,
+                    )
 
         session_result.compute_scores()
         return session_result

--- a/trajectoryrl/utils/trajrl_api.py
+++ b/trajectoryrl/utils/trajrl_api.py
@@ -59,6 +59,10 @@ def _default_cycle_logs_url() -> str:
     return f"{_api_base_url()}/api/validators/logs/cycle"
 
 
+def _default_scenario_progress_url_template() -> str:
+    return f"{_api_base_url()}/api/v2/epoch/{{challenge_epoch_id}}/scenario_progress"
+
+
 def _sign(prefix: str, hotkey_kp, timestamp: int, *extras: str) -> Tuple[str, str, str]:
     """Build a signed message for a v2 endpoint.
 
@@ -426,6 +430,96 @@ async def submit_challenge_score(
         return False
     except Exception as e:
         logger.warning("Challenge score submit error: %s", e)
+        return False
+
+
+async def submit_scenario_progress(
+    wallet,
+    *,
+    challenge_epoch_id: int,
+    miner_hotkey: str,
+    miner_uid: int,
+    scenario_name: str,
+    scenario_index: int,
+    total_scenarios: int,
+    quality: float,
+    cost_usd: Optional[float] = None,
+    duration_s: Optional[float] = None,
+    timed_out: Optional[bool] = None,
+    submit_url_template: Optional[str] = None,
+    timeout: float = 10.0,
+) -> bool:
+    """Post a partial per-scenario result for the in-progress epoch.
+
+    Implements ``POST /api/v2/epoch/{challenge_epoch_id}/scenario_progress``.
+    Decorative / UX-only — drives the live ``/challenge`` page and is
+    discarded once the canonical eval bundle uploads. The per-eval log
+    archive at ``/api/validators/logs/upload`` remains the source of
+    truth.
+
+    Signing prefix is ``trajectoryrl-scenario-progress`` and binds the
+    epoch id + scenario name into the message, so signatures are not
+    interchangeable across scenarios or epochs.
+    """
+    try:
+        hotkey_kp = wallet.hotkey
+    except Exception:
+        logger.debug("Skipping scenario_progress: wallet hotkey not available")
+        return False
+
+    timestamp = int(time.time())
+    hotkey_addr, _msg, signature = _sign(
+        "trajectoryrl-scenario-progress",
+        hotkey_kp,
+        timestamp,
+        str(challenge_epoch_id),
+        scenario_name,
+    )
+
+    payload: Dict[str, Any] = {
+        "validator_hotkey": hotkey_addr,
+        "miner_hotkey": miner_hotkey,
+        "miner_uid": miner_uid,
+        "scenario_name": scenario_name,
+        "scenario_index": scenario_index,
+        "total_scenarios": total_scenarios,
+        "quality": quality,
+        "timestamp": timestamp,
+        "signature": signature,
+        "version": __version__,
+    }
+    if cost_usd is not None:
+        payload["cost_usd"] = cost_usd
+    if duration_s is not None:
+        payload["duration_s"] = duration_s
+    if timed_out is not None:
+        payload["timed_out"] = timed_out
+
+    submit_url_template = (
+        submit_url_template or _default_scenario_progress_url_template()
+    )
+    submit_url = submit_url_template.format(challenge_epoch_id=challenge_epoch_id)
+
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(submit_url, json=payload, timeout=timeout)
+        if resp.status_code == 200:
+            logger.debug(
+                "Scenario progress submitted (epoch=%d, scenario=%s, q=%.3f)",
+                challenge_epoch_id, scenario_name, quality,
+            )
+            return True
+        # 404 is expected before the server endpoint is rolled out — log
+        # at debug to avoid spamming until the web side ships.
+        log_level = logging.DEBUG if resp.status_code == 404 else logging.WARNING
+        logger.log(
+            log_level,
+            "Scenario progress submit failed: %d %s",
+            resp.status_code, resp.text[:200],
+        )
+        return False
+    except Exception as e:
+        logger.debug("Scenario progress submit error: %s", e)
         return False
 
 


### PR DESCRIPTION
## Summary

Adds an opt-in fire-and-forget hook that posts each scenario's result to the platform server as soon as it completes, instead of waiting for the full eval to finish. Drives a live per-validator scenario tile strip on the `/challenge` page; the per-eval log archive at `/api/validators/logs/upload` remains the canonical source of truth.

**Off by default.** Set `TRAJRL_SCENARIO_STREAMING=1` to enable once the server's `POST /api/v2/epoch/{id}/scenario_progress` endpoint is live (see paired trajectoryrl.web PR).

## Streaming payload

```
POST /api/v2/epoch/{challenge_epoch_id}/scenario_progress
{
  validator_hotkey, miner_hotkey, miner_uid,
  scenario_name, scenario_index, total_scenarios,
  quality, cost_usd, duration_s, timed_out,
  timestamp, signature, version
}
```

Signature prefix: `trajectoryrl-scenario-progress:{hotkey}:{ts}:{epoch_id}:{scenario_name}` — replay-safe per-scenario.

## Files changed

| File | Change |
|---|---|
| `trajectoryrl/utils/trajrl_api.py` | New `submit_scenario_progress()` + URL helper. 10s timeout. 404 logs at debug (silent until endpoint exists); other failures at warning. Always returns bool, never raises. |
| `trajectoryrl/utils/sandbox_harness.py` | `evaluate_miner()` + `_run_eval_sync()` accept optional `on_episode_done(episode, idx, total)` callback. Invoked after each `episodes.append`, wrapped in try/except so a callback failure can never abort the eval. |
| `trajectoryrl/utils/miner_eval.py` | Threads `on_episode_done` through to `harness.evaluate_miner`. |
| `trajectoryrl/base/validator.py` | `_evaluate_challenger` builds the callback inside `os.getenv("TRAJRL_SCENARIO_STREAMING") == "1"`. Captures the main asyncio loop and dispatches the POST via `run_coroutine_threadsafe` (the harness runs in `run_in_executor`). |

152 insertions, 3 deletions.

## Why fire-and-forget / why no replay

This stream is decorative — it drives the `/challenge` page's live-battle UI. The canonical record stays in two places:

1. The validator's final `POST /api/v2/epoch/{id}/score` (idempotent, one per validator per epoch)
2. The per-eval `logs.tar.gz` at `POST /api/validators/logs/upload` (with replay-on-startup)

A dropped scenario_progress POST = one tile stays empty for ~30s until the per-eval submission lands. No data loss, no protocol break, no scoring impact.

## No version / SPEC_NUMBER bump

- Default-off path is a no-op — existing eval flow unchanged.
- No scoring change (just observability).

## Test plan

- [x] 112/112 unit tests pass (`pytest tests/ --ignore=tests/test_sandbox_harness.py`)
- [x] Smoke imports OK across all 4 changed modules
- [ ] Land paired trajectoryrl.web PR (server endpoint + table + UI)
- [ ] Set `TRAJRL_SCENARIO_STREAMING=1` on staging validator first
- [ ] Confirm tile strip fills in real-time on `/challenge` for an active eval
- [ ] Roll to fleet via VERSION bump (e.g. 0.6.7) once verified on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)