### PR TITLE
feat(scoring): add swe-bench-astropy-2 scenario, bump SPEC_NUMBER

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 11
+SPEC_NUMBER = 12
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -64,6 +64,7 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
     "log-summary-date-ranges",
     "nginx-request-logging",
     "path-tracing",
+    "swe-bench-astropy-2",
     "vulnerable-secret",
 )
 


### PR DESCRIPTION
Adds the new patch-verifier scenario published in
trajectoryRL/trajrl-bench#47 to SANDBOX_SCENARIOS so every validator
runs it as part of the per-pack evaluation session. Bumps SPEC_NUMBER
from 11 to 12 since the scenario set changed and old cached scores are
no longer comparable to new ones.

`swe-bench-astropy-2` is the suite's first true debugging scenario —
agent reads a pinned (bug-present) astropy source tree and produces a
unified-diff patch at `/app/solution.patch`. 5 sub-tests grade smoothly
for partial credit (patch-exists, patch-applies, existing-test-passes,
new-lowercase-test-passes, no-collateral-damage).

## Validator operational impact

- **Verifier wall time**: ~3-5 min per eval (astropy editable install
  dominates). Roughly 2x the next-heaviest scenario.
- **Agent wall time**: ~5-10 min per eval (multi-file source navigation
  vs. one-shot setup script).
- **Per-eval cost**: ~\$0.09 (Qwen 35B reads more tokens than for a
  config task).
- **Median eval cycle**: ~50 min → ~60 min for the 10-scenario set.
  Right at the epoch budget; cushion will shrink as we add more.

## Coordination

Land after trajectoryRL/trajrl-bench#47 merges and the bench image is
republished — validators need the new scenario directory to be present
in the pulled sandbox image before the SPEC=12 cutover, otherwise
scoring sessions abort on missing-scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)