### PR TITLE
feat(validator): bump PARALLEL_SCENARIO_EVALS default 2 → 3

### DIFF
--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -1426,10 +1426,10 @@ class TestParallelScenarioOrchestrator:
 
         return h
 
-    def test_default_config_is_two(self):
+    def test_default_config_is_three(self):
         # Bumping this default is a behavior change for every operator;
         # surface it in a test so a casual edit can't slip through.
-        assert ValidatorConfig.parallel_scenario_evals == 2
+        assert ValidatorConfig.parallel_scenario_evals == 3
 
     def test_env_var_clamps_to_at_least_one(self, monkeypatch, tmp_path):
         # PARALLEL_SCENARIO_EVALS=0 (or negative) must clamp up — a

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -174,15 +174,14 @@ class ValidatorConfig:
     # Number of scenarios to evaluate concurrently within a single
     # pack's eval session. Each parallel slot spins up its own
     # scenario container (mem_limit=4g, cpu_quota=2cpu) and its own
-    # hermes chat (one concurrent LLM stream). Default 2 ≈ 8 GB RAM
-    # + 4 CPU + 2 concurrent LLM requests at peak — conservative
-    # sizing that fits a typical validator host with room to spare.
+    # hermes chat (one concurrent LLM stream). Default 3 ≈ 12 GB RAM
+    # + 6 CPU + 3 concurrent LLM requests at peak.
     # Set ``PARALLEL_SCENARIO_EVALS=1`` to reproduce the pre-PR
     # sequential behavior, or raise it on bigger boxes. Clamped to
     # >=1 at load time. The on-chain submit path is unaffected —
     # scenarios still produce the same per-name quality dict, just
     # in a different completion order.
-    parallel_scenario_evals: int = 2
+    parallel_scenario_evals: int = 3
     # Scenarios + episodes-per-scenario are not configurable on purpose:
     # every validator runs the same set so scores are comparable across
     # validators / windows / SPEC_NUMBER bumps. To change the set, add a
@@ -292,7 +291,7 @@ class ValidatorConfig:
             image_channel=os.getenv("IMAGE_CHANNEL", DEFAULT_IMAGE_CHANNEL),
             sandbox_timeout_per_episode=int(os.getenv("SANDBOX_TIMEOUT_PER_EPISODE", "600")),
             parallel_scenario_evals=max(
-                1, int(os.getenv("PARALLEL_SCENARIO_EVALS", "2"))
+                1, int(os.getenv("PARALLEL_SCENARIO_EVALS", "3"))
             ),
             # --- Startup aggregation ---
             aggregate_when_start=os.getenv("AGGREGATE_WHEN_START", "1") == "1",


### PR DESCRIPTION
## Summary

- Raises validator default for concurrent scenario evals within one pack from `2` to `3`.
- Each parallel slot still costs ~4g RAM + 2 CPU + one in-flight LLM stream, so the new default sits at roughly **12 GB RAM / 6 CPU / 3 concurrent LLM requests** at peak (up from 8 GB / 4 CPU / 2 concurrent).
- Scoring surface is unchanged — scenarios still produce the same per-name quality dict, just completed faster. Operators on smaller boxes can opt back to the previous default with `PARALLEL_SCENARIO_EVALS=2` (or `1` for the pre-parallel sequential path).
- Updated `test_default_config_is_two` → `test_default_config_is_three` so the locked-in default tracks the new value.

## Test plan

- [x] `pytest tests/test_sandbox_harness.py::TestParallelScenarioOrchestrator` — 7 passed locally on `/opt/venv`.
- [ ] Operator note: validator hosts should have ≥12 GB free RAM and ≥6 free CPU under the new default; downsizing to `PARALLEL_SCENARIO_EVALS=2` remains a one-env-var revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)