### PR TITLE
fix(validator): discard partial-eval score when harness aborts mid-session

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -38,7 +38,11 @@ from ..utils.sandbox_harness import TrajectorySandboxHarness
 from ..utils.github import PackFetcher
 from ..utils import config as _config_mod
 from ..utils.commitments import MinerCommitment
-from ..utils.miner_eval import evaluate_miner_s1, SKIP_PACK_VERIFY
+from ..utils.miner_eval import (
+    evaluate_miner_s1,
+    SKIP_PACK_VERIFY,
+    SKIP_EPOCH_CHANGED,
+)
 from ..utils.trajrl_api import (
     heartbeat,
     fetch_current_epoch,
@@ -1070,6 +1074,19 @@ class TrajectoryValidator:
         )
 
         eval_result = await self._evaluate_challenger(commitment, challenge_epoch_id)
+
+        # Harness aborted mid-session because the epoch had moved on.
+        # Drop the eval entirely — POSTing the partial sum would punish
+        # the miner for scenarios we never ran (server-side 409s most of
+        # these anyway, but the intent here is "no submission", not "low
+        # submission that hopefully gets rejected").
+        if eval_result and eval_result.get("skip_reason") == SKIP_EPOCH_CHANGED:
+            logger.info(
+                "Discarding eval for epoch %d: harness aborted mid-session "
+                "(epoch moved on); no score submitted",
+                challenge_epoch_id,
+            )
+            return
 
         rejected = False
         rejection_detail: Optional[str] = None

--- a/trajectoryrl/utils/miner_eval.py
+++ b/trajectoryrl/utils/miner_eval.py
@@ -43,6 +43,10 @@ SKIP_INVALID_PACK = "invalid_pack_structure"  # pack JSON parsed but root / file
 SKIP_MISSING_SKILL_MD = "missing_skill_md"
 SKIP_EMPTY_SKILL_MD = "empty_skill_md"
 SKIP_S1_EVAL_ERROR = "s1_eval_error"
+# Harness gave up on remaining scenarios because the active challenge
+# epoch had moved on. The validator discards the partial session rather
+# than POSTing a score whose missing scenarios would be counted as 0.
+SKIP_EPOCH_CHANGED = "epoch_changed_mid_eval"
 
 
 @dataclass
@@ -191,6 +195,18 @@ async def evaluate_miner_s1(
             sandbox_result=result,
             skip_reason=SKIP_S1_EVAL_ERROR,
             skip_detail=result.error,
+        )
+
+    if result.aborted_mid_session:
+        log.info(
+            "S1 evaluation aborted mid-session: epoch moved on after "
+            "%d/%d scenarios; discarding partial result",
+            len(result.scenarios), len(harness.sandbox_scenarios),
+        )
+        return MinerEvalOutcome(
+            success=False,
+            sandbox_result=result,
+            skip_reason=SKIP_EPOCH_CHANGED,
         )
 
     # Step 3: Per-episode transcript tail logging (file-only via mlog)

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -347,6 +347,11 @@ class _SessionResult:
     pack_hash: str = ""
     validator_salt: str = ""
     skill_md: str = ""
+    # True when the scenario loop broke early via the
+    # ``is_epoch_still_current`` gate. The downstream layer treats this
+    # as "discard the session" — submitting the partial sum would punish
+    # the miner for scenarios we never ran.
+    aborted_mid_session: bool = False
 
     def compute_scores(self) -> None:
         """Aggregate per-scenario correctness into the session score.
@@ -388,6 +393,10 @@ class SandboxEvaluationResult:
         self.response = ""
         self.rubric = {}
         self.error: Optional[str] = None
+        # Mirrors _SessionResult.aborted_mid_session — surfaces up to
+        # evaluate_miner_s1 so the validator can drop the partial
+        # session rather than POST a low-biased score.
+        self.aborted_mid_session: bool = session_result.aborted_mid_session
 
         self.cost_usd: Optional[float] = None
         self.token_usage: Optional[Dict[str, int]] = None
@@ -1058,6 +1067,7 @@ class TrajectorySandboxHarness:
                         session_id, pack_hash[:12], cell_index, total,
                         total - cell_index,
                     )
+                    session_result.aborted_mid_session = True
                     break
 
             episode = self._run_episode(


### PR DESCRIPTION
## Summary
- When the harness's per-scenario `is_epoch_still_current` gate breaks the loop early, the surviving `session_result` only contains the scenarios that actually ran. The old path treated that as `success=True` and POSTed the sum — silently counting the **skipped scenarios as 0** and unfairly dragging the miner's consensus score down.
- Server-side already `409`s most of these (epoch finalized by the time the late POST arrives), but a) the finalize SELECT→UPDATE race window can let one slip into `challenge_scores`, and b) the intent on the validator should be *no submission*, not "low submission that hopefully gets rejected".

## Mechanism
1. `sandbox_harness.py` — `_SessionResult` gains an `aborted_mid_session: bool` field; the `break` after `is_epoch_still_current` returns False sets it `True`. `SandboxEvaluationResult` surfaces it.
2. `miner_eval.py` — new `SKIP_EPOCH_CHANGED = "epoch_changed_mid_eval"` skip reason. After the harness call, if `result.aborted_mid_session`, return `MinerEvalOutcome(success=False, skip_reason=SKIP_EPOCH_CHANGED)` instead of letting the partial result flow into the normal success path.
3. `validator.py` `_score_challenger` — short-circuits on `skip_reason == SKIP_EPOCH_CHANGED` and returns without calling `submit_challenge_score`. Logs one info line.

## Behaviour matrix
| Case | Before | After |
|---|---|---|
| Eval completes all scenarios | Submit normal score | unchanged |
| Pack verify fails / exception | Submit `rejected=True, score=0` | unchanged |
| Harness breaks mid-session via `is_epoch_still_current` | Submit `success=True, score=Σ(completed scenarios)` ❌ unfair | Log "Discarding eval…" and skip the POST ✅ |
| Mid-epoch budget gate (eval never starts) | No submission | unchanged |

## Notes
- No `SPEC_NUMBER` bump — this only suppresses noisy/unfair submissions on the abort path; the score formula on normal completion is unchanged.
- Log uploads (`_fire_upload_eval_logs`, `_fire_upload_cycle_logs`) are skipped together with the submission on the abort path. If retaining the partial diagnostic logs is preferred, the early-`return` can be moved past the upload block.
- `docs/API.md` has unrelated uncommitted local edits that are deliberately not bundled with this PR.

## Test plan
- [ ] Watch validator logs in staging for the first time `is_epoch_still_current` returns False mid-eval — expect `Discarding eval for epoch N: harness aborted mid-session …`, no subsequent `POST /api/v2/epoch/N/score`.
- [ ] Confirm next eval-loop tick picks up the new `challenge_epoch_id` and scores it normally.
- [ ] Sanity-check on PROD `challenge_scores` for the affected epoch: validator hotkey should be absent (vs. previously a low-biased row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)