### PR TITLE
feat(validator): report judge_model on /api/v2/epoch/{id}/score

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -1071,6 +1071,7 @@ class TrajectoryValidator:
             spec_number=_spec_number(),
             llm_base_url=self.config.llm_base_url,
             llm_model=self.config.llm_model,
+            judge_model=self.config.judge_model or None,
             **self._harness_metadata(),
         )
 

--- a/trajectoryrl/utils/trajrl_api.py
+++ b/trajectoryrl/utils/trajrl_api.py
@@ -346,6 +346,7 @@ async def submit_challenge_score(
     spec_number: Optional[int] = None,
     llm_base_url: Optional[str] = None,
     llm_model: Optional[str] = None,
+    judge_model: Optional[str] = None,
     bench_image_hash: Optional[str] = None,
     harness_image_hash: Optional[str] = None,
     bench_version: Optional[str] = None,
@@ -404,6 +405,8 @@ async def submit_challenge_score(
         payload["llm_base_url"] = llm_base_url
     if llm_model is not None:
         payload["llm_model"] = llm_model
+    if judge_model is not None:
+        payload["judge_model"] = judge_model
     if bench_image_hash is not None:
         payload["bench_image_hash"] = bench_image_hash
     if harness_image_hash is not None:


### PR DESCRIPTION
## Summary

Picks up the unfinished half of the closed PR #210. The original "validators page shows judge instead of testee model" bug was fixed naturally by the v6.0 rewrite — \`llm_model\` now correctly carries the testee. But the v6 path still doesn't surface \`judge_model\` to the website at all, even though the schema is ready for it on both sides.

This PR adds the missing wiring on the validator side:

- \`trajrl_api.py:submit_challenge_score\` accepts a new \`judge_model\` kwarg, forwards it in the JSON payload (None-skipped, matching the existing pattern).
- \`validator.py:1073\` passes \`judge_model=self.config.judge_model or None\`.

The web side (\`POST /api/v2/epoch/{id}/score\` and \`challenge_scores.judge_model\`) already accept the field — see \`trajectoryrl.web/src/app/api/v2/epoch/[challenge_epoch_id]/score/route.ts:214\` and \`src/lib/db/challenge-scores.ts:62\`. So this PR is wire-compatible: validators that haven't set \`JUDGE_MODEL\` send no new field, and the server tolerates missing \`judge_model\` (already null-defaulted).

## Companion change (web)

The \`/api/validators\` route currently reads \`llm_model\` + \`judge_model\` via a LATERAL join on \`score_submit_log\` — a v5-era table that v6 validators no longer write to. A small follow-up PR on the web side switches that LATERAL to read from \`challenge_scores\` so the validators page actually picks up the new judge_model values from this PR. Will open separately.

## Backwards compat

- Validators with \`JUDGE_MODEL\` unset (\`config.judge_model == ""\`) → \`judge_model\` resolves to \`None\` → field is not added to payload → wire format unchanged.
- Validators with \`JUDGE_MODEL\` set → \`judge_model\` lands in \`challenge_scores.judge_model\`.
- Web server tolerates missing \`judge_model\` (\`null\` fallback).

## Test plan

- [ ] CI green
- [ ] Local sanity: \`from trajectoryrl.utils.trajrl_api import submit_challenge_score; 'judge_model' in inspect.signature(submit_challenge_score).parameters\` → True
- [ ] After web-side companion PR: validators page on trajrl.com shows both testee + judge model

🤖 Generated with [Claude Code](https://claude.com/claude-code)