### PR TITLE
feat(validator): parallelize scenario eval within a pack (PARALLEL_SCENARIO_EVALS)

### DIFF
--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -1419,10 +1419,10 @@ class TestParallelScenarioOrchestrator:
 
         return h
 
-    def test_default_config_is_three(self):
+    def test_default_config_is_two(self):
         # Bumping this default is a behavior change for every operator;
         # surface it in a test so a casual edit can't slip through.
-        assert ValidatorConfig.parallel_scenario_evals == 3
+        assert ValidatorConfig.parallel_scenario_evals == 2
 
     def test_env_var_clamps_to_at_least_one(self, monkeypatch, tmp_path):
         # PARALLEL_SCENARIO_EVALS=0 (or negative) must clamp up — a

--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -1344,3 +1344,345 @@ class TestTimedOutRecoveryE2E:
             "content didn't make it through write_artifacts"
         )
         assert turns_file.read_text() == recovered
+
+
+# ---------------------------------------------------------------------------
+# Tests: parallel scenario orchestrator (PARALLEL_SCENARIO_EVALS)
+#
+# These pin down the contract for the parallel scenario dispatcher inside
+# ``TrajectorySandboxHarness._run_eval_sync``. The dispatcher must:
+#   - run up to ``parallel_scenario_evals`` scenarios concurrently
+#   - preserve the per-cell-index ordering of ``session_result.episodes``
+#     (downstream score aggregation is order-invariant, but
+#      ``scenario_qualities`` and the validator's live page assume the list
+#      is stable)
+#   - re-check the epoch-current gate before each submit + after each
+#     completion, and kill in-flight containers on abort
+# ---------------------------------------------------------------------------
+
+class TestParallelScenarioOrchestrator:
+    """Verifies fan-out, ordering, and mid-session kill semantics.
+
+    Mocks ``_run_episode`` with a timed stub so we can observe overlap
+    and ordering deterministically without touching Docker.
+    """
+
+    @staticmethod
+    def _setup_harness(
+        monkeypatch,
+        tmp_path,
+        parallelism: int,
+        scenarios: tuple[str, ...] = (
+            "scenario-a", "scenario-b", "scenario-c",
+            "scenario-d", "scenario-e",
+        ),
+    ) -> TrajectorySandboxHarness:
+        """Build a harness with the scenario set + image lookup mocked."""
+        from trajectoryrl.utils import sandbox_harness as sh
+
+        cfg = ValidatorConfig(
+            pack_cache_dir=tmp_path / "packs",
+            log_dir=tmp_path / "logs",
+            eval_state_path=tmp_path / "eval_state.json",
+            winner_state_path=tmp_path / "winner_state.json",
+            pack_first_seen_path=tmp_path / "pack_first_seen.json",
+            active_set_dir=tmp_path / "active_sets",
+            parallel_scenario_evals=parallelism,
+        )
+        h = TrajectorySandboxHarness(cfg)
+
+        # Pin the scenario set for this test — the production tuple has
+        # 10 real scenarios, but we only need 3–5 to exercise the
+        # orchestrator.
+        monkeypatch.setattr(sh, "SANDBOX_SCENARIOS", scenarios)
+
+        # Image refresh + scenario-info loading + image ref are not
+        # exercised by the parallel loop itself; short-circuit them.
+        monkeypatch.setattr(h, "_pull_sync", lambda: None)
+
+        def fake_load(name):
+            h._scenario_info = {
+                "name": name,
+                "image_repo": f"ghcr.io/test/{name}",
+                "instruction_md": f"# {name}\n",
+                "agent_output_path": "/app/out.txt",
+                "verifier_timeout_s": 60,
+                "agent_timeout_s": 60,
+                "tests_files_b64": {"test.sh": "echo ok"},
+            }
+            return h._scenario_info
+
+        monkeypatch.setattr(h, "_load_scenario_info", fake_load)
+        monkeypatch.setattr(
+            h, "_scenario_image_ref", lambda: "ghcr.io/test/img:latest",
+        )
+
+        return h
+
+    def test_default_config_is_three(self):
+        # Bumping this default is a behavior change for every operator;
+        # surface it in a test so a casual edit can't slip through.
+        assert ValidatorConfig.parallel_scenario_evals == 3
+
+    def test_env_var_clamps_to_at_least_one(self, monkeypatch, tmp_path):
+        # PARALLEL_SCENARIO_EVALS=0 (or negative) must clamp up — a
+        # bare ThreadPoolExecutor refuses max_workers<1.
+        monkeypatch.setenv("PARALLEL_SCENARIO_EVALS", "0")
+        # ``from_env`` reads .env files; pin to an empty file so the
+        # env var is the only source of truth in this test.
+        env_file = tmp_path / "empty.env"
+        env_file.write_text("")
+        cfg = ValidatorConfig.from_env(dotenv_path=env_file)
+        assert cfg.parallel_scenario_evals == 1
+
+    def test_sequential_when_parallelism_one(self, monkeypatch, tmp_path):
+        """With parallelism=1, no two episodes are in flight at the
+        same instant — the dispatcher reproduces the pre-PR sequential
+        behavior."""
+        scenarios = ("s0", "s1", "s2")
+        h = self._setup_harness(
+            monkeypatch, tmp_path, parallelism=1, scenarios=scenarios,
+        )
+
+        active = 0
+        active_lock = threading.Lock()
+        max_observed = 0
+
+        def fake_run_episode(*, session_id, episode_index, skill_md, spec,
+                             on_chat_start=None, on_chat_end=None,
+                             on_container_started=None,
+                             on_container_finished=None):
+            nonlocal active, max_observed
+            with active_lock:
+                active += 1
+                max_observed = max(max_observed, active)
+            time.sleep(0.02)
+            with active_lock:
+                active -= 1
+            return _EpisodeResult(
+                episode_index=episode_index, scenario=spec["name"],
+                quality=0.5,
+            )
+
+        monkeypatch.setattr(h, "_run_episode", fake_run_episode)
+        result = h._run_eval_sync(
+            skill_md="x", epoch_seed=0, salt="s", pack_hash="abc",
+        )
+
+        assert max_observed == 1
+        assert [e.scenario for e in result.episodes] == list(scenarios)
+
+    def test_peak_concurrency_bounded_by_parallelism(
+        self, monkeypatch, tmp_path,
+    ):
+        """With parallelism=N, at most N episodes are ever in flight
+        simultaneously."""
+        scenarios = ("s0", "s1", "s2", "s3", "s4")
+        h = self._setup_harness(
+            monkeypatch, tmp_path, parallelism=3, scenarios=scenarios,
+        )
+
+        active = 0
+        active_lock = threading.Lock()
+        max_observed = 0
+        start_barrier = threading.Barrier(3, timeout=5.0)
+
+        def fake_run_episode(*, session_id, episode_index, skill_md, spec,
+                             on_chat_start=None, on_chat_end=None,
+                             on_container_started=None,
+                             on_container_finished=None):
+            nonlocal active, max_observed
+            with active_lock:
+                active += 1
+                max_observed = max(max_observed, active)
+            # The first three to enter sync up via the barrier so we
+            # can prove 3 truly run concurrently (rather than "3 over
+            # the lifetime of the loop"). Later submits don't wait
+            # because the barrier has already broken.
+            try:
+                start_barrier.wait()
+            except threading.BrokenBarrierError:
+                pass
+            time.sleep(0.02)
+            with active_lock:
+                active -= 1
+            return _EpisodeResult(
+                episode_index=episode_index, scenario=spec["name"],
+                quality=0.4,
+            )
+
+        monkeypatch.setattr(h, "_run_episode", fake_run_episode)
+        result = h._run_eval_sync(
+            skill_md="x", epoch_seed=0, salt="s", pack_hash="abc",
+        )
+
+        # Concurrency cap is exactly 3, never exceeded.
+        assert max_observed == 3
+        # Ordering is still stable by cell_index, not completion order.
+        assert [e.scenario for e in result.episodes] == list(scenarios)
+
+    def test_preserves_cell_index_order_when_completions_race(
+        self, monkeypatch, tmp_path,
+    ):
+        """Stubs that complete in reverse order must still produce
+        ``session_result.episodes`` sorted by cell_index."""
+        scenarios = ("s0", "s1", "s2", "s3")
+        h = self._setup_harness(
+            monkeypatch, tmp_path, parallelism=4, scenarios=scenarios,
+        )
+
+        def fake_run_episode(*, session_id, episode_index, skill_md, spec,
+                             on_chat_start=None, on_chat_end=None,
+                             on_container_started=None,
+                             on_container_finished=None):
+            # Lower indices sleep longer → finish in reverse order.
+            time.sleep(0.05 * (len(scenarios) - episode_index))
+            return _EpisodeResult(
+                episode_index=episode_index, scenario=spec["name"],
+                quality=episode_index / 10.0,
+            )
+
+        monkeypatch.setattr(h, "_run_episode", fake_run_episode)
+        result = h._run_eval_sync(
+            skill_md="x", epoch_seed=0, salt="s", pack_hash="abc",
+        )
+
+        assert [e.scenario for e in result.episodes] == list(scenarios)
+        assert [e.episode_index for e in result.episodes] == [0, 1, 2, 3]
+
+    def test_aborts_and_kills_in_flight_when_epoch_changes(
+        self, monkeypatch, tmp_path,
+    ):
+        """When ``is_epoch_still_current`` flips to False mid-session,
+        the orchestrator stops dispatching new scenarios AND calls
+        ``container.kill()`` on each in-flight container so the workers
+        unwind quickly."""
+        from unittest.mock import MagicMock
+
+        scenarios = ("s0", "s1", "s2", "s3", "s4", "s5")
+        h = self._setup_harness(
+            monkeypatch, tmp_path, parallelism=3, scenarios=scenarios,
+        )
+
+        completed_count = 0
+        completed_lock = threading.Lock()
+        killed_containers: list[MagicMock] = []
+        killed_lock = threading.Lock()
+
+        def fake_is_current(pack_hash: str) -> bool:
+            # First scenario gate is skipped (cell_index==0). After
+            # at least one episode has completed, simulate the
+            # validator's challenge_epoch advancing.
+            with completed_lock:
+                return completed_count < 1
+
+        def fake_run_episode(*, session_id, episode_index, skill_md, spec,
+                             on_chat_start=None, on_chat_end=None,
+                             on_container_started=None,
+                             on_container_finished=None):
+            nonlocal completed_count
+
+            # Each scenario registers a unique mock "container" with
+            # the orchestrator so we can observe kill() calls.
+            fake_container = MagicMock(name=f"sandbox-{spec['name']}")
+
+            def _on_kill(*a, **kw):
+                with killed_lock:
+                    killed_containers.append(fake_container)
+
+            fake_container.kill.side_effect = _on_kill
+
+            if on_container_started is not None:
+                on_container_started(fake_container)
+
+            # Park here for a long time unless killed. ``kill()`` fires
+            # our side_effect synchronously, which we use as the wake
+            # signal via a dedicated event.
+            wake = threading.Event()
+
+            def _signal_wake(*a, **kw):
+                wake.set()
+
+            fake_container.kill.side_effect = lambda *a, **kw: (
+                _on_kill(), _signal_wake(),
+            )
+
+            # ``s0`` completes naturally to drive the epoch flip; the
+            # others wait to be killed or until a generous deadline.
+            if episode_index == 0:
+                time.sleep(0.02)
+            else:
+                wake.wait(timeout=3.0)
+
+            with completed_lock:
+                completed_count += 1
+            if on_container_finished is not None:
+                on_container_finished()
+            return _EpisodeResult(
+                episode_index=episode_index, scenario=spec["name"],
+                quality=0.0,
+                error="killed" if episode_index > 0 else None,
+            )
+
+        monkeypatch.setattr(h, "_run_episode", fake_run_episode)
+        result = h._run_eval_sync(
+            skill_md="x", epoch_seed=0, salt="s", pack_hash="abc",
+            is_epoch_still_current=fake_is_current,
+        )
+
+        # Aborted flag flipped.
+        assert result.aborted_mid_session is True
+        # The two scenarios that were in flight alongside s0 (s1, s2)
+        # received a kill signal. s3+ were never submitted.
+        with killed_lock:
+            kill_count = len(killed_containers)
+        assert kill_count >= 1, (
+            "expected the orchestrator to kill at least one in-flight "
+            "container after the epoch changed; recorded kills: "
+            f"{kill_count}"
+        )
+        # No scenario past the initial parallelism window should have
+        # been submitted — i.e. s3, s4, s5 never produced an episode.
+        scenarios_run = {e.scenario for e in result.episodes}
+        assert "s3" not in scenarios_run
+        assert "s4" not in scenarios_run
+        assert "s5" not in scenarios_run
+
+    def test_final_score_matches_sequential_baseline(
+        self, monkeypatch, tmp_path,
+    ):
+        """compute_scores() output is order-invariant: parallelism=1
+        and parallelism=4 produce the same final_score when scenarios
+        return identical qualities."""
+        scenarios = ("s0", "s1", "s2", "s3")
+
+        def _run_with(parallelism: int) -> float:
+            h = self._setup_harness(
+                monkeypatch, tmp_path, parallelism=parallelism,
+                scenarios=scenarios,
+            )
+
+            def fake_run_episode(*, session_id, episode_index, skill_md, spec,
+                                 on_chat_start=None, on_chat_end=None,
+                                 on_container_started=None,
+                                 on_container_finished=None):
+                # Quality depends on scenario name, not on completion order.
+                quality = {
+                    "s0": 0.25, "s1": 0.5, "s2": 0.75, "s3": 1.0,
+                }[spec["name"]]
+                time.sleep(0.005)
+                return _EpisodeResult(
+                    episode_index=episode_index, scenario=spec["name"],
+                    quality=quality,
+                )
+
+            monkeypatch.setattr(h, "_run_episode", fake_run_episode)
+            result = h._run_eval_sync(
+                skill_md="x", epoch_seed=0, salt="s", pack_hash="abc",
+            )
+            return result.final_score
+
+        seq_score = _run_with(1)
+        par_score = _run_with(4)
+        assert abs(par_score - seq_score) < 1e-9
+        assert abs(seq_score - (0.25 + 0.5 + 0.75 + 1.0)) < 1e-9

--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -1632,13 +1632,15 @@ class TestParallelScenarioOrchestrator:
 
         # Aborted flag flipped.
         assert result.aborted_mid_session is True
-        # The two scenarios that were in flight alongside s0 (s1, s2)
-        # received a kill signal. s3+ were never submitted.
+        # Both scenarios in flight alongside s0 (s1, s2) must receive
+        # a kill signal — a single-kill regression in the fan-out
+        # loop would only stop one of them. ``== 2`` catches that;
+        # ``>= 1`` would silently allow it.
         with killed_lock:
             kill_count = len(killed_containers)
-        assert kill_count >= 1, (
-            "expected the orchestrator to kill at least one in-flight "
-            "container after the epoch changed; recorded kills: "
+        assert kill_count == 2, (
+            "expected exactly the two in-flight containers (s1, s2) "
+            "to be killed after the epoch changed; recorded kills: "
             f"{kill_count}"
         )
         # No scenario past the initial parallelism window should have

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -171,6 +171,17 @@ class ValidatorConfig:
     image_channel: str = DEFAULT_IMAGE_CHANNEL
     sandbox_image: str = ""
     sandbox_timeout_per_episode: int = 600  # 10 min per scenario cell
+    # Number of scenarios to evaluate concurrently within a single
+    # pack's eval session. Each parallel slot spins up its own
+    # scenario container (mem_limit=4g, cpu_quota=2cpu) and its own
+    # hermes chat (one concurrent LLM stream). Default 3 ≈ 12 GB RAM
+    # + 6 CPU + 3 concurrent LLM requests at peak — sized for a
+    # typical validator host. Set ``PARALLEL_SCENARIO_EVALS=1`` to
+    # reproduce the pre-PR sequential behavior, or raise it on
+    # bigger boxes. Clamped to >=1 at load time. The on-chain submit
+    # path is unaffected — scenarios still produce the same per-name
+    # quality dict, just in a different completion order.
+    parallel_scenario_evals: int = 3
     # Scenarios + episodes-per-scenario are not configurable on purpose:
     # every validator runs the same set so scores are comparable across
     # validators / windows / SPEC_NUMBER bumps. To change the set, add a
@@ -279,6 +290,9 @@ class ValidatorConfig:
             # can still pass sandbox_image directly to bypass it.
             image_channel=os.getenv("IMAGE_CHANNEL", DEFAULT_IMAGE_CHANNEL),
             sandbox_timeout_per_episode=int(os.getenv("SANDBOX_TIMEOUT_PER_EPISODE", "600")),
+            parallel_scenario_evals=max(
+                1, int(os.getenv("PARALLEL_SCENARIO_EVALS", "3"))
+            ),
             # --- Startup aggregation ---
             aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "1") == "1",
             full_cycle_on_startup=os.getenv("FULL_CYCLE_ON_STARTUP", "0") == "1",

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -174,14 +174,15 @@ class ValidatorConfig:
     # Number of scenarios to evaluate concurrently within a single
     # pack's eval session. Each parallel slot spins up its own
     # scenario container (mem_limit=4g, cpu_quota=2cpu) and its own
-    # hermes chat (one concurrent LLM stream). Default 3 ≈ 12 GB RAM
-    # + 6 CPU + 3 concurrent LLM requests at peak — sized for a
-    # typical validator host. Set ``PARALLEL_SCENARIO_EVALS=1`` to
-    # reproduce the pre-PR sequential behavior, or raise it on
-    # bigger boxes. Clamped to >=1 at load time. The on-chain submit
-    # path is unaffected — scenarios still produce the same per-name
-    # quality dict, just in a different completion order.
-    parallel_scenario_evals: int = 3
+    # hermes chat (one concurrent LLM stream). Default 2 ≈ 8 GB RAM
+    # + 4 CPU + 2 concurrent LLM requests at peak — conservative
+    # sizing that fits a typical validator host with room to spare.
+    # Set ``PARALLEL_SCENARIO_EVALS=1`` to reproduce the pre-PR
+    # sequential behavior, or raise it on bigger boxes. Clamped to
+    # >=1 at load time. The on-chain submit path is unaffected —
+    # scenarios still produce the same per-name quality dict, just
+    # in a different completion order.
+    parallel_scenario_evals: int = 2
     # Scenarios + episodes-per-scenario are not configurable on purpose:
     # every validator runs the same set so scores are comparable across
     # validators / windows / SPEC_NUMBER bumps. To change the set, add a
@@ -291,7 +292,7 @@ class ValidatorConfig:
             image_channel=os.getenv("IMAGE_CHANNEL", DEFAULT_IMAGE_CHANNEL),
             sandbox_timeout_per_episode=int(os.getenv("SANDBOX_TIMEOUT_PER_EPISODE", "600")),
             parallel_scenario_evals=max(
-                1, int(os.getenv("PARALLEL_SCENARIO_EVALS", "3"))
+                1, int(os.getenv("PARALLEL_SCENARIO_EVALS", "2"))
             ),
             # --- Startup aggregation ---
             aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "1") == "1",

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -1141,8 +1141,16 @@ class TrajectorySandboxHarness:
                 return True
 
         def _kill_in_flight() -> None:
+            # Clear under the lock so a repeat invocation (the abort
+            # path is checked at both branches of the while-loop and
+            # would otherwise double-fire ``docker kill`` on the same
+            # container) is a no-op. The worker's
+            # ``on_container_finished`` callback uses ``pop(default=None)``
+            # so removing entries here doesn't race with worker
+            # cleanup.
             with in_flight_lock:
                 snapshot = list(in_flight.items())
+                in_flight.clear()
             for cell_index, sb in snapshot:
                 try:
                     sb.kill()
@@ -1298,6 +1306,22 @@ class TrajectorySandboxHarness:
         # code's output. Aborted-and-never-submitted scenarios are
         # simply absent from ``results``, mirroring the pre-PR
         # ``break``-out-of-loop behavior.
+        #
+        # Shape note for the parallel abort path: scenarios that were
+        # *in flight* when the epoch flipped land in ``results`` with
+        # ``chat_exit != 0`` (their containers were ``docker kill``-ed
+        # mid-exec). The pre-PR sequential code never had anything
+        # in-flight at the gate, so those entries didn't exist. This
+        # is fine in practice because ``miner_eval.evaluate_miner_s1``
+        # short-circuits on ``aborted_mid_session=True`` *before* it
+        # reads ``session_result.episodes`` for provider-failure
+        # detection or score submission (``miner_eval.py``: the
+        # ``aborted_mid_session`` branch returns ``SKIP_EPOCH_CHANGED``
+        # ahead of the ``_looks_like_provider_failure`` check). Any
+        # future consumer that reads ``episodes`` without first
+        # honoring ``aborted_mid_session`` must filter for
+        # ``chat_exit == 0`` (or ``error is None``) to recover the
+        # sequential shape.
         for cell_index in sorted(results):
             session_result.episodes.append(results[cell_index])
 

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -38,6 +38,7 @@ import secrets
 import tarfile
 import threading
 import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -1106,61 +1107,199 @@ class TrajectorySandboxHarness:
         )
 
         total = len(scenario_specs)
-        for cell_index, spec in enumerate(scenario_specs):
-            # Pre-scenario epoch-current check. Skip on the first
-            # scenario — the session-start gate in validator.py already
-            # verified the pack was current when this session was
-            # picked up. For scenarios 2..N, the epoch may have ended
-            # while we were grinding through earlier scenarios; in that
-            # case the final submission will 409, and we should bail
-            # immediately to free compute for the new challenger.
-            if cell_index > 0 and is_epoch_still_current is not None:
+        # PARALLEL_SCENARIO_EVALS knob: run up to N scenarios
+        # concurrently inside one session. =1 reproduces the old
+        # sequential behavior. Bounded by ``total`` so we don't
+        # allocate idle worker threads when the scenario set is small.
+        parallelism = max(1, int(self.config.parallel_scenario_evals))
+        if total > 0:
+            parallelism = min(parallelism, total)
+        logger.info(
+            "[%s] dispatching %d scenarios with parallelism=%d",
+            session_id, total, parallelism,
+        )
+
+        results: dict[int, _EpisodeResult] = {}
+        in_flight: dict[int, Container] = {}
+        in_flight_lock = threading.Lock()
+        abort_event = threading.Event()
+
+        def _check_still_current() -> bool:
+            """Epoch-current gate. True means keep going; False means
+            stop dispatching and kill in-flight."""
+            if is_epoch_still_current is None:
+                return True
+            try:
+                return bool(is_epoch_still_current(pack_hash))
+            except Exception as e:
+                # Transient API failure: assume current to avoid
+                # false-aborts on a momentary 5xx / timeout.
+                logger.debug(
+                    "is_epoch_still_current callback failed: %s "
+                    "(assuming still current)", e,
+                )
+                return True
+
+        def _kill_in_flight() -> None:
+            with in_flight_lock:
+                snapshot = list(in_flight.items())
+            for cell_index, sb in snapshot:
                 try:
-                    still_current = is_epoch_still_current(pack_hash)
-                except Exception as e:
-                    # Transient API failure: assume current to avoid
-                    # false-aborts on a momentary 5xx / timeout.
-                    logger.debug(
-                        "is_epoch_still_current callback failed: %s "
-                        "(assuming still current)", e,
-                    )
-                    still_current = True
-                if not still_current:
+                    sb.kill()
                     logger.info(
-                        "[%s] pack %s no longer the current challenger "
-                        "after %d/%d scenarios; aborting remaining %d "
-                        "scenarios to catch up to new epoch",
-                        session_id, pack_hash[:12], cell_index, total,
-                        total - cell_index,
+                        "[%s] killed scenario %s (cell %d) — epoch moved on",
+                        session_id,
+                        scenario_specs[cell_index]["name"],
+                        cell_index,
                     )
-                    session_result.aborted_mid_session = True
+                except Exception as e:
+                    logger.debug(
+                        "[%s] sandbox.kill() failed for cell %d: %s",
+                        session_id, cell_index, e,
+                    )
+
+        def _make_started_cb(
+            cell_index: int,
+        ) -> Callable[[Container], None]:
+            def _cb(sandbox: Container) -> None:
+                with in_flight_lock:
+                    in_flight[cell_index] = sandbox
+                # Race: abort_event flipped after submit but before
+                # the worker registered its container. Kill now so
+                # we don't waste a hermes roundtrip.
+                if abort_event.is_set():
+                    try:
+                        sandbox.kill()
+                    except Exception:
+                        pass
+            return _cb
+
+        def _make_finished_cb(cell_index: int) -> Callable[[], None]:
+            def _cb() -> None:
+                with in_flight_lock:
+                    in_flight.pop(cell_index, None)
+            return _cb
+
+        with ThreadPoolExecutor(
+            max_workers=parallelism,
+            thread_name_prefix=f"sandbox-eval-{session_id}",
+        ) as pool:
+            futures: dict[Future, int] = {}
+            submitted = 0
+            while submitted < total or futures:
+                # Top up the pool, respecting the epoch-current gate.
+                # The gate is consulted before every scenario submit
+                # *after* the first — the first scenario was already
+                # gated by validator.py's session-start check.
+                while (
+                    submitted < total
+                    and len(futures) < parallelism
+                    and not abort_event.is_set()
+                ):
+                    cell_index = submitted
+                    if cell_index > 0 and not _check_still_current():
+                        logger.info(
+                            "[%s] pack %s no longer the current "
+                            "challenger after %d/%d scenarios "
+                            "submitted; aborting remaining %d and "
+                            "killing in-flight to catch up to new "
+                            "epoch",
+                            session_id, pack_hash[:12],
+                            cell_index, total, total - cell_index,
+                        )
+                        session_result.aborted_mid_session = True
+                        abort_event.set()
+                        break
+
+                    spec = scenario_specs[cell_index]
+                    fut = pool.submit(
+                        self._run_episode,
+                        session_id=session_id,
+                        episode_index=cell_index,
+                        skill_md=skill_md,
+                        spec=spec,
+                        on_chat_start=(
+                            (lambda sc=spec["name"], idx=cell_index, tot=total:
+                                on_episode_start(sc, idx, tot))
+                            if on_episode_start is not None else None
+                        ),
+                        on_chat_end=(
+                            (lambda sc=spec["name"], idx=cell_index, tot=total:
+                                on_episode_verifying(sc, idx, tot))
+                            if on_episode_verifying is not None else None
+                        ),
+                        on_container_started=_make_started_cb(cell_index),
+                        on_container_finished=_make_finished_cb(cell_index),
+                    )
+                    futures[fut] = cell_index
+                    submitted += 1
+
+                if abort_event.is_set():
+                    _kill_in_flight()
+
+                if not futures:
                     break
 
-            episode = self._run_episode(
-                session_id=session_id,
-                episode_index=cell_index,
-                skill_md=skill_md,
-                spec=spec,
-                on_chat_start=(
-                    (lambda sc=spec["name"], idx=cell_index, tot=total:
-                        on_episode_start(sc, idx, tot))
-                    if on_episode_start is not None else None
-                ),
-                on_chat_end=(
-                    (lambda sc=spec["name"], idx=cell_index, tot=total:
-                        on_episode_verifying(sc, idx, tot))
-                    if on_episode_verifying is not None else None
-                ),
-            )
-            session_result.episodes.append(episode)
-            if on_episode_done is not None:
-                try:
-                    on_episode_done(episode, cell_index, total)
-                except Exception as e:
-                    logger.warning(
-                        "on_episode_done callback failed for %s: %s",
-                        episode.scenario, e,
+                done, _ = wait(
+                    list(futures.keys()), return_when=FIRST_COMPLETED,
+                )
+                for fut in done:
+                    cell_index = futures.pop(fut)
+                    try:
+                        episode = fut.result()
+                    except Exception as e:
+                        # ``_run_episode`` catches its own exceptions
+                        # and writes them to ``episode.error``. This
+                        # is a defensive backstop for unexpected
+                        # executor-side failures (e.g. the worker
+                        # thread itself crashed before returning).
+                        logger.error(
+                            "[%s] episode cell %d crashed in worker: %s",
+                            session_id, cell_index, e, exc_info=True,
+                        )
+                        episode = _EpisodeResult(
+                            episode_index=cell_index,
+                            scenario=scenario_specs[cell_index]["name"],
+                        )
+                        episode.error = f"executor exception: {e}"
+                    results[cell_index] = episode
+                    if on_episode_done is not None:
+                        try:
+                            on_episode_done(episode, cell_index, total)
+                        except Exception as e:
+                            logger.warning(
+                                "on_episode_done callback failed for %s: %s",
+                                episode.scenario, e,
+                            )
+
+                # After completing at least one episode, re-check the
+                # epoch gate so a stale-epoch pack doesn't keep
+                # launching scenarios. (The inner submit loop also
+                # re-checks per-submit; this catches the case where
+                # the gate flipped while we were waiting on a future
+                # to complete.)
+                if (
+                    submitted < total
+                    and not abort_event.is_set()
+                    and not _check_still_current()
+                ):
+                    logger.info(
+                        "[%s] pack %s no longer the current challenger "
+                        "after %d/%d scenarios completed; aborting "
+                        "remaining and killing in-flight to catch up "
+                        "to new epoch",
+                        session_id, pack_hash[:12], len(results), total,
                     )
+                    session_result.aborted_mid_session = True
+                    abort_event.set()
+                    _kill_in_flight()
+
+        # Stable-order append by cell_index — matches the sequential
+        # code's output. Aborted-and-never-submitted scenarios are
+        # simply absent from ``results``, mirroring the pre-PR
+        # ``break``-out-of-loop behavior.
+        for cell_index in sorted(results):
+            session_result.episodes.append(results[cell_index])
 
         session_result.compute_scores()
         return session_result
@@ -1173,6 +1312,8 @@ class TrajectorySandboxHarness:
         spec: dict,
         on_chat_start: Optional[Callable[[], None]] = None,
         on_chat_end: Optional[Callable[[], None]] = None,
+        on_container_started: Optional[Callable[[Container], None]] = None,
+        on_container_finished: Optional[Callable[[], None]] = None,
     ) -> _EpisodeResult:
         """Run one cell: spin up the scenario container, exec hermes,
         extract output, run verifier, tear down.
@@ -1249,6 +1390,19 @@ class TrajectorySandboxHarness:
                 time.sleep(0.5 + min(attempt * 0.2, 1.5))
             else:
                 raise RuntimeError("Sandbox container failed to start")
+
+            # Register the in-flight container handle with the
+            # orchestrator so it can kill it if the epoch moves on
+            # mid-session. Best-effort — exception in the callback
+            # must not block the episode.
+            if on_container_started is not None:
+                try:
+                    on_container_started(sandbox)
+                except Exception as e:
+                    logger.warning(
+                        "[%s] %s on_container_started callback failed: %s",
+                        session_id, scenario, e,
+                    )
 
             # Drop SKILL.md + INSTRUCTION.md into /workspace.
             _put_file(sandbox, "/workspace/SKILL.md", skill_md)
@@ -1429,6 +1583,14 @@ class TrajectorySandboxHarness:
                     sandbox.remove(force=True, v=True)
                 except Exception:
                     pass
+            if on_container_finished is not None:
+                try:
+                    on_container_finished()
+                except Exception as e:
+                    logger.warning(
+                        "[%s] %s on_container_finished callback failed: %s",
+                        session_id, scenario, e,
+                    )
 
         episode.duration_s = time.time() - t0
         return episode


### PR DESCRIPTION
## Summary

- New `PARALLEL_SCENARIO_EVALS` env-var knob (default `2`) controls how many scenarios run concurrently inside one pack's eval session. `=1` reproduces the pre-PR sequential behavior.
- The submit / signing / on-chain path is untouched — only the per-scenario fan-out inside `TrajectorySandboxHarness._run_eval_sync` changes.
- When `is_epoch_still_current` flips to False mid-session, the orchestrator stops dispatching new scenarios AND `docker kill`s the in-flight scenario containers so compute is freed for the new challenger immediately.

## Why

Today the validator runs the 10 scenarios for a challenger pack sequentially (~25–40 min per pack). The eval pipeline is single-challenger-per-epoch under v6, so the parallelizable axis worth attacking is scenarios within one pack. Each scenario already runs in its own fresh container with its own hermes process and no shared state, so the fan-out is mechanically simple.

Default of `2` (~8 GB RAM + 4 CPU + 2 concurrent LLM streams at peak) is sized for a typical validator host and gives ~2× speedup while leaving headroom. Operators on larger boxes can raise it (`3`–`4` for the hosts with 16+ GB and 8+ cores); constrained operators can drop to `1`.

## Design notes

- Bounded `ThreadPoolExecutor` inside `_run_eval_sync`. Workers run the existing synchronous `_run_episode` body unchanged.
- Episode results are collected by `cell_index` and appended to `session_result.episodes` in stable order, so `compute_scores()` / `scenario_qualities` output matches the sequential path byte-for-byte given identical per-scenario outputs.
- `_run_episode` gains two optional callbacks (`on_container_started`, `on_container_finished`) so the orchestrator can track in-flight container handles and kill them on epoch change.
- `_looks_like_provider_failure` is unchanged — it aggregates terminal state across `_SessionResult.episodes` post-loop and is concurrency-agnostic.
- No `SPEC_NUMBER` bump: execution-strategy-only change. Given identical inputs the scenario quality dict is the same; only completion order shifts.

## Test plan

- [x] `pytest tests/test_sandbox_harness.py` — 91 passed including 7 new tests in `TestParallelScenarioOrchestrator`:
  - default config field present + clamped to `>=1` from env
  - `parallelism=1` reproduces sequential (peak concurrency observed = 1)
  - `parallelism=3` caps peak concurrency at 3 (verified via barrier + counter)
  - in-flight kill on abort is idempotent (double-fire of `_kill_in_flight()` no-ops on the second pass) and tightly asserted (`kill_count == 2` when exactly two scenarios were in flight at the gate flip)
  - reverse-finishing-order stubs still produce `cell_index`-ordered `episodes`
  - mid-session `is_epoch_still_current=False` → `aborted_mid_session=True`, in-flight Mock containers receive `.kill()`, scenarios past the parallelism window never submitted
  - `final_score` identical between `parallelism=1` and `parallelism=4`
- [x] `pytest tests/test_miner_eval.py` — 19 passed, no regressions
- [ ] Manual smoke on aliyun box with a known-good pack hash (operator step before rolling out to mainnet validator)
- [ ] Document the resource multiplier (4 GB × N RAM, 2 CPU × N, N concurrent LLM streams) in `VALIDATOR_OPERATIONS.md` (follow-up)

Plan file: `/root/.claude/plans/feature-parellel-eval-validator-eval-mi-twinkling-penguin.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
