### PR TITLE
feat(scoring): SPEC=13, rotate scenario set (drop break-filter, add largest-eigenval + write-compressor)

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 12
+SPEC_NUMBER = 13
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -57,16 +57,17 @@ logger = logging.getLogger(__name__)
 # bumps. Adding or removing a scenario must come with a SPEC_NUMBER bump
 # so cached scores invalidate. Sorted alphabetically for stability.
 SANDBOX_SCENARIOS: tuple[str, ...] = (
-    "break-filter-js-from-html",
     "cancel-async-tasks",
     "configure-git-webserver",
     "db-wal-recovery",
     "fix-git",
+    "largest-eigenval",
     "log-summary-date-ranges",
     "nginx-request-logging",
     "path-tracing",
     "swe-bench-astropy-2",
     "vulnerable-secret",
+    "write-compressor",
 )
 
 


### PR DESCRIPTION
## Summary

Bump `SPEC_NUMBER` 12 → 13 and rotate the active scenario set: **drop** `break-filter-js-from-html`, **add** `largest-eigenval` + `write-compressor`. Net 10 − 1 + 2 = **11 active scenarios** at SPEC=13.

## Diff

```diff
- SPEC_NUMBER = 12
+ SPEC_NUMBER = 13

  SANDBOX_SCENARIOS: tuple[str, ...] = (
-     "break-filter-js-from-html",
      "cancel-async-tasks",
      "configure-git-webserver",
      "db-wal-recovery",
      "fix-git",
+     "largest-eigenval",
      "log-summary-date-ranges",
      "nginx-request-logging",
      "path-tracing",
      "swe-bench-astropy-2",
      "vulnerable-secret",
+     "write-compressor",
  )
```

Two files, +3/-2 lines total. No code-path changes.

## Why drop `break-filter-js-from-html`

Per the 2026-05-22 saturation review + today's cheat-detector trend analysis:

- **No honest-miner signal**: mean_q ≈ 0.02 over the last 48h, pass rate 2% (4/170). Hermes-class agents don't construct XSS bypasses against a non-trivial filter in 20 min from cold start.
- **20-min agent timeout is a critical-path tax** at `PARALLEL_SCENARIO_EVALS=2`: today's slow-eval investigation showed break-filter alone consuming its full 20-min cap on long-tail sessions.
- **Persistent cheat-attempt target**: two TRUE-positive bypass attempts caught today citing literal `<a href="javascript:alert(1)">` payloads and the `<svg>→<style>→event-handler` nesting recipe specific to this scenario. Removing it removes the incentive surface.

## Why add `largest-eigenval` (medium)

- **27 graded pytest cells** (3 tests × 9 matrix sizes) — highest partial-credit resolution in the suite.
- **Built-in ceiling-defying axis**: `test_speedup` is a strictly-faster-than-numpy gate. No flat 1.0 ceiling — top miners spread along implementation quality.
- **Strong anti-cheat**: verifier sequesters `np.linalg.eig`/`eigvals`/`random.seed`/`random.normal` refs *before* importing candidate `eigen.py`; timing runs in `ProcessPoolExecutor` (isolated worker) to defeat `time.perf_counter` patches.
- 15-min agent budget.

## Why add `write-compressor` (hard)

- **Anti-memorization gold**: reverse-engineer a custom arithmetic coder (`decomp.c`) and write a compatible compressor. Not in any training corpus.
- **3 graded tests including continuous-ish size threshold** (`≤ 2500 bytes`); reference solve.sh hits 2264 bytes.
- 15-min agent budget. Different solve-shape from existing ceiling-sensitive scenarios (path-tracing = graphics insight; swe-bench-astropy-2 = multi-file nav; write-compressor = format reverse-engineering).
- Smoke-tested on `scenario-write-compressor:pr-55-d2f3d13`: reference solve.sh → 3/3 pass, reward=1.

## Net effect at SPEC=13

| | SPEC=12 | SPEC=13 |
|---|---|---|
| Active scenarios | 10 | 11 |
| Dropped | — | break-filter-js-from-html |
| Added | — | largest-eigenval, write-compressor |
| Highest-resolution scenario | swe-bench-astropy-2 (5 cells) | **largest-eigenval (27 cells)** |
| Cheat-trap scenarios | 1 (break-filter) | 0 |

`SPEC_NUMBER = 13` triggers cached-score invalidation per the existing consensus mechanism.

## ⚠️ Sequencing — do NOT merge until trajrl-bench `:latest` is updated

This PR references `ghcr.io/trajectoryrl/scenario-largest-eigenval:latest` and `ghcr.io/trajectoryrl/scenario-write-compressor:latest`. Both images currently exist only at PR-preview tags. The trajrl-bench `auto-discover` CI only publishes `:latest` on tagged releases.

Both scenario sources are now on `trajrl-bench` main:
- `082d567 feat(scenarios): add largest-eigenval (#54)`
- `0d2e4c6 feat(scenarios): add write-compressor (#55)`

**Required before merging this PR**: trajrl-bench tags a release that incorporates both — that's a maintainer-side action (consistent with how previous scenario adds rolled out). Until then, validators would 404 on the first eval of either new scenario.

## Smoke tests already done (bench side)

- `largest-eigenval` PR #54 smoke (earlier this session): scenario-images-pr build succeeded; verifier path validated.
- `write-compressor` PR #55 smoke (just now): pulled `scenario-write-compressor:pr-55-d2f3d13`, ran reference `solve.sh` → `/app/data.comp` at 2264 bytes; ran `tests/test.sh` end-to-end → `passed=3 failed=0`, `reward.txt = 1`; anti-tamper restore verified.

## Test plan post-merge

- [ ] After trajrl-bench `:latest` updates, run one full eval cycle on a single validator. Confirm both new scenarios run + score correctly without 404 or timeout regressions.
- [ ] Monitor `final_score` distribution after a couple of epochs — expect mean to shift up slightly (replacing a 0.02-mean scenario with two that score 0.5+ for competent packs).
- [ ] Watch for cheat-detector verdict deltas — should see fewer `<svg>`-style break-filter exploit attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
