### PR TITLE
fix(harness): anchor exec-stream deadline on time.monotonic()

### DIFF
--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -622,3 +622,52 @@ class TestDrainExecStreamWithDeadline:
             assert chunks == []
         finally:
             never_ends.set()
+
+    @pytest.mark.timeout(3)
+    def test_deadline_survives_wall_clock_jumping_backwards(self, monkeypatch):
+        """Wall-clock time can jump backwards under NTP correction or
+        manual clock adjustment. A deadline computed from ``time.time()``
+        becomes unreachable when the clock jumps back, leaving the
+        helper waiting on a deadline that never arrives.
+
+        Simulate it by monkeypatching ``time.time`` in the harness
+        module to return monotonically *decreasing* values. A correct
+        helper anchors its deadline on ``time.monotonic()`` (which
+        cannot regress) so the deadline still fires; a helper that
+        anchors on ``time.time()`` will park past the configured
+        timeout and pytest-timeout will fail this test at 3 s."""
+        never_ends = threading.Event()
+
+        def stream():
+            never_ends.wait()
+            yield b""  # pragma: no cover
+
+        from trajectoryrl.utils import sandbox_harness
+
+        fake_now = [1_000_000.0]
+
+        def receding_clock() -> float:
+            # Each call rewinds the wall clock by 0.5 s — much faster
+            # than any plausible NTP correction, but the direction is
+            # what matters for the test.
+            fake_now[0] -= 0.5
+            return fake_now[0]
+
+        monkeypatch.setattr(sandbox_harness.time, "time", receding_clock)
+
+        try:
+            start = time.monotonic()
+            chunks, timed_out = _drain_exec_stream_with_deadline(
+                stream(), timeout=0.3,
+            )
+            elapsed = time.monotonic() - start
+
+            assert timed_out is True
+            assert chunks == []
+            assert elapsed < 1.5, (
+                f"deadline took {elapsed:.2f}s under a receding wall clock; "
+                "helper likely still anchored on time.time() instead of "
+                "time.monotonic()"
+            )
+        finally:
+            never_ends.set()

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -129,9 +129,14 @@ def _drain_exec_stream_with_deadline(
 
     chunks: list[bytes] = []
     timed_out = False
-    deadline = time.time() + timeout
+    # Anchor the deadline on ``time.monotonic()`` so an NTP correction
+    # or manual clock adjustment during the call cannot make the
+    # deadline unreachable. ``time.time()`` can jump arbitrarily;
+    # ``time.monotonic()`` is guaranteed by the standard library to
+    # only move forward.
+    deadline = time.monotonic() + timeout
     while True:
-        remaining = deadline - time.time()
+        remaining = deadline - time.monotonic()
         if remaining <= 0:
             timed_out = True
             if on_deadline is not None:


### PR DESCRIPTION
## Summary

Anchor the exec-stream deadline on `time.monotonic()` instead of
`time.time()`. Wall-clock time can regress under NTP correction or
manual clock adjustment; `time.monotonic()` is contractually never
regressing and is the standard choice for deadline arithmetic.

Stacks on top of #248 (the threaded-drain fix). #248 introduced
the helper this PR patches; this PR sits on the same fix-branch
so it can be reviewed in isolation but lands cleanly after #248
merges.

## Why this matters

A validator running with `SANDBOX_TIMEOUT_PER_EPISODE=600` and an
NTP-corrected clock can today end up parking past its configured
deadline: the `deadline = time.time() + 600` computed at episode
start refers to a wall-clock instant that the system clock may
later step over. The per-iteration `remaining = deadline -
time.time()` check then stays positive indefinitely.

This is the same wedged-epoch failure mode as #248, just via a
different upstream trigger (the OS clock instead of a stuck LLM
API). Both should be impossible.

## How it's structured

1. **`4b9c125 test(harness): regression for wall-clock deadline drift`**
   Monkeypatches `time.time` in the harness module to return
   monotonically decreasing values (simulating NTP-backwards). The
   helper computed from `time.time()` parks past the configured
   timeout; pytest-timeout fires at 3.0 s. RED at this commit.

2. **`5477e4d fix(harness): anchor exec-stream deadline on time.monotonic()`**
   Replace `time.time()` with `time.monotonic()` in the deadline
   computation and the remaining-budget check. The previous commit's
   test now passes; full sandbox-harness suite is 54 passing.

3. **`e8db349 chore(harness): ruff cleanup of test-file imports`**
   Same lint cleanup as in #248 (F401 + I001) — pulls in the
   chore commit so this branch's test file stays ruff-clean on its
   own.

## Verification

Check out `4b9c125` and run
`pytest tests/test_sandbox_harness.py::TestDrainExecStreamWithDeadline::test_deadline_survives_wall_clock_jumping_backwards`.
The test deadlocks under the configured 3 s pytest-timeout. Then
check out `5477e4d` and run the same command; the test passes
within ~0.5 s.

## Scope discipline

Only the deadline arithmetic in `_drain_exec_stream_with_deadline`
is changed. Other `time.time()` uses in the module are timestamps
(logged event times, `episode.duration_s` computed at episode end)
where wall-clock semantics are desired or harmless. Those stay on
`time.time()`.

## Test plan

- [x] `pytest tests/test_sandbox_harness.py` — 54 passing (1 new)
- [x] `ruff check --config pyproject.toml tests/test_sandbox_harness.py`
      — clean. (Pre-existing I001 on harness import-block also on
      `origin/main`, intentionally untouched.)
- [x] Verified RED commit: test fails at pytest-timeout
- [ ] Reviewer: re-verify by checking out `4b9c125` and running
      the single new test
- [ ] Merge after #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

