### PR TITLE
feat(validator): drop TRAJRL_SCENARIO_STREAMING gate, always stream

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -26,7 +26,6 @@ import datetime
 import hashlib
 import json
 import logging
-import os
 import time
 
 from pathlib import Path
@@ -795,31 +794,29 @@ class TrajectoryValidator:
             f"epoch_id={challenge_epoch_id}"
         )
 
-        # Per-scenario streaming hook for the live /challenge page.
-        # Off by default; enable with TRAJRL_SCENARIO_STREAMING=1 once
-        # the platform server's /scenario_progress endpoint is live.
-        # The eval runs inside run_in_executor so the callback fires on
-        # a worker thread; schedule the async POST back on the main loop
-        # via run_coroutine_threadsafe (fire-and-forget).
-        on_episode_done = None
-        if os.getenv("TRAJRL_SCENARIO_STREAMING") == "1":
-            loop = asyncio.get_running_loop()
+        # Per-scenario streaming hook for the live /challenge page. The
+        # eval runs inside run_in_executor so the callback fires on a
+        # worker thread; schedule the async POST back on the main loop
+        # via run_coroutine_threadsafe (fire-and-forget). The submit is
+        # bounded by a 10s timeout, 404s log at debug, other errors at
+        # warning — none affect eval correctness.
+        loop = asyncio.get_running_loop()
 
-            def on_episode_done(episode, scenario_index, total_scenarios):
-                coro = submit_scenario_progress(
-                    self.wallet,
-                    challenge_epoch_id=challenge_epoch_id,
-                    miner_hotkey=commitment.hotkey,
-                    miner_uid=commitment.uid,
-                    scenario_name=episode.scenario,
-                    scenario_index=scenario_index,
-                    total_scenarios=total_scenarios,
-                    quality=episode.quality,
-                    cost_usd=episode.cost_usd,
-                    duration_s=episode.duration_s,
-                    timed_out=episode.timed_out,
-                )
-                asyncio.run_coroutine_threadsafe(coro, loop)
+        def on_episode_done(episode, scenario_index, total_scenarios):
+            coro = submit_scenario_progress(
+                self.wallet,
+                challenge_epoch_id=challenge_epoch_id,
+                miner_hotkey=commitment.hotkey,
+                miner_uid=commitment.uid,
+                scenario_name=episode.scenario,
+                scenario_index=scenario_index,
+                total_scenarios=total_scenarios,
+                quality=episode.quality,
+                cost_usd=episode.cost_usd,
+                duration_s=episode.duration_s,
+                timed_out=episode.timed_out,
+            )
+            asyncio.run_coroutine_threadsafe(coro, loop)
 
         outcome = await evaluate_miner_s1(
             harness=self._sandbox_harness,


### PR DESCRIPTION
## Summary

Removes the env-var gate from `_evaluate_challenger`. The flag was a landing-order safety belt — it let the validator-side patch land before the platform server's `/api/v2/epoch/{id}/scenario_progress` endpoint existed, without spamming 404s. That window closed once trajectoryrl.web#42 merged and migration 072 was applied.

**Lands before v0.6.7 is tagged** so the first 0.6.7 image ships with streaming on by default. VERSION is already 0.6.7 on main; no tag yet.

## Why default-off was wrong

- Every validator operator would have had to know about the flag and manually set it on `.env.validator`. Most won't — so the `/challenge` page stays empty by default, defeating the point of the feature.
- The submit is **fire-and-forget** with a 10s timeout. 404s log at debug, other errors at warning. **No failure mode aborts an eval.**
- Watchtower rolls the fleet uniformly anyway. Per-validator tuning was never the goal.

## Changes

`trajectoryrl/base/validator.py`:
- Drop the `if os.getenv("TRAJRL_SCENARIO_STREAMING") == "1":` guard in `_evaluate_challenger`. Always construct the `on_episode_done` callback.
- Drop the now-unused `import os`.

23 insertions, 26 deletions. No other behavior changes.

## Test plan

- [x] 112/112 unit tests pass (`pytest tests/ --ignore=tests/test_sandbox_harness.py`)
- [x] Smoke import OK
- [ ] Tag `v0.6.7` after merge → CI publishes GHCR image → watchtower rolls fleet
- [ ] Verify `/challenge` panel populates within 1-2 epochs (each scenario ~30-60s)

## Rollback

If the streaming endpoint ever becomes a problem (unlikely given the safety properties above), the rollback is a one-commit revert plus a fast release. The eval path itself is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)