### PR TITLE
docs(miner): decouple web-submit from on-chain commit step

### DIFF
--- a/docs/MINER_GUIDE.md
+++ b/docs/MINER_GUIDE.md
@@ -228,13 +228,18 @@ git clone https://github.com/trajectoryRL/trajectoryRL.git
 cd trajectoryRL && pip install -e .
 
 trajectoryrl-miner build SKILL.md -o pack.json
-trajectoryrl-miner web-submit pack.json          # managed hosting, recommended
-# OR: trajectoryrl-miner upload pack.json        # self-host on S3 / R2 / GCS
-trajectoryrl-miner submit <pack_url>             # on-chain commitment
+
+# Path B — managed web submit (recommended, no chain commit needed)
+trajectoryrl-miner web-submit pack.json
+
+# Path A — self-host + chain commit (alternative)
+# trajectoryrl-miner upload pack.json             # self-host on S3 / R2 / GCS
+# trajectoryrl-miner submit <pack_url>            # set_commitment on-chain
+
 trajectoryrl-miner status
 ```
 
-The on-chain commitment is `{pack_hash}|{pack_url}`. Validators fetch your `pack.json`, verify the hash, extract `SKILL.md`, and run the full scenario session.
+Path A writes the on-chain commitment `{pack_hash}|{pack_url}`; the platform's syncer ingests it into the challenger queue. Path B writes the queue entry directly via the web API and does not touch the chain. In both cases validators fetch your `pack.json`, verify the hash, extract `SKILL.md`, and run the full scenario session — pick one path, not both.
 
 ---
 
@@ -292,4 +297,4 @@ A: The schema permits multiple files in `files`, but Season 1 only reads `SKILL.
 A: Pack rejected at schema validation.
 
 **Q: How often can I resubmit?**
-A: Self-hosted (`upload` + `submit`): chain-side rate limit (~100 blocks ≈ 20 min between commits). Managed (`web-submit`): one successful submission per hour per hotkey (server cooldown), plus the same chain rate limit on the subsequent `submit` step.
+A: Self-hosted (`upload` + `submit`): chain-side rate limit (~100 blocks ≈ 20 min between commits). Managed (`web-submit`): one successful submission per hour per hotkey (server cooldown). Web-submitted packs do not require a follow-up on-chain `submit`, so the chain rate limit does not apply on this path.

--- a/docs/MINER_OPERATIONS.md
+++ b/docs/MINER_OPERATIONS.md
@@ -30,7 +30,7 @@ The miner CLI (`trajectoryrl-miner`) is a **toolbox**: independent commands you 
 
 ## Quick Start
 
-Submission is three steps: **build** the pack, **host** it (one of two routes), then **commit** the URL on-chain.
+Submission has two paths. **Option A** is three steps (build, host, on-chain commit). **Option B** is two steps (build, web-submit) — the platform handles queue admission for you, no chain commit needed.
 
 ```bash
 git clone https://github.com/trajectoryRL/trajectoryRL.git
@@ -43,9 +43,9 @@ vim SKILL.md
 trajectoryrl-miner build SKILL.md -o pack.json
 ```
 
-For step 3 (hosting), pick **one** route. Both produce a public `pack_url`.
+Then pick **one** route below.
 
-**Option A — Self-hosted (S3 / R2 / GCS / etc.)**
+**Option A — Self-hosted + on-chain commit**
 
 ```bash
 # 3a. Upload to your own S3-compatible bucket
@@ -56,15 +56,14 @@ trajectoryrl-miner upload pack.json
 trajectoryrl-miner submit https://your-bucket.s3.amazonaws.com/pack.json
 ```
 
-**Option B — Managed hosting via `/api/v2/miners/submit`**
+**Option B — Managed web submit (no chain commit)**
 
 ```bash
-# 3b. Submit pack content to trajrl.com (managed GCS), get back pack_url
+# 3b. Submit pack content to trajrl.com (managed GCS).
+#     The platform stores the pack, runs pre-eval, and admits it to
+#     the challenger queue directly. No on-chain commit needed.
 trajectoryrl-miner web-submit pack.json
 # → prints pack_url + cooldown info
-
-# 4b. Commit on-chain (same step as Option A)
-trajectoryrl-miner submit <pack_url>
 ```
 
 Then check status:
@@ -73,7 +72,7 @@ Then check status:
 trajectoryrl-miner status
 ```
 
-That's it. Repeat steps 1 → 4 whenever you improve your SKILL.md.
+That's it. Repeat whenever you improve your SKILL.md.
 
 > The CLI is also runnable as `python neurons/miner.py <command>` if you'd rather not install the entry point. Behaviour is identical.
 
@@ -81,12 +80,12 @@ That's it. Repeat steps 1 → 4 whenever you improve your SKILL.md.
 
 ## Two submission paths
 
-| Path | What you operate | Where the pack lives | Reveal | Use this when |
-|------|-----------------|----------------------|--------|---------------|
-| **A. Self-host + chain commit** | An HTTP host (S3 / GCS / GH / your own server) for `pack.json` | Your bucket | Public on chain immediately (commit URL is on-chain) | You already have hosting and want full control |
-| **B. Web submit (recommended for new miners)** | Just the miner CLI, no hosting | Subnet's GCS at an unguessable random key | URL hidden 48 h; commit on-chain still required for discovery | You want the easiest path; you don't want to run hosting |
+| Path | What you operate | Where the pack lives | Eligibility event | Reveal | Use this when |
+|------|-----------------|----------------------|-------------------|--------|---------------|
+| **A. Self-host + chain commit** | An HTTP host (S3 / GCS / GH / your own server) for `pack.json` | Your bucket | `set_commitment(pack_hash \| url)` on-chain | Public on chain immediately | You already have hosting and want full control |
+| **B. Web submit (recommended for new miners)** | Just the miner CLI, no hosting | Subnet's GCS at an unguessable random key | `miner_submissions` row created by the web-submit API | URL hidden 48 h | You want the easiest path; you don't want to run hosting |
 
-Both paths produce the same on-chain artifact: `set_commitment(pack_hash | url)`. The difference is who hosts the pack content.
+The two paths are **independent and equivalent** in how they feed the challenger queue — pick one, not both. Both produce a `pending_pre_eval` row in the platform's `miner_submissions` table (chain commits via the platform's metagraph syncer; web-submit directly). The picker reads from that table; chain-source and web-source rows compete on identical terms.
 
 ### Path A — chain commit (classic)
 
@@ -103,16 +102,14 @@ trajectoryrl-miner submit https://your-bucket/pack.json   # set_commitment on ch
 trajectoryrl-miner build SKILL.md -o pack.json
 
 # 2. POST pack to the subnet's hosted submit endpoint (signed with your hotkey).
-#    The endpoint stores the pack at an unguessable random GCS path and
-#    returns the pack_url to use on-chain.
+#    The endpoint stores the pack at an unguessable random GCS path,
+#    creates the miner_submissions row, and kicks off pre-eval.
+#    No on-chain commit step is required after this.
 trajectoryrl-miner web-submit pack.json
 # → Response: { pack_url: "https://storage.googleapis.com/.../pack.json", ... }
-
-# 3. Commit on-chain with the returned pack_url
-trajectoryrl-miner submit <pack_url_from_response>
 ```
 
-The `web-submit` endpoint immediately validates your signature, hash and pack format, kicks off pre-eval asynchronously, and returns the `pack_url`. Web-source URLs are not exposed in any other API for **48 hours** (the "reveal gate"), so a competitor can't simply scrape the dashboard to harvest your fresh SKILL.md.
+The `web-submit` endpoint immediately validates your signature, hash and pack format, kicks off pre-eval asynchronously, and returns the `pack_url`. The platform queues the pack for the next eligible challenger epoch on its own — no follow-up `set_commitment` is needed. Web-source URLs are not exposed in any other API for **48 hours** (the "reveal gate"), so a competitor can't simply scrape the dashboard to harvest your fresh SKILL.md.
 
 Full request/response spec for `/api/v2/miners/submit` is in [`trajectoryrl.web/API.md`](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md).
 
@@ -168,9 +165,9 @@ Reads S3 config from environment or CLI flags. Returns the public URL for use wi
 
 ### web-submit
 
-Submit pack content directly to the managed web service (`POST /api/v2/miners/submit`). The server stores your pack at an unguessable random GCS path and returns the public URL. No S3 / R2 / bucket config required — the request is signed with your hotkey, so the only credential you need is the wallet itself.
+Submit pack content directly to the managed web service (`POST /api/v2/miners/submit`). The server stores your pack at an unguessable random GCS path, creates the `miner_submissions` row, and kicks off pre-eval. No S3 / R2 / bucket config required — the request is signed with your hotkey, so the only credential you need is the wallet itself.
 
-This command does **only** the HTTP upload — it does not touch the chain. The on-chain commit is a separate step, run via `submit <pack_url>` (same step you'd run after `upload`).
+This command is **self-contained** — it does not touch the chain, and you do **not** need to follow up with `submit <pack_url>`. The platform queues the pack for evaluation on its own.
 
 ```bash
 trajectoryrl-miner web-submit pack.json
@@ -189,7 +186,9 @@ Submitted! pack_url = https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<ra
   next_upload_at:   2026-05-04T15:00:00.000Z
   pre_eval_status:  pending
 
-Next step: trajectoryrl-miner submit https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<random_key>.json
+Done — the platform will pre-eval and admit your pack to the
+challenger queue automatically. No on-chain commit required for
+web-submitted packs.
 ```
 
 **Cooldown**: The endpoint enforces a per-miner cooldown (default **1 hour**, set server-side via `MINER_SUBMIT_COOLDOWN_SECONDS`). Submitting again before `next_upload_allowed_at` returns HTTP 429 and the CLI prints the cooldown info to stderr. Field-validation, signature, and GCS-upload errors do **not** consume the cooldown — only successfully persisted submissions do.
@@ -296,16 +295,19 @@ For SKILL.md authoring patterns and what makes a pack score well, the canonical 
 │                                                         │
 │  1. Write / iterate on SKILL.md                         │
 │  2. build → pack.json                                   │
-│  3. host:                                               │
-│       • upload      → self-hosted public URL            │
-│       • web-submit  → managed GCS URL via /api/v2/...   │
-│  4. submit → on-chain commitment                        │
-│  5. Wait for validator evaluation (one epoch)           │
-│  6. Check results, iterate                              │
+│  3. Pick ONE submission path:                           │
+│       Path A (self-host + chain commit)                 │
+│         • upload  → self-hosted public URL              │
+│         • submit  → on-chain commitment                 │
+│       Path B (managed web submit)                       │
+│         • web-submit → platform queues the pack         │
+│                        directly; no chain commit        │
+│  4. Wait for validator evaluation (one epoch)           │
+│  5. Check results, iterate                              │
 └─────────────────────────────────────────────────────────┘
 ```
 
-Validators only re-evaluate when your `pack_hash` changes. No need to resubmit if your SKILL.md hasn't changed — your existing on-chain commitment carries you forward into every future epoch's eval set automatically (eligibility is driven by the chain commitment, not by an off-chain heartbeat).
+Validators only re-evaluate when your `pack_hash` changes. No need to resubmit if your SKILL.md hasn't changed — once your pack is in the queue (via chain commitment or via web-submit), it carries forward into every future epoch's eval set automatically. Eligibility is driven by the latest `miner_submissions` row for your hotkey, not by an off-chain heartbeat.
 
 ### Submission timing — the freeze gap
 
@@ -337,7 +339,7 @@ For the full window math (`cutoff_time`, `window_start`, `commit_block` semantic
 | Pre-eval feedback loop | none — wait for next epoch's snapshot | server runs pre-eval async; reflected in the next epoch_snapshot |
 | Best for | miners with existing infra / custom storage | new miners or anyone wanting one-command publishing |
 
-The on-chain commit step (and therefore the validator discovery path) is identical in both cases — `<pack_hash>|<pack_url>` written via `set_commitment`.
+Discovery differs by path: Path A relies on the on-chain `<pack_hash>|<pack_url>` written via `set_commitment`, which the platform's syncer ingests into `miner_submissions`. Path B writes the `miner_submissions` row directly via the API. Once the row exists, the challenger picker treats both sources identically.
 
 ---
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -200,7 +200,9 @@ def cmd_web_submit(args):
     print(f"  next_upload_at:   {response.get('next_upload_allowed_at')}")
     print(f"  pre_eval_status:  {response.get('pre_eval_status')}")
     print()
-    print(f"Next step: python neurons/miner.py submit {pack_url}")
+    print("Done — the platform will pre-eval and admit your pack to the")
+    print("challenger queue automatically. No on-chain commit required for")
+    print("web-submitted packs.")
     return 0
 
 
@@ -321,7 +323,7 @@ Examples:
     p_web = sub.add_parser(
         "web-submit",
         help="Submit pack via /api/v2/miners/submit (managed GCS hosting); "
-             "follow up with `submit <pack_url>` for the on-chain commit",
+             "no on-chain commit needed — the platform queues the pack directly",
     )
     p_web.add_argument("pack_path", help="Path to pack.json")
     p_web.add_argument(

--- a/trajectoryrl/base/miner.py
+++ b/trajectoryrl/base/miner.py
@@ -1,17 +1,28 @@
-"""TrajectoryRL Miner — Pack building and on-chain submission.
+"""TrajectoryRL Miner — Pack building and submission.
 
-Season 1 workflow:
-    1. Write SKILL.md
-    2. Build pack: build_s1_pack(skill_content) -> {"schema_version": 1, "files": {"SKILL.md": "..."}}
-    3. Host pack.json — either:
-        a. Self-hosted (S3-compatible bucket, R2, etc.), or
-        b. Submit to the managed web service via ``submit_pack_via_api``
-           (POST /api/v2/miners/submit) — server stores the pack at a
-           random GCS key and returns the URL
-    4. Submit on-chain commitment via submit_commitment(pack_hash, pack_url)
+Season 1 workflow — two independent paths:
 
-The on-chain commitment is block-timestamped, establishing first-mover
-precedence. Validators read commitments and fetch packs via HTTP.
+    Path A — self-host + on-chain commit
+        1. Write SKILL.md
+        2. Build pack: build_s1_pack(skill_content)
+                       -> {"schema_version": 1, "files": {"SKILL.md": "..."}}
+        3. Host pack.json on a public URL (S3 / R2 / GCS / GitHub raw / etc.)
+        4. submit_commitment(pack_hash, pack_url) writes the on-chain
+           pointer; validators read commitments and fetch packs via HTTP.
+
+    Path B — managed web submit (no chain commit needed)
+        1. Write SKILL.md
+        2. Build pack
+        3. submit_pack_via_api(pack) POSTs to /api/v2/miners/submit.
+           The platform stores the pack at a random GCS key, runs
+           pre-eval, and admits the pack to the challenger queue
+           directly. The miner does NOT need to follow up with
+           submit_commitment — eligibility is driven by the
+           miner_submissions row created by the API call.
+
+Both paths produce an equally-evaluated entry in the challenger queue;
+they differ only in who hosts the bytes and whether the eligibility
+event lives on-chain or in the platform DB.
 """
 
 import hashlib
@@ -43,13 +54,21 @@ DEFAULT_MINER_SUBMIT_URL = f"{DEFAULT_API_BASE_URL}/api/v2/miners/submit"
 class TrajectoryMiner:
     """TrajectoryRL miner for building and submitting policy packs.
 
-    Example::
+    Example (Path A — self-host + chain commit)::
 
         miner = TrajectoryMiner(wallet_name="miner", wallet_hotkey="default")
         pack = TrajectoryMiner.build_s1_pack(open("SKILL.md").read())
         pack_hash = TrajectoryMiner.save_pack(pack, "pack.json")
         # Upload pack.json to a public URL, then:
         miner.submit_commitment(pack_hash, "https://example.com/pack.json")
+
+    Example (Path B — managed web submit, no chain commit needed)::
+
+        miner = TrajectoryMiner(wallet_name="miner", wallet_hotkey="default")
+        pack = TrajectoryMiner.build_s1_pack(open("SKILL.md").read())
+        miner.submit_pack_via_api(pack)
+        # The platform queues the pack for evaluation; no follow-up
+        # submit_commitment call is required.
     """
 
     def __init__(
@@ -291,11 +310,13 @@ class TrajectoryMiner:
     ) -> Optional[Dict[str, Any]]:
         """Submit a pack to the managed web service (POST /api/v2/miners/submit).
 
-        The web service stores the pack in GCS under a random key and
-        returns a public ``pack_url`` that the miner subsequently
-        commits on-chain via ``submit_commitment``. This is an
-        alternative to self-hosting (R2, S3, etc.) — the chain
-        commitment step is identical in both cases.
+        The web service stores the pack in GCS under a random key,
+        runs pre-eval, and admits the pack to the challenger queue
+        directly. Web-submitted packs do NOT require a follow-up
+        on-chain ``submit_commitment`` — eligibility is driven by the
+        ``miner_submissions`` row this call creates on the platform.
+        This is a fully self-contained alternative to the self-host +
+        chain-commit path; pick one, not both.
 
         Args:
             pack: The pack dict (will be canonicalized and hashed).


### PR DESCRIPTION
## Summary

web-submit is self-contained: the platform creates the `miner_submissions` row, runs pre-eval, and admits the pack to the challenger queue directly. No follow-up `set_commitment` is required. Docs, CLI hints, and module docstrings still framed it as a two-step (web-submit → submit) flow, which led miners to think the chain commit was mandatory after web-submit.

This PR rewrites those surfaces to present Path A (self-host + chain commit) and Path B (managed web-submit, no chain step) as **independent and equivalent** ways to enter the challenger queue. Pick one, not both.

## Changes

- **`neurons/miner.py`** — `cmd_web_submit` drops the "Next step: submit" hint; `web-submit` subparser help reflects the self-contained semantics.
- **`trajectoryrl/base/miner.py`** — module docstring restructured into Path A / Path B; `TrajectoryMiner` example adds Path B; `submit_pack_via_api` docstring clarifies no follow-up chain commit is required.
- **`docs/MINER_OPERATIONS.md`** — Quick Start, Two Paths table, web-submit CLI reference, Typical Workflow ASCII diagram, and the hosting-option comparison are all updated.
- **`docs/MINER_GUIDE.md`** — Submission code block + resubmit-frequency FAQ reflect the same independence.

## Why now

Verified in `trajectoryrl.web` that the v6 challenger picker (`src/lib/db/challenger-queue.ts:buildPickHeadQuery`) reads exclusively from `miner_submissions` with `eval_status='pending_eval'`, FIFO. Both `source='chain'` and `source='web'` rows compete on identical terms. `commit_block IS NULL` is a fully supported state for web-only rows. So nothing in the architecture requires the chain commit after web-submit — only the docs did.

## Test plan

- [ ] Run `pytest tests/test_miner.py` — only help-text assertion is `pack_path` / `--api-base-url` (no break).
- [ ] Manually invoke `python neurons/miner.py web-submit --help` and `python neurons/miner.py web-submit <pack.json>` against staging to confirm the new output.
- [ ] Skim the rendered MINER_GUIDE.md / MINER_OPERATIONS.md for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)