### PR TITLE
feat(scoring): SPEC 15 — add regex-chess + race-condition-fix

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 14
+SPEC_NUMBER = 15
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -62,6 +62,8 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
     "largest-eigenval",
     "nginx-request-logging",
     "path-tracing",
+    "race-condition-fix",
+    "regex-chess",
     "swe-bench-astropy-2",
     "write-compressor",
 )
@@ -77,12 +79,21 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
 # across SPEC bumps. Per-scenario discrimination (mean_quality, the
 # [0,1] aggregate) is unaffected.
 #
-# Increment this whenever a scenario is removed; reset when a removed
-# scenario is replaced rather than just dropped. SPEC 14 dropped 4
-# scenarios — cancel-async-tasks, fix-git, log-summary-date-ranges,
-# vulnerable-secret — saturated at mean ≥ 0.82 over last 72h with
-# pass rates of 96-98% (validator analytics 2026-05-27).
-REMOVED_SCENARIO_BASE_SCORE: float = 4.0
+# Increment this whenever a scenario is removed; decrement when a
+# removed slot is refilled with a real scenario. SPEC 14 dropped 4
+# saturated scenarios — cancel-async-tasks, fix-git,
+# log-summary-date-ranges, vulnerable-secret (mean ≥ 0.82 over 72h,
+# pass rates 96-98%, validator analytics 2026-05-27) — and set the
+# offset to 4 so the headline max stayed at 11.
+#
+# SPEC 15 refills 2 of those 4 slots with hard, discriminating
+# scenarios (race-condition-fix, regex-chess), so N goes 7→9 and the
+# offset drops 4→2 — the headline max stays 11. Note this is NOT
+# score-preserving the way SPEC 14's *removal* was: those phantom
+# base-points are now backed by real hard scenarios, so observed
+# scores will fall until packs actually solve them. That drop is the
+# intended discrimination signal, not a regression.
+REMOVED_SCENARIO_BASE_SCORE: float = 2.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add **race-condition-fix** and **regex-chess** to `SANDBOX_SCENARIOS` (7 → 9).
- `REMOVED_SCENARIO_BASE_SCORE` **4.0 → 2.0** — refilling 2 of SPEC 14's 4 dropped slots, so the headline max stays **11**.
- `SPEC_NUMBER` **14 → 15** (scoring surface changed → cached scores invalidate).

## ⚠️ Do not merge until prerequisites are met
1. **Bench timeout PR** trajectoryRL/trajrl-bench#60 merged (caps regex-chess agent budget 3600→1200s).
2. **Bench release tag cut** so `scenario-regex-chess:latest` and `scenario-race-condition-fix:latest` (and the sandbox-agent image carrying their `scenario-info`) are published. The harness pulls scenarios by `:latest`; merging this before publish **will break evals** (`RuntimeError: scenario … has no image_repo`).

## Scoring implication (read before merging)
This is **not** score-preserving the way SPEC 14's *removal* was. SPEC 14 dropped *saturated* scenarios (everyone at ceiling), so the base offset kept observed scores flat. SPEC 15 replaces 2 phantom base-points with 2 *hard* scenarios that packs will mostly score low on — so **observed scores will fall** (e.g. a current ~9.6 pack will land lower) until miners actually solve them. That drop is the intended discrimination signal, not a regression. Headline *max* is unchanged at 11.

## Test plan
- [x] `tests/test_sandbox_harness.py` + `tests/test_validator.py` — 129 pass; the 6 failures are pre-existing on `main` (epoch-sleep + worker-clamp), unrelated to this change.
- [ ] After bench release, dry-run one eval cycle to confirm both new scenarios pull + verify cleanly before this rides out to other validators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)