### PR TITLE
fix(harness): remove superseded per-scenario images after pull

### DIFF
--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -684,9 +684,26 @@ class TrajectorySandboxHarness:
             if not scenario_image:
                 continue
             try:
+                old_id: str | None = None
+                try:
+                    old_id = self.client.images.get(scenario_image).id
+                except docker.errors.ImageNotFound:
+                    pass
                 logger.info("Pulling scenario image: %s", scenario_image)
                 self.client.images.pull(scenario_image)
                 img = self.client.images.get(scenario_image)
+                if old_id and img.id and old_id != img.id:
+                    try:
+                        self.client.images.remove(old_id)
+                        logger.info(
+                            "Removed superseded scenario image %s (%s)",
+                            scenario_image, old_id[:19],
+                        )
+                    except docker.errors.APIError as e:
+                        logger.debug(
+                            "Skip rmi superseded %s (%s): %s",
+                            scenario_image, old_id[:19], e,
+                        )
                 digests = img.attrs.get("RepoDigests", [])
                 digest = digests[0].split("@", 1)[-1] if digests else img.id
                 self.scenario_image_hashes[scenario_name] = digest


### PR DESCRIPTION
## Summary

- Per-scenario images (one repo per entry in `SANDBOX_SCENARIOS`, layered on `sandbox-agent`) were being re-pulled every eval cycle after #252, but the old image id was never removed when the channel tag re-pointed to a new manifest. With ~8 scenario repos × every-cycle pulls, untagged old layers accumulated indefinitely on validator hosts.
- Apply the same `old_id → pull → rmi(old_id)` pattern that the sandbox-agent block already uses (`sandbox_harness.py:610-639`) inside the per-scenario loop.
- `ImageNotFound` on the pre-pull lookup is a no-op (first pull). `APIError` on the post-pull remove falls back to debug log — matches the sandbox-agent block's tolerance for the case where a stopped container still references the old image.

## Test plan

- [ ] Sanity: `python -c "import trajectoryrl.utils.sandbox_harness"` (done locally)
- [ ] On a validator host, watch `docker images ghcr.io/trajectoryrl/*` after a trajrl-bench release that bumps the channel tag — the previous scenario image ids should be gone after the next eval cycle, instead of lingering as `<none>` entries.
- [ ] Confirm no warning spam on a validator that has never pulled before (i.e. first-ever pull path still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)