### PR TITLE
SPEC=17: activate git-leak-recovery + kv-store-grpc scenarios

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 16
+SPEC_NUMBER = 17
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -59,6 +59,8 @@ logger = logging.getLogger(__name__)
 SANDBOX_SCENARIOS: tuple[str, ...] = (
     "configure-git-webserver",
     "db-wal-recovery",
+    "git-leak-recovery",
+    "kv-store-grpc",
     "largest-eigenval",
     "nginx-request-logging",
     "path-tracing",
@@ -99,6 +101,12 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
 # continuity — that is exactly what the SPEC_NUMBER bump signals: SPEC
 # 16 scores are not comparable with SPEC ≤15, the seat is re-competed
 # from a clean start, and the score surface tightens to performance only.
+#
+# SPEC 17 adds two real scenarios — git-leak-recovery + kv-store-grpc
+# (adapted from terminal-bench-2) — so N goes 9→11 and the score range
+# becomes [0, 11]. The offset stays 0.0 (these are real scenarios, not
+# phantom refills). Requires trajrl-bench >= 4.0.13, which ships the new
+# scenario images; older bench images will report "unknown scenario".
 REMOVED_SCENARIO_BASE_SCORE: float = 0.0
 
 


### PR DESCRIPTION
## Summary
Activates two new terminal-bench-2-derived scenarios in `SANDBOX_SCENARIOS` (added to trajrl-bench in trajectoryRL/trajrl-bench#63):

- **git-leak-recovery** — recover a leaked secret from unreachable git objects and purge it from history (`reflog expire` + `gc --prune`).
- **kv-store-grpc** — implement + run a gRPC key-value store from a proto spec.

Changes:
- `SANDBOX_SCENARIOS`: 9 → 11 (alphabetical insert).
- `SPEC_NUMBER`: 16 → 17 (scenario set changed → cached scores invalidate; seat re-competed from a clean start).
- `REMOVED_SCENARIO_BASE_SCORE`: stays `0.0` (real scenarios, not phantom refills). Score range becomes `[0, 11]`.

## ⚠️ Release ordering (hard dependency)
**Do not tag/release this validator build until trajrl-bench >= 4.0.13 is published on GHCR** (the image that ships these scenario files). Otherwise the per-scenario `cli scenario-info` probe fails with `unknown scenario: git-leak-recovery` and evals break. Order: merge bench scenario PR (#63) → merge bench version bump → bench image publishes → then release this.

## Note on discrimination
Both scenarios are well-formed and verified end-to-end (gold solutions pass; no-op/partial score low), but **the current Qwen3.5-35B-A3B testee solves both vanilla** (git-leak-recovery 6/6, kv-store-grpc 7/7 with only a generic skill). They will not discriminate competitive packs at the current testee strength and may saturate like prior dropped scenarios — adding per the owner's call to grow the library/rotation. (Full empirical writeup in the session notes.)

## Tests
`tests/test_sandbox_harness.py` scoring tests pass. One pre-existing failure (`test_env_var_clamps_to_at_least_one`, concurrency clamping) is unrelated and also red on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)