### PR TITLE
feat(scoring): add configure-git-webserver scenario, bump SPEC_NUMBER

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 10
+SPEC_NUMBER = 11
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -58,6 +58,7 @@ logger = logging.getLogger(__name__)
 SANDBOX_SCENARIOS: tuple[str, ...] = (
     "break-filter-js-from-html",
     "cancel-async-tasks",
+    "configure-git-webserver",
     "db-wal-recovery",
     "fix-git",
     "log-summary-date-ranges",


### PR DESCRIPTION
## Summary
- Adds the new shell-verifier scenario `configure-git-webserver` (published in trajectoryRL/trajrl-bench#46) to `SANDBOX_SCENARIOS` so every validator runs it as part of the per-pack evaluation session.
- Bumps `SPEC_NUMBER` from 10 to 11 — the scenario set changed, so old cached scores are no longer comparable. Per the comment in `config.py`: *"Bump SPEC_NUMBER whenever a change makes new scores incomparable with old ones (adding/removing scenarios, …)."*

## Dependencies
- Depends on trajectoryRL/trajrl-bench#50, which adds `configure-git-webserver` to the `scenario-images` matrix so `ghcr.io/trajectoryrl/scenario-configure-git-webserver:latest` actually exists. Land trajrl-bench#50 and cut a trajrl-bench tag first; otherwise the harness will fail to pull the scenario image at evaluation time.

## Test plan
- [ ] After trajrl-bench tag is out, run `python scripts/eval_pack.py --pack <pack.json> --no-pull` against a SKILL.md that targets shell verifiers; confirm the per-scenario summary lists `configure-git-webserver`.
- [ ] Verify `harness.sandbox_scenarios` (from `cli scenarios`) contains `configure-git-webserver` after pulling the new bench image.
- [ ] Confirm cached scores from `SPEC_NUMBER=10` are not consumed for `SPEC_NUMBER=11` aggregation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)