### PR TITLE
feat(eval-uploads): include spec_number on intermediate uploads

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -461,6 +461,7 @@ Like `/api/scores/submit`, this is fire-and-forget — failures must be silently
 | `block_height` | string | Yes | Block height of this eval (string-encoded number; links to the corresponding `submit_eval` record) |
 | `pack_hash` | string | Yes | SHA-256 hash of the pack being evaluated. Each upload must correspond to exactly one pack. |
 | `epoch_number` | string | No | Optional epoch number (string-encoded non-negative integer) this log belongs to. When supplied, the server stores it as-is on the `eval_logs` row. When omitted/empty, the server derives it from the latest synced `block_height` in `sync_state`. |
+| `spec_number` | string | No | Optional validator-side `SPEC_NUMBER` (string-encoded non-negative integer) — the active scoring contract under which this eval ran. Stored on the `eval_logs` row so server-side stats can bucket logs by spec. Omitted by older validator releases; the column stays NULL. |
 | `timestamp` | string | Yes | Unix timestamp in seconds (string-encoded number) |
 | `signature` | string | Yes | Validator's signature over `"trajectoryrl-logs:{validator_hotkey}:{timestamp}"` |
 | `log_archive` | file | Yes | `.tar.gz` archive containing all log files for this eval run. Max 10 MB. |
@@ -561,6 +562,7 @@ Like `/api/scores/submit`, this is fire-and-forget.
 | `eval_id` | string | Yes | Eval cycle identifier in `YYYYMMDD_HHMMSS` format (same value shared with per-miner uploads of this cycle) |
 | `block_height` | string | Yes | Block height at cycle start (string-encoded number) |
 | `epoch_number` | string | No | Optional epoch number (string-encoded non-negative integer) this cycle belongs to. When supplied, the server stores it as-is on the `eval_logs` row. When omitted/empty, the server derives it from the latest synced `block_height` in `sync_state`. |
+| `spec_number` | string | No | Optional validator-side `SPEC_NUMBER` (string-encoded non-negative integer) — the active scoring contract for this cycle. Stored on the `eval_logs` row so server-side stats can bucket cycle logs by spec. Omitted by older validator releases; the column stays NULL. |
 | `timestamp` | string | Yes | Unix timestamp in seconds (string-encoded number) |
 | `signature` | string | Yes | Validator's signature over `"trajectoryrl-logs:{validator_hotkey}:{timestamp}"` |
 | `log_archive` | file | Yes | `.tar.gz` archive containing the cycle log. Max 10 MB. |

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -502,6 +502,7 @@ class TrajectoryValidator:
                 "miner_uid": uid,
                 "block_height": block_height,
                 "pack_hash": commitment.pack_hash,
+                "spec_number": _spec_number(),
                 "type": "eval",
             }
             try:
@@ -521,6 +522,7 @@ class TrajectoryValidator:
                 pack_hash=commitment.pack_hash,
                 log_archive=log_archive,
                 epoch_number=challenge_epoch_id,
+                spec_number=_spec_number(),
             )
             if ok:
                 try:
@@ -570,6 +572,7 @@ class TrajectoryValidator:
                 "eval_id": eval_id,
                 "challenge_epoch_id": challenge_epoch_id,
                 "block_height": block_height,
+                "spec_number": _spec_number(),
                 "type": "cycle",
             }
             try:
@@ -586,6 +589,7 @@ class TrajectoryValidator:
                 block_height=block_height,
                 log_archive=archive,
                 epoch_number=challenge_epoch_id,
+                spec_number=_spec_number(),
             )
             if ok:
                 try:
@@ -644,6 +648,7 @@ class TrajectoryValidator:
                     epoch_number=meta.get(
                         "challenge_epoch_id", meta.get("window_number")
                     ),
+                    spec_number=meta.get("spec_number"),
                 )
                 if ok:
                     eval_uploaded += 1
@@ -672,6 +677,7 @@ class TrajectoryValidator:
                 epoch_number=meta.get(
                     "challenge_epoch_id", meta.get("window_number")
                 ),
+                spec_number=meta.get("spec_number"),
             )
             if ok:
                 cycle_uploaded += 1
@@ -816,6 +822,7 @@ class TrajectoryValidator:
                 cost_usd=episode.cost_usd,
                 duration_s=episode.duration_s,
                 timed_out=episode.timed_out,
+                spec_number=_spec_number(),
             )
             asyncio.run_coroutine_threadsafe(coro, loop)
 

--- a/trajectoryrl/utils/trajrl_api.py
+++ b/trajectoryrl/utils/trajrl_api.py
@@ -446,6 +446,7 @@ async def submit_scenario_progress(
     cost_usd: Optional[float] = None,
     duration_s: Optional[float] = None,
     timed_out: Optional[bool] = None,
+    spec_number: Optional[int] = None,
     submit_url_template: Optional[str] = None,
     timeout: float = 10.0,
 ) -> bool:
@@ -494,6 +495,8 @@ async def submit_scenario_progress(
         payload["duration_s"] = duration_s
     if timed_out is not None:
         payload["timed_out"] = timed_out
+    if spec_number is not None:
+        payload["spec_number"] = spec_number
 
     submit_url_template = (
         submit_url_template or _default_scenario_progress_url_template()
@@ -533,6 +536,7 @@ async def upload_eval_logs(
     pack_hash: str,
     log_archive: bytes,
     epoch_number: Optional[int] = None,
+    spec_number: Optional[int] = None,
     upload_url: Optional[str] = None,
 ) -> bool:
     """Upload eval log archive to the dashboard API.
@@ -563,6 +567,8 @@ async def upload_eval_logs(
     }
     if epoch_number is not None:
         form_data["epoch_number"] = str(epoch_number)
+    if spec_number is not None:
+        form_data["spec_number"] = str(spec_number)
 
     try:
         async with httpx.AsyncClient() as client:
@@ -601,6 +607,7 @@ async def upload_cycle_logs(
     block_height: int,
     log_archive: bytes,
     epoch_number: Optional[int] = None,
+    spec_number: Optional[int] = None,
     upload_url: Optional[str] = None,
 ) -> bool:
     """Upload eval cycle log archive to the dashboard API.
@@ -628,6 +635,8 @@ async def upload_cycle_logs(
     }
     if epoch_number is not None:
         form_data["epoch_number"] = str(epoch_number)
+    if spec_number is not None:
+        form_data["spec_number"] = str(spec_number)
 
     try:
         async with httpx.AsyncClient() as client:


### PR DESCRIPTION
## Summary

The score POST already includes `spec_number` (handled by `submit_challenge_score`). Mirror the same plumbing on the three other eval-related upload paths so the server can bucket those records by scoring spec.

Pairs with [trajectoryrl.web PR](https://github.com/trajectoryRL/trajectoryrl.web/pulls) (`feat/upload-spec-number`) which adds migration 075 + the route handlers + DB layer that read/persist the new field.

## Changes

- **`trajrl_api.submit_scenario_progress`** — `spec_number: Optional[int] = None` kwarg, attached to JSON payload only when supplied (matches the existing `cost_usd / duration_s / timed_out` shape).
- **`trajrl_api.upload_eval_logs` / `upload_cycle_logs`** — same kwarg, attached to multipart `form_data` (matches the existing `epoch_number` shape).
- **`validator._score_challenger`** — pass `spec_number=_spec_number()` at the `scenario_progress` callback and on the eval-log upload call.
- **`validator._fire_upload_eval_logs` / `_fire_upload_cycle_logs`** — same.
- **`validator._replay_pending_uploads`** — `spec_number` is now persisted in `upload_meta.json` / `cycle_upload_meta.json` at write time so a daemon restart re-uploads with the original spec_number; meta files written by older daemons (no key) fall back to `None`, and the server stores NULL.
- **`API.md` mirror** (`docs/API.md`) — document the new optional `spec_number` form field on `/logs/upload` + `/logs/cycle`. v6 section stays byte-identical with the web copy.

## Compatibility

- **New validator + old server** — old server ignores the unknown form/body field; helper still returns 200. No breakage.
- **Old validator + new server** — server stores NULL `spec_number` (existing behaviour). No breakage.

So PRs can land in any order.

## Test plan

- [x] `python3 -c \"import ast; ast.parse(open('trajectoryrl/base/validator.py').read())\"` parses clean
- [x] `python3 -c \"import ast; ast.parse(open('trajectoryrl/utils/trajrl_api.py').read())\"` parses clean
- [ ] After web migration 075 lands on staging + this rolls: confirm a fresh `scenario_progress` row carries `spec_number = SPEC_NUMBER`
- [ ] Confirm a fresh `eval_logs` row (both `log_type='miner'` and `'cycle'`) carries `spec_number = SPEC_NUMBER`
- [ ] Restart-replay path: kill daemon mid-upload, restart, verify the replay-uploaded row still carries the original spec_number from `upload_meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)