### PR TITLE
[coding-agent] trigger validator build on VERSION change

### DIFF
--- a/.github/workflows/build-validator.yml
+++ b/.github/workflows/build-validator.yml
@@ -24,6 +24,7 @@ on:
       - "trajectoryrl/**"
       - "docker/**"
       - "pyproject.toml"
+      - "VERSION"
       - ".github/workflows/**"
     tags:
       - "v*"


### PR DESCRIPTION
## Why

A push to `staging` that only bumps `VERSION` did not trigger **Build Validator Image** — the push trigger's `paths` filter doesn't include `VERSION`, so the run was filtered out.

`VERSION` is meaningful to the image, though:
- `docker/Dockerfile.validator` does `COPY pyproject.toml requirements.txt VERSION ./`
- `trajectoryrl/__init__.py` reads it at runtime as `__version__`

So a version bump changes what the built image reports and should produce a fresh image.

## Change

Add `VERSION` to the `staging` push `paths` filter so version bumps rebuild the validator image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)