### PR TITLE
fix(harness): honor per-scenario agent_timeout_s from scenario-info

### DIFF
--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -17,6 +17,7 @@ from trajectoryrl.utils.sandbox_harness import (
     _EpisodeResult,
     _parse_ctrf_correctness,
     _parse_session_cost,
+    _pick_episode_timeout,
     _SessionResult,
 )
 
@@ -676,8 +677,6 @@ class TestDrainExecStreamWithDeadline:
 # ---------------------------------------------------------------------------
 # _pick_episode_timeout — per-scenario agent timeout from task.toml.
 # ---------------------------------------------------------------------------
-
-from trajectoryrl.utils.sandbox_harness import _pick_episode_timeout
 
 
 class TestPickEpisodeTimeout:

--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -671,3 +671,63 @@ class TestDrainExecStreamWithDeadline:
             )
         finally:
             never_ends.set()
+
+
+# ---------------------------------------------------------------------------
+# _pick_episode_timeout — per-scenario agent timeout from task.toml.
+# ---------------------------------------------------------------------------
+
+from trajectoryrl.utils.sandbox_harness import _pick_episode_timeout
+
+
+class TestPickEpisodeTimeout:
+    """The scenario-info payload now carries ``agent_timeout_s`` per
+    scenario (trajrl-bench PR #42). The harness should prefer that
+    value when present and fall back to the global config default
+    otherwise — so a path-tracing scenario that pins 900 s gets 900 s
+    even when the validator's global is 600 s, and an older
+    sandbox-agent image still works.
+    """
+
+    def test_uses_scenario_pinned_timeout_when_present(self):
+        spec = {
+            "name": "path-tracing",
+            "agent_timeout_s": 900,
+        }
+        assert _pick_episode_timeout(spec, config_default=600) == 900.0
+
+    def test_falls_back_to_config_default_when_missing(self):
+        spec = {"name": "old-bench-no-agent-field"}
+        assert _pick_episode_timeout(spec, config_default=600) == 600.0
+
+    def test_falls_back_to_config_default_when_none(self):
+        spec = {"name": "x", "agent_timeout_s": None}
+        assert _pick_episode_timeout(spec, config_default=600) == 600.0
+
+    def test_falls_back_to_config_default_when_zero_or_negative(self):
+        # A 0 or negative agent_timeout_s would defeat the purpose
+        # of having a deadline. Treat it as "not set" and fall back.
+        for bad in (0, -1, -900):
+            spec = {"name": "x", "agent_timeout_s": bad}
+            assert _pick_episode_timeout(spec, config_default=600) == 600.0, (
+                f"agent_timeout_s={bad} should have fallen back"
+            )
+
+    def test_falls_back_to_config_default_when_nan(self):
+        # NaN would propagate into ``time.monotonic() + timeout`` and
+        # produce a NaN deadline that no clock reading can clear,
+        # giving us back the deadlock we just fixed via a different
+        # door. Reject explicitly so a future refactor of the
+        # validation predicate cannot accidentally let it through.
+        spec = {"name": "x", "agent_timeout_s": float("nan")}
+        assert _pick_episode_timeout(spec, config_default=600) == 600.0
+
+    def test_returns_float_for_deadline_arithmetic(self):
+        # The caller passes the result directly into
+        # ``time.monotonic() + timeout``; a non-float (e.g. an int
+        # from JSON) is fine numerically but a returned float is the
+        # documented contract.
+        spec = {"name": "x", "agent_timeout_s": 123}
+        result = _pick_episode_timeout(spec, config_default=600)
+        assert isinstance(result, float)
+        assert result == 123.0

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -161,6 +161,22 @@ def _drain_exec_stream_with_deadline(
     return chunks, timed_out
 
 
+def _pick_episode_timeout(spec: dict, config_default: float) -> float:
+    """Choose the per-episode wall-clock budget for the agent.
+
+    Prefers the scenario-pinned ``agent_timeout_s`` from
+    ``scenario-info`` (originating from ``[agent].timeout_sec`` in
+    the scenario's ``task.toml``) when present and positive. Falls
+    back to the global config default otherwise — happens with
+    sandbox-agent images older than the CLI that emits the field, or
+    if a scenario explicitly defaults the value to zero.
+
+    Returning a float so the caller can pass it straight to the
+    deadline arithmetic.
+    """
+    return float(config_default)
+
+
 # ---------------------------------------------------------------------------
 # Result types
 # ---------------------------------------------------------------------------
@@ -847,6 +863,12 @@ class TrajectorySandboxHarness:
                 "instruction_md": info["instruction_md"],
                 "agent_output_path": info["agent_output_path"],
                 "verifier_timeout_s": int(info.get("verifier_timeout_s", 300)),
+                # Per-scenario agent budget from task.toml's
+                # ``[agent].timeout_sec``, surfaced by ``trajrl_bench.cli
+                # scenario-info``. ``None`` when the sandbox-agent image
+                # is older than the CLI that emits the field; consumer
+                # falls back to the global default in that case.
+                "agent_timeout_s": info.get("agent_timeout_s"),
                 "tests_files_b64": tests_files_b64,
             })
 
@@ -1058,7 +1080,9 @@ class TrajectorySandboxHarness:
                         session_id, scenario, e,
                     )
 
-            timeout = self.config.sandbox_timeout_per_episode
+            timeout = _pick_episode_timeout(
+                spec, self.config.sandbox_timeout_per_episode,
+            )
             exec_id = self.client.api.exec_create(
                 sandbox.id,
                 cmd=["bash", "-c", agent_cmd],

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -32,6 +32,7 @@ import hashlib
 import io
 import json
 import logging
+import math
 import queue
 import secrets
 import tarfile
@@ -174,6 +175,20 @@ def _pick_episode_timeout(spec: dict, config_default: float) -> float:
     Returning a float so the caller can pass it straight to the
     deadline arithmetic.
     """
+    pinned = spec.get("agent_timeout_s")
+    # ``pinned > 0`` already excludes NaN by Python's float-compare
+    # semantics (any comparison with NaN returns False), but spell
+    # the guard out so a future refactor of this predicate doesn't
+    # quietly drop it. A NaN that slipped through would propagate
+    # into ``time.monotonic() + NaN`` and produce a deadline no clock
+    # reading can clear — the same deadlock pattern this module
+    # already had to fix once.
+    if (
+        pinned is not None
+        and not (isinstance(pinned, float) and math.isnan(pinned))
+        and pinned > 0
+    ):
+        return float(pinned)
     return float(config_default)
 
 


### PR DESCRIPTION
## Summary

Make `_run_episode` honor the per-scenario agent timeout that
trajrl-bench's `scenario-info` payload now carries
(`agent_timeout_s`), instead of collapsing every scenario to a
single global `SANDBOX_TIMEOUT_PER_EPISODE`.

Stacks on top of #248 (threaded-drain fix). Depends on
trajrl-bench#42 being merged and a fresh sandbox-agent image
shipped so `scenario-info` returns the new field — without that,
this PR is a no-op (everyone keeps using the config default).

## Why this matters

`task.toml` already specifies per-scenario `[agent].timeout_sec`
(path-tracing and break-filter-js-from-html: 1200 s; the other
six shipped scenarios: 900 s). The validator just wasn't reading
it. So:

- **Hard scenarios are starved if the operator runs near the
  documented default.** `SANDBOX_TIMEOUT_PER_EPISODE` defaults to
  600 s in `config.py:169`, and `.env.validator.example` documents
  600 s and ships the override commented out. A production-log
  audit of 5 v0.6.11 validators (combined ≈ 2.3M τ stake) shows
  path-tracing TIMEOUTs at wall-clocks ranging 683-1324 s, and
  TAO.com pins their configured global at ≤ 675 s via a
  `vulnerable-secret` TIMEOUT at that value (see PR #248 for the
  full data). Operator config is not directly observable, but the
  observed TIMEOUT-cap pattern is consistent with all five running
  at the documented 600 s default. Whatever value an operator
  picks, the per-scenario fix gives strictly more accurate
  allocation than collapsing all eight scenarios to one number.
- **Easy scenarios hold the whole global budget hostage.** A single
  global means an operator can't tighten one scenario without
  tightening all — even though `vulnerable-secret` typically
  finishes in <100 s and `path-tracing` needs minutes.
- **Measurement reliability suffers.** Scenarios that sit close
  to the configured ceiling oscillate between completing and
  timing out across runs purely from LLM-latency jitter. We
  observed the baseline pack score `path-tracing` at 0.8 in one
  run and 0.2 (TIMEOUT at 614 s) in a re-run with identical pack
  hash and identical `epoch_seed`. Without per-scenario timeouts,
  single-run pack rankings on path-tracing are noise dominated by
  whether Hermes happened to finish under the operator's global.

After this PR each scenario gets the budget its author specified.
Concrete impact for the shipped scenario set, assuming the
documented default (operator config not directly observable):

| Scenario | `[agent] timeout_sec` | Pre-PR (default 600) | Post-PR | Δ |
|---|---|---|---|---|
| break-filter-js-from-html | 1200 | 600 | 1200 | +600 |
| cancel-async-tasks | 900 | 600 | 900 | +300 |
| db-wal-recovery | 900 | 600 | 900 | +300 |
| fix-git | 900 | 600 | 900 | +300 |
| log-summary-date-ranges | 900 | 600 | 900 | +300 |
| nginx-request-logging | 900 | 600 | 900 | +300 |
| path-tracing | 1200 | 600 | 1200 | +600 |
| vulnerable-secret | 900 | 600 | 900 | +300 |

Worst-case pack wall-time goes from `8 × 600 = 4800 s ≈ 80 min`
to `6 × 900 + 2 × 1200 = 7800 s ≈ 130 min` (under the documented
default; operators running with a higher global already pay this
or more, and benefit from the per-scenario *cap* this PR also
introduces — `vulnerable-secret` will no longer eat 1500 s on
their setup just because path-tracing might need it). Operators
should double-check their epoch window accommodates the post-PR
worst case. The global default (`SANDBOX_TIMEOUT_PER_EPISODE`)
still applies to scenarios that don't pin a value, and to older
sandbox-agent images that don't yet surface the field.

## How it's structured

1. **`964baab refactor(harness): extract _pick_episode_timeout helper`**
   Plumb `agent_timeout_s` from scenario-info into the
   `scenario_specs` dict, and extract `_pick_episode_timeout` from
   `_run_episode`. At this commit the helper returns
   `config_default` unchanged — no behavior change.

2. **`4837748 test(harness): regression for per-scenario agent timeout`**
   Six tests for the helper. Two deliberately FAIL at this commit:
   - `test_uses_scenario_pinned_timeout_when_present`
   - `test_returns_float_for_deadline_arithmetic`

   Four pass (fall-back paths — missing field, None, 0/negative
   value, NaN — already work because the helper unconditionally
   returns `config_default` at this commit; the NaN test in
   particular pins the contract so a future refactor of the
   validation predicate can't silently drop the
   implicit-via-comparison NaN guard).

3. **`81b2719 fix(harness): honor per-scenario agent_timeout_s from scenario-info`**
   Make the helper actually read `spec["agent_timeout_s"]` and
   validate it (positive, not None, not NaN). All six tests pass;
   full sandbox-harness suite is 59 passing.

4. **`3e0d8d0 chore(harness): ruff cleanup of test-file imports`**
   Drops unused `from dataclasses import dataclass, field` (F401),
   alphabetises the multi-line import block, and folds a mid-file
   `_pick_episode_timeout` import into the top-of-file block
   (I001 + E402). No test changes.

## Verification

**Mechanical (no Docker required):** check out `4837748` and run

```
pytest tests/test_sandbox_harness.py::TestPickEpisodeTimeout
```

Two of six tests fail
(`test_uses_scenario_pinned_timeout_when_present` and
`test_returns_float_for_deadline_arithmetic`). Then check out
`81b2719` and run the same command; all six pass.

**Integration:** in a local workspace with the trajrl-bench
submodule pinned to the #42 commit but trajectoryRL still on
`origin/main` (i.e. without this PR), a re-bench of the baseline
pack confirmed the "field plumbed but unread" condition:

- `scenario-info` payload carries `agent_timeout_s` for every
  shipped scenario (the field flows through trajrl-bench#42).
- `path-tracing` was nonetheless cut off at 614 s in one run —
  exactly the global `SANDBOX_TIMEOUT_PER_EPISODE=600` ceiling
  with the threaded-drain slack from #248. A second run of the
  same pack-hash + same `epoch_seed` against the same scenario
  finished cleanly and scored 0.8.
- With this PR merged, the same scenario will get its
  `task.toml`-pinned 1200 s and the cliff-induced score
  oscillation goes away.

This is the exact "field plumbed but unread" condition the PR
fixes; the integration evidence is consistent with the unit-test
contract.

## Flexibility / edge cases considered

- `agent_timeout_s` missing from spec (older sandbox-agent image)
  → fall back to global default. Test:
  `test_falls_back_to_config_default_when_missing`.
- `agent_timeout_s` is `None` (different serialisation of "unset")
  → fall back. Test:
  `test_falls_back_to_config_default_when_none`.
- `agent_timeout_s` is `0` or negative → fall back. A 0-second
  deadline burns an episode for guaranteed-zero return; almost
  certainly a misconfiguration. Test:
  `test_falls_back_to_config_default_when_zero_or_negative`.
- `agent_timeout_s` is `NaN` → fall back. Pinned explicitly so a
  future refactor of the validation predicate can't silently
  drop the implicit-via-comparison NaN guard (`x > 0` is False
  for NaN, but a later rewrite to `not (x <= 0)` would let it
  through). Test:
  `test_falls_back_to_config_default_when_nan`.
- Returned value is always a `float` so the caller can pass it
  straight into `time.monotonic() + timeout` arithmetic without
  worrying about int/float promotion. Test:
  `test_returns_float_for_deadline_arithmetic`.

## Backward compatibility

When the sandbox-agent image is older than trajrl-bench#42, the
`scenario-info` payload omits `agent_timeout_s`. The helper's
fallback covers this: `pinned is None → return config_default`,
which is identical to the pre-PR behavior. So this PR can land
ahead of a sandbox-agent rebuild and validators see a graceful
no-op until they pull a newer image.

## Test plan

- [x] `pytest tests/test_sandbox_harness.py` — 59 passing (6 new)
- [x] `ruff check --config pyproject.toml tests/test_sandbox_harness.py`
      — clean after the chore commit. (Pre-existing I001 on
      `sandbox_harness.py:27` import-block order is also on
      `origin/main` and intentionally untouched by this PR.)
- [x] Verified RED commit: 2 of 6 tests fail at `4837748`
      (`test_uses_scenario_pinned_timeout_when_present`,
      `test_returns_float_for_deadline_arithmetic`)
- [x] Integration smoke: re-bench with sandbox-agent built on
      #42 + trajectoryRL on `origin/main` confirmed
      `scenario-info` surfaces `agent_timeout_s` and harness
      ignores it (path-tracing cut off at 614 s under the 600 s
      global ceiling).
- [ ] Reviewer: re-verify RED by checking out `4837748` and running
      `pytest tests/test_sandbox_harness.py::TestPickEpisodeTimeout`
- [ ] Merge after trajrl-bench#42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
