### PR TITLE
[coding-agent] retry infra-incomplete scenarios with incremental backoff

### DIFF
--- a/tests/test_sandbox_harness.py
+++ b/tests/test_sandbox_harness.py
@@ -15,11 +15,13 @@ from trajectoryrl.utils.sandbox_harness import (
     SandboxEvaluationResult,
     TrajectorySandboxHarness,
     _drain_exec_stream_with_deadline,
+    _episode_incomplete_no_progress,
     _EpisodeResult,
     _looks_like_provider_failure,
     _parse_ctrf_correctness,
     _parse_session_cost,
     _pick_episode_timeout,
+    _retry_episode_on_incomplete,
     _SessionResult,
 )
 
@@ -1426,6 +1428,43 @@ class TestParallelScenarioOrchestrator:
 
         return h
 
+    def test_run_eval_sync_retries_infra_incomplete_scenario(
+        self, monkeypatch, tmp_path,
+    ):
+        # Epoch-2030: a scenario comes back infra-incomplete (clean exit,
+        # 0 tool calls, finish_reason=incomplete). The dispatcher must
+        # re-run it and record the recovered score, not POST a poisoned 0.
+        scenarios = ("s0",)
+        h = self._setup_harness(
+            monkeypatch, tmp_path, parallelism=1, scenarios=scenarios,
+        )
+        h.config.scenario_incomplete_max_retries = 2
+        h.config.scenario_incomplete_backoff_base_s = 0.0  # no real sleep
+
+        calls = {"n": 0}
+
+        def fake_run_episode(*, session_id, episode_index, skill_md, spec,
+                             on_chat_start=None, on_chat_end=None,
+                             on_container_started=None,
+                             on_container_finished=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return _ep(scenario=spec["name"])  # infra-incomplete
+            return _EpisodeResult(
+                episode_index=episode_index, scenario=spec["name"],
+                quality=0.7, chat_exit=0,
+                turns_log=_turns_log_blob(
+                    tool_call_count=3, finish_reason="stop",
+                ),
+            )
+
+        monkeypatch.setattr(h, "_run_episode", fake_run_episode)
+        result = h._run_eval_sync(
+            skill_md="x", epoch_seed=0, salt="s", pack_hash="abc",
+        )
+        assert calls["n"] == 2  # retried the infra-incomplete scenario once
+        assert [e.quality for e in result.episodes] == [0.7]
+
     def test_default_config_is_three(self):
         # Bumping this default is a behavior change for every operator;
         # surface it in a test so a casual edit can't slip through.
@@ -1696,3 +1735,174 @@ class TestParallelScenarioOrchestrator:
         assert abs(par_score - seq_score) < 1e-9
         expected = 0.25 + 0.5 + 0.75 + 1.0 + REMOVED_SCENARIO_BASE_SCORE
         assert abs(seq_score - expected) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Infra-incomplete detection + scenario-level retry with backoff
+# ---------------------------------------------------------------------------
+# Anchor (epoch 2030 incident): the testee LLM endpoint returned
+# `finish_reason=incomplete` with no tool call / ~0 billing on fresh
+# sessions during a multi-minute rate-limit window. Those scenarios were
+# scored 0 and POSTed to consensus. hermes' in-container retry (6 calls in
+# ~1.3s) was too fast to outlast the window. We detect that signature per
+# episode and retry the whole scenario with incremental backoff.
+
+import json as _json_retry
+
+
+def _turns_log_blob(*, tool_call_count: int, finish_reason: str) -> str:
+    """Build a one-session turns.jsonl blob like hermes exports."""
+    session = {
+        "tool_call_count": tool_call_count,
+        "messages": [
+            {"role": "user", "content": "Solve the task"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": None,
+                "finish_reason": finish_reason,
+            },
+        ],
+    }
+    return _json_retry.dumps(session)
+
+
+def _ep(
+    *,
+    chat_exit=0,
+    timed_out=False,
+    tool_call_count=0,
+    finish_reason="incomplete",
+    turns_log=None,
+    quality=0.0,
+    scenario="regex-chess",
+) -> _EpisodeResult:
+    if turns_log is None:
+        turns_log = _turns_log_blob(
+            tool_call_count=tool_call_count, finish_reason=finish_reason
+        )
+    return _EpisodeResult(
+        episode_index=0,
+        scenario=scenario,
+        quality=quality,
+        chat_exit=chat_exit,
+        timed_out=timed_out,
+        turns_log=turns_log,
+    )
+
+
+class TestEpisodeIncompleteNoProgress:
+    def test_clean_exit_no_tool_calls_incomplete_is_infra(self):
+        # The epoch-2030 signature: hermes exited 0, agent never issued a
+        # tool call, model truncated (finish_reason=incomplete).
+        assert _episode_incomplete_no_progress(_ep()) is True
+
+    def test_genuine_pack_zero_with_tool_calls_is_not_infra(self):
+        # db-wal-recovery style: agent worked (tool calls) but failed the
+        # task. A real miner 0 — must NOT be treated as infra / retried.
+        ep = _ep(tool_call_count=5, finish_reason="stop", quality=0.0)
+        assert _episode_incomplete_no_progress(ep) is False
+
+    def test_timed_out_is_not_infra(self):
+        # Heavy scenario that ran real work then hit the per-episode
+        # deadline (GyrMS write-compressor). Real signal, keep it.
+        ep = _ep(timed_out=True, tool_call_count=0)
+        assert _episode_incomplete_no_progress(ep) is False
+
+    def test_hermes_hard_fail_nonzero_exit_is_not_this_path(self):
+        # chat_exit != 0 is the session-wide provider-failure path
+        # (_looks_like_provider_failure), not the clean-exit incomplete one.
+        ep = _ep(chat_exit=1, tool_call_count=0)
+        assert _episode_incomplete_no_progress(ep) is False
+
+    def test_clean_stop_no_tools_is_not_infra(self):
+        # Model cleanly stopped (finish_reason=stop) without a tool call:
+        # a pack signal (agent gave up), not a truncation. Keep the 0.
+        ep = _ep(tool_call_count=0, finish_reason="stop")
+        assert _episode_incomplete_no_progress(ep) is False
+
+    def test_empty_turns_log_is_not_infra(self):
+        # No session captured → no positive evidence of incomplete; be
+        # conservative and don't false-trigger a retry.
+        ep = _ep(turns_log="")
+        assert _episode_incomplete_no_progress(ep) is False
+
+
+class TestRetryEpisodeOnIncomplete:
+    def test_retries_until_success_then_stops(self):
+        results = [_ep(), _ep(), _ep(tool_call_count=4, finish_reason="stop", quality=0.8)]
+        calls = {"n": 0}
+        slept: list[float] = []
+
+        def run_fn():
+            ep = results[calls["n"]]
+            calls["n"] += 1
+            return ep
+
+        out = _retry_episode_on_incomplete(
+            run_fn,
+            max_retries=3,
+            backoff_base_s=20.0,
+            backoff_factor=3.0,
+            sleep_fn=slept.append,
+        )
+        assert out.quality == 0.8           # returned the recovered episode
+        assert calls["n"] == 3              # 1 initial + 2 retries
+        assert slept == [20.0, 60.0]        # incremental backoff steps
+
+    def test_exhausts_retries_when_always_incomplete(self):
+        calls = {"n": 0}
+        slept: list[float] = []
+
+        def run_fn():
+            calls["n"] += 1
+            return _ep()
+
+        out = _retry_episode_on_incomplete(
+            run_fn,
+            max_retries=3,
+            backoff_base_s=20.0,
+            backoff_factor=3.0,
+            sleep_fn=slept.append,
+        )
+        assert _episode_incomplete_no_progress(out) is True
+        assert calls["n"] == 4              # 1 initial + 3 retries
+        assert slept == [20.0, 60.0, 180.0]  # max cumulative backoff = 260s
+
+    def test_no_retry_when_first_attempt_succeeds(self):
+        calls = {"n": 0}
+        slept: list[float] = []
+
+        def run_fn():
+            calls["n"] += 1
+            return _ep(tool_call_count=3, finish_reason="stop", quality=1.0)
+
+        out = _retry_episode_on_incomplete(
+            run_fn,
+            max_retries=3,
+            backoff_base_s=20.0,
+            backoff_factor=3.0,
+            sleep_fn=slept.append,
+        )
+        assert out.quality == 1.0
+        assert calls["n"] == 1
+        assert slept == []
+
+    def test_stops_retrying_when_epoch_moved_on(self):
+        calls = {"n": 0}
+        slept: list[float] = []
+
+        def run_fn():
+            calls["n"] += 1
+            return _ep()
+
+        out = _retry_episode_on_incomplete(
+            run_fn,
+            max_retries=3,
+            backoff_base_s=20.0,
+            backoff_factor=3.0,
+            sleep_fn=slept.append,
+            still_current=lambda: False,   # epoch already advanced
+        )
+        assert calls["n"] == 1             # no retry attempted
+        assert slept == []

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -182,6 +182,20 @@ class ValidatorConfig:
     # scenarios still produce the same per-name quality dict, just
     # in a different completion order.
     parallel_scenario_evals: int = 3
+    # Scenario-level retry for infra-incomplete episodes. When the testee
+    # LLM endpoint returns ``finish_reason=incomplete`` with no tool call
+    # (a rate-limit / load-shedding truncation — the agent never acts and
+    # would otherwise be scored a poisoned 0), re-run the whole scenario
+    # after an incremental backoff so a transient multi-minute window can
+    # pass before the real score is recorded. hermes' in-container retry
+    # (~6 LLM calls in ~1.3s) is far too fast to outlast such a window.
+    # Defaults: sleeps of 20s / 60s / 180s (max ~260s cumulative backoff),
+    # sized to cover the epoch-2030 ~5-min OpenRouter degradation. Backoff
+    # is gated on the epoch-current check, so short dynamic epochs bail
+    # early instead of stalling. Set max_retries=0 to disable.
+    scenario_incomplete_max_retries: int = 3
+    scenario_incomplete_backoff_base_s: float = 20.0
+    scenario_incomplete_backoff_factor: float = 3.0
     # Scenarios + episodes-per-scenario are not configurable on purpose:
     # every validator runs the same set so scores are comparable across
     # validators / windows / SPEC_NUMBER bumps. To change the set, add a

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -729,6 +729,116 @@ def _looks_like_provider_failure(episodes: List["_EpisodeResult"]) -> bool:
     return True
 
 
+def _last_session_obj(turns_log: str) -> dict | None:
+    """Return the last non-empty JSON object in a turns.jsonl blob.
+
+    The validator wipes Hermes' store between episodes, so the blob
+    normally carries exactly one session; we take the last line
+    defensively. Returns None when empty / unparseable.
+    """
+    if not turns_log:
+        return None
+    last: dict | None = None
+    for line in turns_log.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            last = parsed
+    return last
+
+
+def _episode_incomplete_no_progress(ep: "_EpisodeResult") -> bool:
+    """True when hermes exited cleanly but the agent never acted because
+    the testee model truncated (``finish_reason=incomplete``) instead of
+    answering — the epoch-2030 rate-limit signature.
+
+    Distinguishes infra failure (retry-worthy) from a real miner 0:
+
+    * ``chat_exit`` non-zero / deadline kill → not this path (that is the
+      session-wide ``_looks_like_provider_failure`` case or a real
+      timeout); only clean exits (``0`` / unknown ``None``) qualify.
+    * ``timed_out`` → the agent did real work then hit the deadline; a
+      genuine signal, not a truncation. Keep it.
+    * ``tool_call_count > 0`` → the agent engaged with the task. Whatever
+      score it got is a real pack signal, even if zero.
+    * ``tool_call_count == 0`` AND any assistant turn
+      ``finish_reason == "incomplete"`` → the model emitted reasoning but
+      no content / tool call and got cut off. Infra. A clean
+      ``finish_reason == "stop"`` with no tool call is the agent giving
+      up — a pack signal — and is NOT flagged.
+    """
+    if ep.chat_exit not in (0, None):
+        return False
+    if ep.timed_out:
+        return False
+    session = _last_session_obj(ep.turns_log)
+    if not session:
+        return False
+    try:
+        tool_calls = int(session.get("tool_call_count") or 0)
+    except (TypeError, ValueError):
+        tool_calls = 0
+    if tool_calls > 0:
+        return False
+    for msg in session.get("messages") or []:
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and msg.get("finish_reason") == "incomplete"
+        ):
+            return True
+    return False
+
+
+def _retry_episode_on_incomplete(
+    run_fn: Callable[[], "_EpisodeResult"],
+    *,
+    max_retries: int,
+    backoff_base_s: float,
+    backoff_factor: float,
+    still_current: Optional[Callable[[], bool]] = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    log: Optional[logging.Logger] = None,
+    label: str = "",
+) -> "_EpisodeResult":
+    """Run an episode, retrying with incremental backoff while it comes
+    back infra-incomplete (see ``_episode_incomplete_no_progress``).
+
+    hermes' in-container retry fires ~6 LLM calls in ~1.3s — far too fast
+    to outlast a multi-minute provider rate-limit window. This re-runs the
+    whole scenario after a growing sleep (``base * factor**attempt``), so a
+    transient window can pass before the agent's real score is recorded
+    instead of a poisoned 0.
+
+    The backoff is gated on ``still_current``: if the epoch advances during
+    a sleep, retrying is pointless (the submission would 409) so we stop
+    and return what we have.
+    """
+    ep = run_fn()
+    attempt = 0
+    while attempt < max_retries and _episode_incomplete_no_progress(ep):
+        if still_current is not None and not still_current():
+            break
+        sleep_s = backoff_base_s * (backoff_factor ** attempt)
+        if log is not None:
+            log.warning(
+                "%s infra-incomplete (clean exit, no tool call, "
+                "finish_reason=incomplete); retry %d/%d after %.0fs backoff",
+                label, attempt + 1, max_retries, sleep_s,
+            )
+        sleep_fn(sleep_s)
+        if still_current is not None and not still_current():
+            break
+        attempt += 1
+        ep = run_fn()
+    return ep
+
+
 # ---------------------------------------------------------------------------
 # Harness
 # ---------------------------------------------------------------------------
@@ -1263,7 +1373,8 @@ class TrajectorySandboxHarness:
 
                     spec = scenario_specs[cell_index]
                     fut = pool.submit(
-                        self._run_episode,
+                        self._run_episode_with_retry,
+                        still_current=_check_still_current,
                         session_id=session_id,
                         episode_index=cell_index,
                         skill_md=skill_md,
@@ -1369,6 +1480,30 @@ class TrajectorySandboxHarness:
 
         session_result.compute_scores()
         return session_result
+
+    def _run_episode_with_retry(
+        self,
+        *,
+        still_current: Optional[Callable[[], bool]] = None,
+        **episode_kwargs,
+    ) -> _EpisodeResult:
+        """Worker entrypoint: run a scenario, retrying with incremental
+        backoff while it returns infra-incomplete (clean exit, no tool
+        call, ``finish_reason=incomplete`` — a testee-LLM truncation, not
+        a miner signal). See ``_retry_episode_on_incomplete`` and the
+        ``scenario_incomplete_*`` config knobs.
+        """
+        spec = episode_kwargs.get("spec") or {}
+        label = f"[{episode_kwargs.get('session_id')}] {spec.get('name', '?')}"
+        return _retry_episode_on_incomplete(
+            lambda: self._run_episode(**episode_kwargs),
+            max_retries=self.config.scenario_incomplete_max_retries,
+            backoff_base_s=self.config.scenario_incomplete_backoff_base_s,
+            backoff_factor=self.config.scenario_incomplete_backoff_factor,
+            still_current=still_current,
+            log=logger,
+            label=label,
+        )
 
     def _run_episode(
         self,


### PR DESCRIPTION
## Problem (observed at epoch 2030)

Replaying epoch 2030 from `eval_log_scenario_summaries` + the GCS per-episode logs: the testee model (`qwen/qwen3.5-35b-a3b`, via OpenRouter) intermittently returned **degenerate completions** on fresh sessions — reasoning only, **no `content`, no tool call, ~0 billed output** — which hermes records in `turns.jsonl` as `finish_reason=incomplete`. The agent therefore never issued a tool call, never wrote its output file, and the verifier scored a `0`.

- The affected scenarios (regex-chess / swe-bench-astropy-2 / write-compressor / race-condition-fix) are the last cells dispatched, so they were the ones running when the window hit → **every validator scored them `0` except GyrMS (74)**, whose separate LLM key stayed healthy and completed all 9 (regex-chess actually ran ~12 min / 47K chars there). This confirms it is **per-key**, not a global outage, and not an image/pack problem.
- These `0`s slipped past `_looks_like_provider_failure` (it is all-or-nothing: earlier scenarios billed cost and `chat_exit==0`), got POSTed to consensus, and were then amplified by the spec-16 Winsorized seating (the one correct non-zero from 74 is clipped as an outlier).
- hermes' in-container retry (`api_call_count=6` in ~1.3s) is far too fast to outlast a multi-minute degradation window.

**Root cause (prior investigation, PR #276):** OpenRouter load-balances this model across providers; the degenerate completions concentrate on one bad provider (Parasail) while others (e.g. Alibaba) serve fine in the same window. The primary mitigation is at the OpenRouter routing layer (route `ignore` the bad provider). This PR is the **defense-in-depth** complement at the harness layer.

## Change

Scenario-level retry with incremental backoff, so a transient window can pass before the real score is recorded instead of a poisoned `0`:

- **`_episode_incomplete_no_progress(ep)`** — detects the infra signature: clean hermes exit (`chat_exit in {0, None}`), not `timed_out`, `tool_call_count == 0`, and an assistant turn with `finish_reason == "incomplete"`. Distinguished from a real miner `0` (`tool_call_count > 0`, or a clean `finish_reason=stop`) and from a genuine timeout (did real work then hit the deadline).
- **`_retry_episode_on_incomplete(run_fn, ...)`** — re-runs the scenario after `base * factor**attempt` backoff while it stays infra-incomplete, gated on `is_epoch_still_current` so short dynamic epochs bail early instead of stalling.
- Wired into the parallel dispatcher via **`_run_episode_with_retry`**.
- **Config knobs** (`ValidatorConfig`): `scenario_incomplete_max_retries=3`, `backoff_base_s=20.0`, `backoff_factor=3.0` → sleeps of 20 / 60 / 180s (~260s max cumulative backoff, sized to the observed window). `max_retries=0` disables.

**Max wait:** if all retries fail, ~4 attempts (~40s) + backoff (260s) ≈ ~5 min before giving up; if it recovers mid-way it only waits up to that retry, then runs the scenario for real. Failed attempts return in ~10s, so the cost is bounded.

## Tests (TDD)

- Predicate: infra-incomplete ✅ / real `0` with tool calls ❌ / timeout ❌ / `chat_exit!=0` ❌ / clean `stop` ❌ / empty log ❌
- Retry loop: stops on success / exhausts retries / no retry on first success / stops when the epoch moved on (asserts backoff steps `[20, 60, 180]`)
- Dispatcher integration: `_run_eval_sync` re-runs an infra-incomplete scenario and records the recovered score

`tests/test_sandbox_harness.py`: 100 passed (+11). The 5 `TestSleepUntilNextEpoch` failures in `test_validator.py` are **pre-existing on main** and unrelated to this PR.

## Relationship to PR #276 / follow-ups

PR #276 took the **discard** approach (extend `_looks_like_provider_failure` to drop degenerate sessions). This PR takes the **retry** approach instead — recover the real score rather than abstain. They are complementary; the upstream fix remains routing the bad provider out at OpenRouter.

Not included (deliberately): broadening the predicate beyond `finish_reason==incomplete`, and discarding/abstaining after retries are exhausted (touches the consensus scoring policy — separate decision). `_episode_incomplete_no_progress` is a reusable primitive for that.

> Note: the `tool_call_count==0` signal has a known second cause — a hermes sessions-export bug that zeroes it on HEALTHY high-output-token sessions (`path-tracing` / `write-compressor`). This predicate sidesteps that because it additionally requires an assistant `finish_reason==incomplete` turn, which those export-bugged sessions (message log dropped) do not carry. Any future broadening to a pure `tool_call_count` signal must add an `output_tokens` floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
