### PR TITLE
feat: add schemelike-metacircular-eval to scenario set (SPEC 18→19)

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 18
+SPEC_NUMBER = 19
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -67,6 +67,7 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
     "path-tracing",
     "race-condition-fix",
     "regex-chess",
+    "schemelike-metacircular-eval",
     "swe-bench-astropy-2",
     "write-compressor",
 )
@@ -419,7 +420,7 @@ class _SessionResult:
         SPEC 16 B=0, so the range is [0, N] (perfect = N = 9); the
         prior "headline max stays 11" continuity was deliberately
         dropped at the SPEC 16 bump (see the constant's docstring).
-        (N grows as scenarios are added — currently 12.)
+        (N grows as scenarios are added — currently 13.)
         Mean quality (sum/N, no offset) is the [0, 1] convenience aggregate.
 
         Rationale (Ning, 2026-05-04): equal weight per scenario, no


### PR DESCRIPTION
## What

Adds `schemelike-metacircular-eval` to the active set:
- `SANDBOX_SCENARIOS` 12 → 13 (inserted alphabetically).
- `SPEC_NUMBER` 18 → 19.

Scenario content + image live in trajrl-bench (#67; adapted from terminal-bench-2, Apache-2.0).

## ⚠️ Draft — stacked, merge order (hard dependency)

Stacked on **#287** (the git-multibranch SPEC bump); retarget to `main` once #287 merges. Activates the scenario on the **live SN11 scoring surface**, so it must land **after** its image is published:

1. trajrl-bench **#67** (scenario files) → **#68** (bump → 4.0.15, publishes `scenario-schemelike-metacircular-eval`).
2. **Then** this PR — validators auto-pull the new image. Merging before the image exists would break validators bumping to SPEC 19.

> Also pending: a vanilla-SKILL baseline with the real testee (Qwen3.5-35B-A3B) to confirm the difficulty band before activation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)