### PR TITLE
fix(harness): break exec_stream timeout deadlock on silent Hermes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
 dev = [
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-timeout>=2.3.0",
     "black>=23.0.0",
     "ruff>=0.1.0",
 ]

--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -8,19 +8,17 @@ import threading
 import time
 
 import pytest
-from dataclasses import dataclass, field
 
 from trajectoryrl.utils.config import ValidatorConfig
 from trajectoryrl.utils.sandbox_harness import (
-    TrajectorySandboxHarness,
     SandboxEvaluationResult,
-    _SessionResult,
+    TrajectorySandboxHarness,
+    _drain_exec_stream_with_deadline,
     _EpisodeResult,
     _parse_ctrf_correctness,
     _parse_session_cost,
-    _drain_exec_stream_with_deadline,
+    _SessionResult,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -389,8 +387,8 @@ def _make_harness(sandbox_image: str = "", tmp_path=None) -> TrajectorySandboxHa
     The helpers we test only touch ``self.config`` + cached attribute
     state; we never call ``self.client``.
     """
-    from pathlib import Path
     import tempfile
+    from pathlib import Path
 
     if tmp_path is None:
         tmp_path = Path(tempfile.mkdtemp())

--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -4,6 +4,9 @@ Tests the result mapping, config wiring, and SKILL.md extraction
 without requiring Docker or real LLM API calls.
 """
 
+import threading
+import time
+
 import pytest
 from dataclasses import dataclass, field
 
@@ -15,6 +18,7 @@ from trajectoryrl.utils.sandbox_harness import (
     _EpisodeResult,
     _parse_ctrf_correctness,
     _parse_session_cost,
+    _drain_exec_stream_with_deadline,
 )
 
 
@@ -442,3 +446,181 @@ class TestScenarioImageRef:
         h = _make_harness()
         h._scenario_info = {"name": "cancel-async-tasks"}
         assert h._scenario_image_ref() == ""
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the exec-stream timeout helper.
+#
+# These pin down the contract that ``_drain_exec_stream_with_deadline``
+# returns within ``timeout + slack`` even when the stream iterator blocks
+# silently — the wild-caught case being a Hermes process parked on a
+# stuck LLM API call that emits no stdout. The naive
+# ``for chunk in stream: ... if deadline: break`` pattern parks in
+# ``next()`` and never re-checks the deadline.
+# ---------------------------------------------------------------------------
+
+class TestDrainExecStreamWithDeadline:
+
+    def test_returns_all_chunks_when_iterator_completes(self):
+        def stream():
+            yield b"hello "
+            yield b"world"
+
+        chunks, timed_out = _drain_exec_stream_with_deadline(
+            stream(), timeout=5.0,
+        )
+
+        assert b"".join(chunks) == b"hello world"
+        assert timed_out is False
+
+    @pytest.mark.timeout(3)
+    def test_fires_deadline_when_iterator_blocks_silently(self):
+        """An iterator that emits nothing and never returns — Hermes
+        blocked on a stalled API call — must still trip the deadline
+        within ``timeout + small slack``. The pre-fix inline code
+        deadlocks here because the deadline check sat inside the
+        ``for chunk in stream`` body and never re-runs without a
+        chunk to wake it."""
+        never_ends = threading.Event()
+
+        def stream():
+            never_ends.wait()  # blocks forever
+            yield b"won't get here"  # pragma: no cover
+
+        try:
+            start = time.monotonic()
+            chunks, timed_out = _drain_exec_stream_with_deadline(
+                stream(), timeout=0.5,
+            )
+            elapsed = time.monotonic() - start
+
+            assert timed_out is True
+            assert chunks == []
+            # Slack budget for thread wake-up jitter on CI. Anything
+            # past this strongly suggests an in-loop deadline check
+            # reintroduced the deadlock.
+            assert elapsed < 1.5, (
+                f"deadline took {elapsed:.2f}s; deadlock likely reintroduced"
+            )
+        finally:
+            never_ends.set()
+
+    def test_zero_timeout_returns_immediately_as_timed_out(self):
+        """A 0-timeout call (or one past deadline at entry) must
+        return ``timed_out=True`` even if the iterator is empty —
+        the pre-fix in-loop check never executes the body on an
+        empty iterator and so leaves ``timed_out`` at its False
+        default. Pins the deadline-check-runs-first contract."""
+        chunks, timed_out = _drain_exec_stream_with_deadline(
+            iter([]), timeout=0,
+        )
+        assert chunks == []
+        assert timed_out is True
+
+    @pytest.mark.timeout(3)
+    def test_collects_chunks_before_deadline_when_iterator_then_blocks(self):
+        emitted_one = threading.Event()
+        never_ends = threading.Event()
+
+        def stream():
+            yield b"partial-output"
+            emitted_one.set()
+            never_ends.wait()
+            yield b"never"  # pragma: no cover
+
+        try:
+            chunks, timed_out = _drain_exec_stream_with_deadline(
+                stream(), timeout=0.5,
+            )
+
+            assert emitted_one.is_set(), (
+                "first chunk should have been produced before deadline"
+            )
+            assert b"".join(chunks) == b"partial-output"
+            assert timed_out is True
+        finally:
+            never_ends.set()
+
+    def test_iterator_exception_is_caught_and_reported(self):
+        def stream():
+            yield b"head"
+            raise ConnectionResetError("docker socket closed")
+
+        chunks, timed_out = _drain_exec_stream_with_deadline(
+            stream(), timeout=5.0,
+        )
+
+        # Pre-exception chunks are still surfaced; an iterator that
+        # ends early via exception is not the same thing as a timeout.
+        assert b"".join(chunks) == b"head"
+        assert timed_out is False
+
+    @pytest.mark.timeout(3)
+    def test_invokes_on_deadline_callback_exactly_once_on_timeout(self):
+        """The callback exists so the caller can release the blocked
+        exec socket (pkill the in-container process). It must fire
+        exactly once at deadline — never zero times, never twice.
+        Pre-fix the deadline never fires on a silent iterator so the
+        callback is never invoked: this test fails by callback
+        invocation count = 0."""
+        called: list[float] = []
+        never_ends = threading.Event()
+
+        def stream():
+            never_ends.wait()
+            yield b""  # pragma: no cover
+
+        try:
+            _drain_exec_stream_with_deadline(
+                stream(),
+                timeout=0.3,
+                on_deadline=lambda: called.append(time.monotonic()),
+            )
+
+            assert len(called) == 1, (
+                f"on_deadline must fire exactly once; fired {len(called)}"
+            )
+        finally:
+            never_ends.set()
+
+    def test_does_not_invoke_callback_when_iterator_completes_in_time(self):
+        called: list[bool] = []
+
+        def stream():
+            yield b"done"
+
+        _drain_exec_stream_with_deadline(
+            stream(),
+            timeout=5.0,
+            on_deadline=lambda: called.append(True),
+        )
+
+        assert called == [], "on_deadline must not fire on clean completion"
+
+    @pytest.mark.timeout(3)
+    def test_callback_failure_does_not_leak_out(self):
+        """The on_deadline callback runs in-process; if it raises
+        (e.g. pkill against a torn-down container), the helper must
+        swallow the exception so the caller still gets the partial
+        transcript and proceeds to teardown. Pre-fix this never
+        gets exercised because the callback isn't called; once the
+        fix lets the deadline fire, a raising callback would tear
+        down the helper without this safety net."""
+        never_ends = threading.Event()
+
+        def stream():
+            never_ends.wait()
+            yield b""  # pragma: no cover
+
+        def boom() -> None:
+            raise RuntimeError("docker SDK lost the container")
+
+        try:
+            chunks, timed_out = _drain_exec_stream_with_deadline(
+                stream(), timeout=0.3, on_deadline=boom,
+            )
+
+            assert timed_out is True
+            assert chunks == []
+        finally:
+            never_ends.set()

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -32,8 +32,10 @@ import hashlib
 import io
 import json
 import logging
+import queue
 import secrets
 import tarfile
+import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -72,26 +74,85 @@ def _drain_exec_stream_with_deadline(
     stream,
     timeout: float,
     on_deadline: Callable[[], None] | None = None,
+    poll_interval_s: float = 1.0,
 ) -> tuple[list[bytes], bool]:
     """Drain a docker exec_start stream subject to a wall-clock deadline.
 
-    Returns ``(chunks, timed_out)``. If ``on_deadline`` is provided it
-    is invoked once when the deadline fires.
+    The docker-py exec_start iterator parks on ``next()`` whenever the
+    container produces no stdout (e.g. a Hermes process blocked on an
+    LLM API call that never returns). A naive ``for chunk in stream``
+    deadline check therefore only re-fires between chunks and never
+    triggers on a fully-silent hang. Drain the iterator in a daemon
+    thread and poll a bounded queue from the caller so the deadline
+    check runs on every poll-tick.
+
+    Args:
+        stream: Iterable producing ``bytes`` chunks. May block
+            indefinitely between chunks.
+        timeout: Wall-clock deadline in seconds from the call.
+        on_deadline: Optional callback fired once when the deadline
+            trips. Used by the caller to ``pkill`` the in-container
+            process so the stream socket releases.
+        poll_interval_s: Upper bound on a single ``Queue.get`` wait.
+            Smaller → faster shutdown past the deadline; larger →
+            fewer idle wakeups. Default 1.0 s.
+
+    Returns:
+        ``(chunks, timed_out)``. ``chunks`` holds the bytes received
+        before the iterator ended, the deadline fired, or it raised.
+        ``timed_out`` is True iff the deadline fired before the
+        iterator finished on its own.
+
+    Lifecycle note:
+        The reader is a daemon thread that exits naturally when the
+        underlying ``stream`` raises or terminates. Callers should
+        pair invocation with eventual closure of the stream source
+        (in the harness: the ``finally`` block's ``sandbox.stop()``
+        releases the docker socket and the reader returns) — otherwise
+        the daemon thread sits on ``next(stream)`` until process exit.
     """
+    chunk_q: queue.Queue = queue.Queue()
+    sentinel = object()
+
+    def _reader() -> None:
+        try:
+            for c in stream:
+                chunk_q.put(c)
+        except Exception as exc:  # noqa: BLE001
+            chunk_q.put(exc)
+        finally:
+            chunk_q.put(sentinel)
+
+    threading.Thread(
+        target=_reader, daemon=True, name="exec-stream-drain",
+    ).start()
+
     chunks: list[bytes] = []
     timed_out = False
     deadline = time.time() + timeout
-    try:
-        for chunk in stream:
-            if chunk:
-                chunks.append(chunk)
-            if time.time() > deadline:
-                timed_out = True
-                if on_deadline is not None:
+    while True:
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            timed_out = True
+            if on_deadline is not None:
+                try:
                     on_deadline()
-                break
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("exec stream raised: %s", exc)
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "exec-stream on_deadline callback failed: %s", exc,
+                    )
+            break
+        try:
+            item = chunk_q.get(timeout=min(remaining, poll_interval_s))
+        except queue.Empty:
+            continue
+        if item is sentinel:
+            break
+        if isinstance(item, Exception):
+            logger.warning("exec stream raised: %s", item)
+            break
+        if item:
+            chunks.append(item)
     return chunks, timed_out
 
 
@@ -1000,8 +1061,28 @@ class TrajectorySandboxHarness:
             )["Id"]
 
             stream = self.client.api.exec_start(exec_id, stream=True, demux=False)
+
+            def _kill_hermes() -> None:
+                # Releases the blocked exec_start socket so we can
+                # proceed to teardown instead of waiting on the
+                # finally-block's container.stop().
+                #
+                # ``-f hermes`` matches by cmdline pattern, which is
+                # intentionally broad: it kills both the ``hermes chat``
+                # python process and the ``bash -c '... hermes chat ...'``
+                # wrapper that exec was registered under. The agent user
+                # in the sandbox-agent image is the only thing in the
+                # container, so collateral on other processes is not a
+                # concern.
+                sandbox.exec_run(
+                    ["pkill", "-KILL", "-f", "hermes"],
+                    user="root",
+                )
+
             transcript_chunks, episode.timed_out = (
-                _drain_exec_stream_with_deadline(stream, timeout=timeout)
+                _drain_exec_stream_with_deadline(
+                    stream, timeout=timeout, on_deadline=_kill_hermes,
+                )
             )
             episode.transcript = b"".join(transcript_chunks).decode(
                 "utf-8", errors="replace",

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -65,6 +65,37 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
 
 
 # ---------------------------------------------------------------------------
+# Exec-stream helpers
+# ---------------------------------------------------------------------------
+
+def _drain_exec_stream_with_deadline(
+    stream,
+    timeout: float,
+    on_deadline: Callable[[], None] | None = None,
+) -> tuple[list[bytes], bool]:
+    """Drain a docker exec_start stream subject to a wall-clock deadline.
+
+    Returns ``(chunks, timed_out)``. If ``on_deadline`` is provided it
+    is invoked once when the deadline fires.
+    """
+    chunks: list[bytes] = []
+    timed_out = False
+    deadline = time.time() + timeout
+    try:
+        for chunk in stream:
+            if chunk:
+                chunks.append(chunk)
+            if time.time() > deadline:
+                timed_out = True
+                if on_deadline is not None:
+                    on_deadline()
+                break
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("exec stream raised: %s", exc)
+    return chunks, timed_out
+
+
+# ---------------------------------------------------------------------------
 # Result types
 # ---------------------------------------------------------------------------
 
@@ -969,20 +1000,9 @@ class TrajectorySandboxHarness:
             )["Id"]
 
             stream = self.client.api.exec_start(exec_id, stream=True, demux=False)
-            transcript_chunks: list[bytes] = []
-            stream_deadline = time.time() + timeout
-            try:
-                for chunk in stream:
-                    if chunk:
-                        transcript_chunks.append(chunk)
-                    if time.time() > stream_deadline:
-                        episode.timed_out = True
-                        break
-            except Exception as e:
-                logger.warning(
-                    "[%s] %s exec stream broke: %s",
-                    session_id, scenario, e,
-                )
+            transcript_chunks, episode.timed_out = (
+                _drain_exec_stream_with_deadline(stream, timeout=timeout)
+            )
             episode.transcript = b"".join(transcript_chunks).decode(
                 "utf-8", errors="replace",
             )


### PR DESCRIPTION
## Summary

The per-episode deadline check in `_run_episode` sat inside a
`for chunk in stream:` iterator over `docker exec_start(stream=True)`.
When the testee Hermes process blocks on a stuck LLM API call and
emits no stdout, the iterator parks in `next()` and the
`time.time() > stream_deadline` check never re-fires. The episode
runs past `SANDBOX_TIMEOUT_PER_EPISODE` until something external
kills the container.

This PR replaces the in-loop check with a daemon-thread drain +
bounded `queue.get(timeout=...)` poll so the deadline check runs on
every poll-tick regardless of whether chunks are arriving. When the
deadline trips, an `on_deadline` callback `pkill`s the in-container
hermes process so the blocked `exec_start` socket releases and the
function proceeds to teardown.

## Why this matters

In production the deadlock means a single wedged miner pack can
block an entire epoch window. The validator's `finally` block
(`sandbox.stop(timeout=5)`) only runs *after* the function returns,
which never happens while the iterator is parked. We observed this
locally — `path-tracing` ran 1481 s under
`SANDBOX_TIMEOUT_PER_EPISODE=600` before manual `docker stop`
released the stream. With this fix the same scenario cleanly cuts
off at 621.7 s and the harness proceeds to the verifier with the
partial transcript intact.

Concretely for a validator process:

- **Bounded per-episode cost.** With `SANDBOX_TIMEOUT_PER_EPISODE=600`
  and 8 scenarios, worst-case wall-clock per pack is now genuinely
  ~80 min. Pre-fix a single stuck scenario could consume the full
  epoch.
- **No zombie token spend.** The `pkill -KILL -f hermes` in
  `on_deadline` actually stops the agent process. Pre-fix the
  hermes process kept calling the LLM (= real $) until the outer
  `finally` block's `sandbox.stop(timeout=5)` eventually fired —
  and only after the harness itself returned, which it never did.
- **Consensus tightens.** Two validators looking at the same pack
  diverged when one wedged and the other didn't; `consensus_epsilon`
  (0.02 default) is much easier to stay inside when every validator
  experiences the same bounded timeout behavior.
- **`set_weights` lands on time.** A wedged harness pushes a
  validator past `window_publish_pct` (80% of the epoch) and out
  of weight-publishing eligibility for that window. Bounded
  timeouts keep the publish path on schedule.
- **`/api/v2/epoch/{id}/score` reporting unblocks.** A validator
  whose harness is parked never POSTs its scores; peer validators
  see it as silently delinquent. Fix puts the per-miner score row
  back on the wire.

What does *not* change: verifier scoring algorithm, scenario set,
`final_score` aggregation across scenarios, or the meaning of
`SANDBOX_TIMEOUT_PER_EPISODE` (still operator-controlled — the fix
just enforces it reliably).

## How it's structured

The three commits map to a deliberate red/green TDD cycle so a
reviewer can verify the bug and the fix independently:

1. **`f240bc3 refactor(harness): extract _drain_exec_stream_with_deadline helper`**
   Move the inline drain logic into a module-level helper.
   No behavior change — the deadline check is still inside
   `for chunk in stream`. Makes the surface testable without Docker.

2. **`cdafd5e test(harness): add regression for exec-stream timeout deadlock`**
   Eight tests against `_drain_exec_stream_with_deadline`. Five
   deliberately fail at this commit, in two failure classes:

   *Deadlock (pytest-timeout fires at 3 s):*
   - `test_fires_deadline_when_iterator_blocks_silently` — proves
     the fundamental bug.
   - `test_collects_chunks_before_deadline_when_iterator_then_blocks`
     — proves the deadlock survives across iterator state.
   - `test_invokes_on_deadline_callback_exactly_once_on_timeout` —
     also deadlocks pre-fix because the callback fires inside the
     same in-loop check that never runs.
   - `test_callback_failure_does_not_leak_out` — same.

   *Logical (returns wrong value pre-fix):*
   - `test_zero_timeout_returns_immediately_as_timed_out` — pins
     the weaker corollary that the pre-fix loop never executes the
     deadline check on an empty iterator, so `timed_out` stays at
     its False default.

   Three pass at this commit (clean completion, exception
   propagation, "does not invoke callback on success" which holds
   vacuously since the callback never runs pre-fix).

   `pytest-timeout>=2.3.0` added to dev deps so the deadlocking
   tests fail loudly instead of hanging CI.

3. **`aeaea7c fix(harness): break exec_stream timeout deadlock on stuck Hermes`**
   Replace the in-loop check with a threaded drain + queue.get poll.
   Add `on_deadline` callback; caller passes a function that does
   `sandbox.exec_run(["pkill", "-KILL", "-f", "hermes"], user="root")`
   so the blocked exec_start releases.

   All eight regression tests now pass; full `test_sandbox_harness.py`
   suite is 53 passing in ~1.2 s.

4. **`c218394 chore(harness): ruff cleanup of test-file imports`**
   Drops unused `from dataclasses import dataclass, field` (F401)
   and alphabetises the import block (I001). No test changes; the
   new `TestDrainExecStreamWithDeadline` class brought I001 over
   the threshold. Carved out: ruff also flags `import docker` as
   unused, but `docker` is referenced via attribute access
   (`docker.DockerClient`, `docker.errors.NotFound`) so removing
   it would be a latent prod break. Left as-is and noted in the
   commit message.

## Verification

**Mechanical (no Docker required):** check out commit `cdafd5e` (the
test-only commit) and run
`pytest tests/test_sandbox_harness.py::TestDrainExecStreamWithDeadline`.
Five of eight tests fail (four by pytest-timeout, one by
`timed_out=False` on an empty iterator) — the failure modes you'd
see under any docker-py iterator that doesn't emit. Then check out
`aeaea7c` (the fix) and run the same command; all eight pass.

**Integration (with Docker + LLM key):** running
`scripts/eval_pack.py` against a SKILL.md that produces a slow
path-tracer:
- Before: `path-tracing` hangs 1481 s (`exit=None`,
  `timed_out=False` in the harness log) until something kills the
  container externally.
- After: `path-tracing` returns at 621.7 s (`exit=None`,
  `timed_out=True`), verifier picks up the partial agent output.

**Cross-pack regression bench:** subsequent re-bench across three
SKILL.md packs (3 × 8 = 24 episodes total) with this fix in the
loop. All 24 episodes returned cleanly to the harness — zero wedge
events across the run set. The one `path-tracing` TIMEOUT that
occurred (614.1 s wall-clock, `exit=137`, `timed_out=True`,
8110 chars of partial transcript) was handed to the verifier
intact and scored 0.2; exactly the failure mode that pre-fix
required manual `docker stop` to recover from. The threaded-drain
semantics hold under real Hermes output across heterogeneous
scenarios — not just the synthetic generator stand-ins in the
unit tests.

## Production evidence

Pulled recent miner-eval log archives (via `trajrl logs --type
miner --validator <hk>`) from five live SN11 validators on
v0.6.11 — combined stake ≈ 2.3M τ. Each archive's `validator.log`
contains `[<sandbox>] <scenario> starting` and `hermes chat
finished (exit=…, timed_out=…)` lines, so per-scenario wall-clock
duration is directly measurable. Path-tracing TIMEOUT cases:

| Validator | Stake (τ) | path-tracing TIMEOUT wall-clock | Other TIMEOUTs |
|---|---:|---:|---|
| trajrl.com (5ECzcM7s) | 1.12M | 1324 s | db-wal-recovery 1592 s |
| TAO.com (5HTZ6CxJ) | 0.73M | 711 s | vulnerable-secret 675 s |
| Yuma (5FnwjYYF) | 0.20M | 683 s | — |
| General Tensor (5Cd6htiu) | 0.17M | 1064 s | — |
| Rizzo (5GZGoeDm) | 0.12M | 1218 s | — |

Two facts together pin the bug:

1. **Same scenario, wildly different cutoff wall-clocks across
   validators** (683 s ↔ 1324 s, ratio 1.94×). A correctly-implemented
   600 s deadline produces cutoffs clustered at ~605-615 s
   regardless of operator; the only mechanism in the harness that
   produces this kind of variance is the "deadline check sits inside
   the chunk-iteration loop, fires only when the next chunk arrives"
   pattern this PR rewrites. Local repro after the fix: cutoff at
   621.7 s (≈ 600 s + bounded poll-interval slack).

2. **TAO.com pins the configured global to ≤ 675 s.** Their
   `vulnerable-secret` TIMEOUT at 675 s caps `SANDBOX_TIMEOUT_PER_EPISODE`
   at no more than that value (otherwise the scenario could not have
   been cut off there). Combined with their `path-tracing` TIMEOUT
   at 711 s, that's an observed ~+75 s drift past the configured
   deadline on the same validator in the same eval cycle — direct
   in-the-wild measurement of the bug class this PR fixes.

We did not directly observe `SANDBOX_TIMEOUT_PER_EPISODE` for the
other four (operators don't expose runtime config). The simplest
explanation that fits all five data points is "all five run with
the documented default 600 s, drift varies with Hermes chunk-arrival
cadence". A more conservative reading is "at minimum, the bug fires
on TAO.com; the drift-style variance across the other four is
strong circumstantial evidence the same code path is firing on them
too." Either way, the fix is the same.

## Flexibility / edge cases considered

- `timeout=0` or negative → returns immediately, `timed_out=True`.
- Caller-controlled `poll_interval_s` (default 1.0 s) — bounds the
  shutdown latency past the deadline.
- `on_deadline` is optional and exceptions inside it are caught and
  logged at DEBUG; a torn-down container won't surprise the caller.
- `pkill -f hermes` matches by process name across the bundled
  hermes-agent user introduced in #245; no coupling to the previous
  `agent` uid.

## Out of scope

`task.toml` per-scenario `[agent] timeout_sec` is still ignored —
the harness uses the global `SANDBOX_TIMEOUT_PER_EPISODE` for all
scenarios. That's a separate consideration and not changed here.
(Tracked in #250, which stacks on this PR.)

## Test plan

- [x] `pytest tests/test_sandbox_harness.py` — 53 passing (8 new)
- [x] `ruff check --config pyproject.toml tests/test_sandbox_harness.py`
      — clean after the chore commit. (One pre-existing I001 on
      `sandbox_harness.py:27` import-block order is also present on
      `origin/main` and intentionally untouched by this PR.)
- [x] Verified test-only commit: 5 of 8 tests fail (4 by deadlock,
      1 by `timed_out=False` on empty iterator)
- [x] Production smoke: path-tracing cuts off at deadline + slack
      instead of hanging
- [x] Cross-pack bench: 24/24 episodes returned cleanly (3 packs ×
      8 scenarios); path-tracing TIMEOUT case recovered with
      `exit=137, timed_out=True, 8110-char partial transcript` —
      no wedging
- [x] Production-log audit: 5/5 sampled v0.6.11 validators
      (combined ≈ 2.3M τ stake) show path-tracing TIMEOUT wall-clock
      varying 683-1324 s — the variance signature of the bug. TAO.com
      pins the configured global at ≤ 675 s via a `vulnerable-secret`
      TIMEOUT at that value.
- [ ] Reviewer: re-verify red/green by checking out commit `cdafd5e`
      and running the test class

🤖 Generated with [Claude Code](https://claude.com/claude-code)
