### PR TITLE
fix(harness): kill hermes by process-name, not cmdline pattern

### DIFF
--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -730,3 +730,70 @@ class TestPickEpisodeTimeout:
         result = _pick_episode_timeout(spec, config_default=600)
         assert isinstance(result, float)
         assert result == 123.0
+
+
+# ---------------------------------------------------------------------------
+# _kill_chat_process — release blocked exec socket without killing the
+# bash wrapper that runs the in-band session export.
+# ---------------------------------------------------------------------------
+
+
+class TestKillChatProcess:
+    """The timeout handler must kill the agent's hermes chat process so
+    the docker exec_start socket releases, but must NOT kill the bash
+    wrapper that runs the in-band ``hermes sessions export`` after
+    chat returns.
+
+    The previous implementation ran ``pkill -KILL -f hermes``. The
+    ``-f`` flag matches the full command line, which catches both the
+    python ``hermes`` chat process *and* the
+    ``bash -c '...; hermes chat ...; hermes sessions export ...'``
+    wrapper that exec was registered under — because the wrapper's
+    argv contains the string "hermes" in its script body. Killing
+    the wrapper destroys the in-band export step, leaving
+    ``turns.jsonl`` empty after every timeout.
+
+    The hermes binary is a setuptools entry-point script that the
+    kernel reports with ``comm=hermes`` (verified via ``ps -eo comm``
+    inside the sandbox-agent image). Process-name match (``pkill
+    hermes`` without ``-f``) targets only that process; the wrapper's
+    ``comm`` is ``bash`` and survives. The wrapper's ``wait`` returns
+    with exit-status 137, the script continues past the kill point,
+    and the in-band export runs naturally.
+    """
+
+    def test_uses_narrow_process_name_match_not_cmdline(self):
+        """The ``-f`` flag is the bug — matches the wrapper's script
+        body which contains the string "hermes". Process-name match
+        (no ``-f``) targets only the hermes process whose ``comm`` is
+        literally "hermes"; the wrapper's ``comm`` is "bash" and is
+        spared."""
+        from unittest.mock import MagicMock
+
+        from trajectoryrl.utils.sandbox_harness import _kill_chat_process
+
+        sandbox = MagicMock()
+        _kill_chat_process(sandbox)
+
+        sandbox.exec_run.assert_called_once()
+        cmd = sandbox.exec_run.call_args[0][0]
+        assert "-f" not in cmd, (
+            f"-f flag matches by cmdline, which kills the bash wrapper "
+            f"because its argv contains 'hermes'. Got: {cmd}"
+        )
+        assert "hermes" in cmd
+        assert "-KILL" in cmd
+
+    def test_runs_as_root(self):
+        """The hermes process runs as a non-root user inside the
+        sandbox. Killing it from outside the bash wrapper requires
+        root."""
+        from unittest.mock import MagicMock
+
+        from trajectoryrl.utils.sandbox_harness import _kill_chat_process
+
+        sandbox = MagicMock()
+        _kill_chat_process(sandbox)
+
+        kwargs = sandbox.exec_run.call_args[1]
+        assert kwargs.get("user") == "root"

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -192,6 +192,45 @@ def _pick_episode_timeout(spec: dict, config_default: float) -> float:
     return float(config_default)
 
 
+def _kill_chat_process(sandbox) -> None:
+    """Kill the hermes chat process so the blocked exec_start socket
+    releases. Uses process-name match (not cmdline match) so the
+    surrounding bash wrapper survives and runs its in-band session
+    export step.
+
+    Background: ``hermes chat`` is invoked inside a bash wrapper that
+    looks like ``bash -c 'set +e; hermes chat ...; hermes sessions
+    export /workspace/turns.jsonl; exit $?'``. On timeout we want to
+    kill the python chat process so docker's exec_start unblocks and
+    the wrapper proceeds to its export step. We do NOT want to kill
+    the wrapper itself, because then the export never runs and
+    turns.jsonl ends up empty.
+
+    The previous implementation called ``pkill -KILL -f hermes``.
+    ``-f`` matches the full command line, which catches both the
+    python ``hermes`` chat process *and* the bash wrapper — the
+    wrapper's argv contains the literal string "hermes" in its
+    script body, so the pattern matches it too. The wrapper died
+    before reaching the export step on every timeout, leaving
+    ``turns.jsonl`` empty.
+
+    The hermes binary is a setuptools entry-point script whose
+    process ``comm`` is "hermes" (verified inside the sandbox-agent
+    image via ``ps -eo pid,ppid,comm``). The bash wrapper's
+    ``comm`` is "bash". ``pkill hermes`` without ``-f`` matches by
+    ``comm``, so it kills only the chat process. The wrapper's
+    ``wait`` returns with exit-status 137, the script continues past
+    the kill point, and the in-band export runs naturally.
+
+    Runs as root because the chat process is owned by the non-root
+    hermes user; pkill needs privilege to send it a signal.
+    """
+    sandbox.exec_run(
+        ["pkill", "-KILL", "hermes"],
+        user="root",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Result types
 # ---------------------------------------------------------------------------
@@ -1115,26 +1154,11 @@ class TrajectorySandboxHarness:
 
             stream = self.client.api.exec_start(exec_id, stream=True, demux=False)
 
-            def _kill_hermes() -> None:
-                # Releases the blocked exec_start socket so we can
-                # proceed to teardown instead of waiting on the
-                # finally-block's container.stop().
-                #
-                # ``-f hermes`` matches by cmdline pattern, which is
-                # intentionally broad: it kills both the ``hermes chat``
-                # python process and the ``bash -c '... hermes chat ...'``
-                # wrapper that exec was registered under. The agent user
-                # in the sandbox-agent image is the only thing in the
-                # container, so collateral on other processes is not a
-                # concern.
-                sandbox.exec_run(
-                    ["pkill", "-KILL", "-f", "hermes"],
-                    user="root",
-                )
-
             transcript_chunks, episode.timed_out = (
                 _drain_exec_stream_with_deadline(
-                    stream, timeout=timeout, on_deadline=_kill_hermes,
+                    stream,
+                    timeout=timeout,
+                    on_deadline=lambda: _kill_chat_process(sandbox),
                 )
             )
             episode.transcript = b"".join(transcript_chunks).decode(


### PR DESCRIPTION
## Summary
- Replace ``pkill -KILL -f hermes`` with ``pkill -KILL hermes`` (no ``-f``)
- Extract module-level ``_kill_chat_process`` helper so the kill pattern is unit-testable
- 2 regression tests cover the no-``-f`` contract and the root-user invariant

## Why this matters
The timeout handler kills the agent's chat process to release the blocked exec_start socket. With ``-f`` (cmdline match), the pattern catches both:

1. The python ``hermes`` chat process (correct target)
2. The ``bash -c 'set +e; hermes chat ...; hermes sessions export /workspace/turns.jsonl; exit $?'`` wrapper that exec was registered under — because the wrapper's argv contains "hermes" in its script body

Killing the wrapper destroys the in-band ``hermes sessions export`` step. Every timeout-killed episode left ``turns.jsonl`` empty (zero-byte; the writer subsequently skips it from the artifact directory entirely), making timeout-debugging impossible.

## Fix
The hermes binary is a setuptools entry-point script whose process ``comm`` is "hermes". The bash wrapper's ``comm`` is "bash". Process-name match (``pkill hermes`` without ``-f``) targets only the chat process. The wrapper's ``wait`` returns with exit-status 137, the script continues past the kill, and the in-band export runs naturally.

## Empirical confirmation
Verified inside the sandbox-agent image:

```
$ docker run --rm ghcr.io/trajectoryrl/sandbox-agent:latest bash -c '
    bash -c "hermes chat --help & wait; echo continues..." &
    sleep 0.5
    ps -eo pid,ppid,comm | grep -E "hermes|bash"
    pkill -KILL hermes
    sleep 0.5
    ps -eo pid,ppid,comm | grep -E "hermes|bash"
'

Before pkill:                          After ``pkill hermes`` (narrow):
  1     0   bash    (test driver)       1     0   bash    (test driver)
  9     1   bash    (wrapper)           9     1   bash    (wrapper)  ← survives
 11     9   hermes  (chat)              (PID 11 killed)
```

Wrapper continues past the kill point, runs export.

## Commits
Red-green TDD:
1. ``test(harness)``: 2 regression tests for ``_kill_chat_process`` — both fail with ``ImportError`` at this commit
2. ``fix(harness)``: extract helper with the narrow pattern, wire into ``_run_episode``; both tests pass

## Relationship to #254
PR #254 adds a post-mortem export to recover ``turns.jsonl`` after the in-band export was destroyed by the kill. This PR fixes the underlying cause: the kill no longer destroys the in-band export, so post-mortem recovery is no longer routinely needed.

The two PRs are complementary:
- This PR (narrow kill) → in-band export runs on the timeout path; recovers full session including messages array.
- #254 (post-mortem) → defense-in-depth for any other kill path that might still leave the export step unfinished.

They don't conflict structurally (different code paths). Reviewer can land either order.

## Test plan
- [x] ``pytest tests/test_sandbox_harness.py`` → 62 passed locally
- [x] Verified empirically in sandbox-agent image (transcript in commit body)
- [ ] Reviewer: check out commit 1, confirm 2 failures; check out commit 2, confirm all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)