### PR TITLE
feat(spec): dynamic per-epoch spec selection from /epoch/current

### DIFF
--- a/tests/test_spec_registry.py
+++ b/tests/test_spec_registry.py
@@ -1,0 +1,87 @@
+"""Guards for the per-spec scenario registry (dynamic-spec selection).
+
+The validator resolves which scenario set to eval from the server-provided
+``epoch.spec_number`` (GET /epoch/current, driven by the web spec_schedule),
+looking it up in ``SPEC_SCENARIOS``. These tests pin that registry to a
+checked-in snapshot so it can't silently drift from the web's
+``SCORING_BY_SPEC`` (trajectoryrl.web/src/lib/scenario-spec.ts) — a divergence
+would make validators eval a different set than the web assumes.
+"""
+from trajectoryrl.utils import config
+from trajectoryrl.utils.sandbox_harness import (
+    SPEC_SCENARIOS,
+    SANDBOX_SCENARIOS,
+    LATEST_SPEC,
+    scenarios_for_spec,
+    _all_known_scenarios,
+)
+
+# MUST match the web's SCORING_BY_SPEC[*].scenarios exactly.
+EXPECTED_SPEC_SCENARIOS = {
+    17: (
+        "configure-git-webserver",
+        "db-wal-recovery",
+        "git-leak-recovery",
+        "kv-store-grpc",
+        "largest-eigenval",
+        "nginx-request-logging",
+        "path-tracing",
+        "race-condition-fix",
+        "regex-chess",
+        "swe-bench-astropy-2",
+        "write-compressor",
+    ),
+    18: (
+        "configure-git-webserver",
+        "db-wal-recovery",
+        "git-leak-recovery",
+        "git-multibranch",
+        "largest-eigenval",
+        "nginx-request-logging",
+        "path-tracing",
+        "race-condition-fix",
+        "regex-chess",
+        "schemelike-metacircular-eval",
+        "swe-bench-astropy-2",
+        "write-compressor",
+    ),
+}
+
+
+def test_registry_matches_snapshot():
+    """Sync guard vs. the web SCORING_BY_SPEC snapshot."""
+    assert SPEC_SCENARIOS == EXPECTED_SPEC_SCENARIOS
+
+
+def test_spec_number_is_max_known():
+    """config.SPEC_NUMBER is the build's max-known spec (fallback when the
+    server omits epoch.spec_number). It cannot import the registry, so this
+    test enforces the invariant instead."""
+    assert config.SPEC_NUMBER == LATEST_SPEC == max(SPEC_SCENARIOS)
+
+
+def test_scenarios_for_spec_resolves_known():
+    assert scenarios_for_spec(17) == EXPECTED_SPEC_SCENARIOS[17]
+    assert scenarios_for_spec(18) == EXPECTED_SPEC_SCENARIOS[18]
+
+
+def test_scenarios_for_spec_unknown_returns_none():
+    # Server ahead of this build → eval loop abstains (no submission).
+    assert scenarios_for_spec(999) is None
+
+
+def test_sandbox_scenarios_alias_is_latest():
+    assert SANDBOX_SCENARIOS == SPEC_SCENARIOS[LATEST_SPEC]
+
+
+def test_each_spec_set_is_sorted_and_unique():
+    for spec, names in SPEC_SCENARIOS.items():
+        assert list(names) == sorted(names), f"spec {spec} not alphabetically sorted"
+        assert len(set(names)) == len(names), f"spec {spec} has duplicate scenarios"
+
+
+def test_all_known_scenarios_is_sorted_union():
+    union = set()
+    for names in SPEC_SCENARIOS.values():
+        union |= set(names)
+    assert list(_all_known_scenarios()) == sorted(union)

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -34,7 +34,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import bittensor as bt
 
 from ..utils.config import ValidatorConfig
-from ..utils.sandbox_harness import TrajectorySandboxHarness
+from ..utils.sandbox_harness import (
+    TrajectorySandboxHarness,
+    scenarios_for_spec,
+    LATEST_SPEC,
+)
 from ..utils.github import PackFetcher
 from ..utils import config as _config_mod
 from ..utils.commitments import MinerCommitment
@@ -801,6 +805,8 @@ class TrajectoryValidator:
         self,
         commitment: MinerCommitment,
         challenge_epoch_id: int,
+        spec: int,
+        scenarios: tuple,
     ) -> Optional[Dict[str, Any]]:
         """Run a single trajrl-bench evaluation on the active challenger."""
         mlog = self._get_miner_logger(commitment.hotkey)
@@ -840,7 +846,7 @@ class TrajectoryValidator:
                 cost_usd=cost_usd,
                 duration_s=duration_s,
                 timed_out=timed_out,
-                spec_number=_spec_number(),
+                spec_number=spec,
                 harness_name=self._sandbox_harness.harness_name,
                 harness_version=self._sandbox_harness.harness_version,
                 llm_model=self.config.llm_model,
@@ -892,6 +898,7 @@ class TrajectoryValidator:
             commitment=commitment,
             epoch_seed=self._challenge_seed(challenge_epoch_id, self.config.netuid),
             validator_salt=self._default_validator_salt(),
+            scenarios=scenarios,
             mlog=mlog,
             on_episode_start=on_episode_start,
             on_episode_verifying=on_episode_verifying,
@@ -1036,7 +1043,31 @@ class TrajectoryValidator:
             )
             return
 
-        await self._score_challenger(challenge_epoch_id, commitment)
+        # Resolve the active scoring spec for this epoch. The server dictates
+        # it (epoch.spec_number, resolved from the web spec_schedule), so the
+        # validator auto-switches scenario sets at the scheduled cutover epoch
+        # with no redeploy. Fall back to this build's max-known spec when the
+        # field is absent (older web). If the server's spec is newer than this
+        # build knows, abstain — operators must upgrade before the schedule's
+        # effective_epoch; a stale-spec submission is dropped by the web spec
+        # floor anyway.
+        try:
+            spec = int(epoch.get("spec_number", LATEST_SPEC))
+        except (TypeError, ValueError):
+            spec = LATEST_SPEC
+        scenarios = scenarios_for_spec(spec)
+        if scenarios is None:
+            logger.error(
+                "epoch %d requires spec %d but this validator build only "
+                "knows up to spec %d — upgrade the validator. Abstaining "
+                "(no submission) until then.",
+                challenge_epoch_id, spec, LATEST_SPEC,
+            )
+            return
+
+        await self._score_challenger(
+            challenge_epoch_id, commitment, spec, scenarios,
+        )
 
     async def _refresh_winner_cache(self):
         """Pull /api/v2/winner/current, run local derivation, persist cache."""
@@ -1053,6 +1084,7 @@ class TrajectoryValidator:
 
     async def _score_challenger(
         self, challenge_epoch_id: int, commitment: MinerCommitment,
+        spec: int, scenarios: tuple,
     ):
         eval_id = (
             datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
@@ -1074,7 +1106,9 @@ class TrajectoryValidator:
             eval_id, commitment.hotkey,
         )
 
-        eval_result = await self._evaluate_challenger(commitment, challenge_epoch_id)
+        eval_result = await self._evaluate_challenger(
+            commitment, challenge_epoch_id, spec, scenarios,
+        )
 
         # Harness aborted mid-session because the epoch had moved on.
         # Drop the eval entirely — POSTing the partial sum would punish
@@ -1138,7 +1172,7 @@ class TrajectoryValidator:
             rejected=rejected if rejected else None,
             rejection_detail=rejection_detail if rejected else None,
             scenario_results=scenario_results or None,
-            spec_number=_spec_number(),
+            spec_number=spec,
             llm_base_url=self.config.llm_base_url,
             llm_model=self.config.llm_model,
             judge_model=self.config.judge_model or None,

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,6 +41,14 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
+#
+# With the dynamic-spec field on GET /epoch/current, the *active* spec for
+# an epoch comes from the server (epoch.spec_number, resolved from the web
+# spec_schedule). SPEC_NUMBER is now this build's MAX-KNOWN spec: it must
+# equal ``max(sandbox_harness.SPEC_SCENARIOS)`` (enforced by a test), and it
+# is the fallback the validator uses only when the server omits the field
+# (older web). It cannot import the registry (sandbox_harness imports this
+# module), so it is kept in sync manually + by test.
 SPEC_NUMBER = 18
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be

--- a/trajectoryrl/utils/miner_eval.py
+++ b/trajectoryrl/utils/miner_eval.py
@@ -77,6 +77,7 @@ async def evaluate_miner_s1(
     commitment: MinerCommitment,
     epoch_seed: int,
     validator_salt: str = "",
+    scenarios: Optional[tuple[str, ...]] = None,
     mlog: Optional[logging.Logger] = None,
     on_episode_start: Optional[Callable[[str, int, int], None]] = None,
     on_episode_verifying: Optional[Callable[[str, int, int], None]] = None,
@@ -173,9 +174,13 @@ async def evaluate_miner_s1(
             skip_reason=SKIP_EMPTY_SKILL_MD,
         )
 
+    # Scenario set for the epoch's active spec (resolved upstream from
+    # epoch.spec_number). Falls back to the harness default when omitted.
+    eval_scenarios = tuple(scenarios) if scenarios else tuple(harness.sandbox_scenarios)
+
     log.info(
         "S1 evaluation: %d scenarios, skill_md=%d chars",
-        len(harness.sandbox_scenarios), len(skill_md),
+        len(eval_scenarios), len(skill_md),
     )
 
     # Step 2: Run trajrl-bench sandbox evaluation
@@ -185,6 +190,7 @@ async def evaluate_miner_s1(
             epoch_seed=epoch_seed,
             pack_hash=commitment.pack_hash,
             validator_salt=validator_salt,
+            scenarios=eval_scenarios,
             on_episode_start=on_episode_start,
             on_episode_verifying=on_episode_verifying,
             on_episode_done=on_episode_done,
@@ -211,7 +217,7 @@ async def evaluate_miner_s1(
         log.info(
             "S1 evaluation aborted mid-session: epoch moved on after "
             "%d/%d scenarios; discarding partial result",
-            len(result.scenarios), len(harness.sandbox_scenarios),
+            len(result.scenarios), len(eval_scenarios),
         )
         return MinerEvalOutcome(
             success=False,

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -52,24 +52,86 @@ from ..utils.config import ValidatorConfig
 logger = logging.getLogger(__name__)
 
 
-# Scenarios run per session, in order. Every validator runs the full set
-# so scores are comparable across validators / windows / SPEC_NUMBER
-# bumps. Adding or removing a scenario must come with a SPEC_NUMBER bump
-# so cached scores invalidate. Sorted alphabetically for stability.
-SANDBOX_SCENARIOS: tuple[str, ...] = (
-    "configure-git-webserver",
-    "db-wal-recovery",
-    "git-leak-recovery",
-    "git-multibranch",
-    "largest-eigenval",
-    "nginx-request-logging",
-    "path-tracing",
-    "race-condition-fix",
-    "regex-chess",
-    "schemelike-metacircular-eval",
-    "swe-bench-astropy-2",
-    "write-compressor",
-)
+# Per-spec scenario sets. Every validator runs the full set for the
+# *active spec*, so scores are comparable across validators within a spec.
+# The active spec for an epoch is dictated by the server (GET /epoch/current
+# → epoch.spec_number, resolved from the web spec_schedule), so a build that
+# ships multiple specs auto-switches at the scheduled cutover epoch with no
+# coordinated redeploy. Each set is sorted alphabetically for stability.
+#
+# KEEP IN SYNC with the web's SCORING_BY_SPEC in
+# trajectoryrl.web/src/lib/scenario-spec.ts — the two are hand-maintained
+# copies of the same per-spec scenario definition (a divergence would make
+# validators eval a different set than the web assumes). The
+# test_spec_registry test asserts this build's registry matches a
+# checked-in snapshot.
+SPEC_SCENARIOS: dict[int, tuple[str, ...]] = {
+    17: (
+        "configure-git-webserver",
+        "db-wal-recovery",
+        "git-leak-recovery",
+        "kv-store-grpc",
+        "largest-eigenval",
+        "nginx-request-logging",
+        "path-tracing",
+        "race-condition-fix",
+        "regex-chess",
+        "swe-bench-astropy-2",
+        "write-compressor",
+    ),
+    18: (
+        "configure-git-webserver",
+        "db-wal-recovery",
+        "git-leak-recovery",
+        "git-multibranch",
+        "largest-eigenval",
+        "nginx-request-logging",
+        "path-tracing",
+        "race-condition-fix",
+        "regex-chess",
+        "schemelike-metacircular-eval",
+        "swe-bench-astropy-2",
+        "write-compressor",
+    ),
+}
+
+# Per-spec headline-score offset. The web applies the offset at ingest
+# (normalizeIncomingScore); validators submit RAW Σ-per-scenario quality.
+# Kept here for parity and so compute_scores can stay offset-free.
+SPEC_REMOVED_BASE: dict[int, float] = {17: 0.0, 18: 0.0}
+
+# Latest spec this build knows. Fallback when the server omits
+# epoch.spec_number (older web that predates the dynamic-spec field).
+LATEST_SPEC: int = max(SPEC_SCENARIOS)
+
+
+def scenarios_for_spec(spec: int) -> tuple[str, ...] | None:
+    """Scenario set for ``spec``, or ``None`` if this build doesn't know it.
+
+    ``None`` means the server is ahead of this validator's build — the
+    operator must upgrade before the schedule's ``effective_epoch``. The
+    eval loop skips the epoch in that case (a stale-spec submission would
+    be dropped by the web ``requiredSpecForEpoch`` floor anyway).
+    """
+    return SPEC_SCENARIOS.get(spec)
+
+
+def _all_known_scenarios() -> tuple[str, ...]:
+    """Sorted union of every scenario across all specs this build knows.
+
+    The validator pre-pulls this whole set so whichever spec the server
+    selects for an epoch already has its images cached — the cutover needs
+    no extra pull.
+    """
+    seen: set[str] = set()
+    for names in SPEC_SCENARIOS.values():
+        seen.update(names)
+    return tuple(sorted(seen))
+
+
+# Back-compat alias for code paths that still want "the active set" as a
+# single value. The eval path resolves per-epoch via scenarios_for_spec().
+SANDBOX_SCENARIOS: tuple[str, ...] = SPEC_SCENARIOS[LATEST_SPEC]
 
 # Headline-score offset for scenarios that have been retired from the
 # rotation. When we drop saturated scenarios (mean score ≥ ~0.8 in the
@@ -114,7 +176,11 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
 # git-multibranch + schemelike-metacircular-eval, so N goes 11→12 and the
 # score range becomes [0, 12]. The offset stays 0.0. Requires trajrl-bench
 # >= 4.0.14, which ships the new scenario images.
-REMOVED_SCENARIO_BASE_SCORE: float = 0.0
+#
+# Per-spec offsets now live in SPEC_REMOVED_BASE; this back-compat constant
+# tracks the latest spec's offset (0.0). Validators submit raw scores and
+# the web applies the offset at ingest, so this is effectively dead today.
+REMOVED_SCENARIO_BASE_SCORE: float = SPEC_REMOVED_BASE[LATEST_SPEC]
 
 
 # ---------------------------------------------------------------------------
@@ -1027,11 +1093,13 @@ class TrajectorySandboxHarness:
         except Exception as e:
             logger.warning("Failed to query sandbox version: %s", e)
 
-        # Pull the per-scenario environment images for every scenario
-        # this validator runs. ``scenario_image_hashes`` keys each one
-        # for audit / submit-payload metadata.
+        # Pull the per-scenario environment images for every scenario this
+        # validator could run — the UNION across all specs in SPEC_SCENARIOS
+        # — so whichever spec the server selects for an epoch is already
+        # cached and the cutover needs no extra pull.
+        # ``scenario_image_hashes`` keys each one for audit / submit metadata.
         self.scenario_image_hashes = {}
-        for scenario_name in SANDBOX_SCENARIOS:
+        for scenario_name in _all_known_scenarios():
             try:
                 self._scenario_info = None  # force re-fetch per scenario
                 self._load_scenario_info(scenario_name)
@@ -1128,6 +1196,7 @@ class TrajectorySandboxHarness:
         epoch_seed: int,
         pack_hash: str = "",
         validator_salt: str = "",
+        scenarios: Optional[tuple[str, ...]] = None,
         on_episode_start: Optional[Callable[[str, int, int], None]] = None,
         on_episode_verifying: Optional[Callable[[str, int, int], None]] = None,
         on_episode_done: Optional[Callable[[_EpisodeResult, int, int], None]] = None,
@@ -1163,10 +1232,15 @@ class TrajectorySandboxHarness:
             f"{self.config.wallet_hotkey}:{self.config.netuid}".encode()
         ).hexdigest()[:16]
 
+        # The active scenario set for this epoch's spec (resolved by the
+        # caller from epoch.spec_number). Defaults to the build's latest set
+        # for callers that don't pass one (back-compat / tests).
+        scenarios = tuple(scenarios) if scenarios else SANDBOX_SCENARIOS
+
         logger.info(
             "eval starting: pack_hash=%s, seed=%d, scenarios=%s",
             pack_hash[:12] if pack_hash else "?",
-            epoch_seed, list(SANDBOX_SCENARIOS),
+            epoch_seed, list(scenarios),
         )
 
         loop = asyncio.get_event_loop()
@@ -1174,6 +1248,7 @@ class TrajectorySandboxHarness:
             session_result = await loop.run_in_executor(
                 None, lambda: self._run_eval_sync(
                     skill_md, epoch_seed, salt, pack_hash,
+                    scenarios=scenarios,
                     on_episode_start=on_episode_start,
                     on_episode_verifying=on_episode_verifying,
                     on_episode_done=on_episode_done,
@@ -1196,6 +1271,7 @@ class TrajectorySandboxHarness:
 
     def _run_eval_sync(
         self, skill_md: str, epoch_seed: int, salt: str, pack_hash: str,
+        scenarios: Optional[tuple[str, ...]] = None,
         on_episode_start: Optional[Callable[[str, int, int], None]] = None,
         on_episode_verifying: Optional[Callable[[str, int, int], None]] = None,
         on_episode_done: Optional[Callable[[_EpisodeResult, int, int], None]] = None,
@@ -1237,8 +1313,9 @@ class TrajectorySandboxHarness:
         # Pre-load metadata for every scenario so we fail early on a
         # missing one. Each ``_load_scenario_info`` call also primes the
         # per-scenario image ref + tests payload.
+        scenarios = tuple(scenarios) if scenarios else SANDBOX_SCENARIOS
         scenario_specs: list[dict] = []
-        for name in SANDBOX_SCENARIOS:
+        for name in scenarios:
             self._scenario_info = None  # bust cache; loop reads each
             info = self._load_scenario_info(name)
             scenario_image = self._scenario_image_ref()


### PR DESCRIPTION
## What

Validators resolve which scenario set to eval from the server's `epoch.spec_number` (GET /epoch/current, driven by the web `spec_schedule`) instead of a single hardcoded `SANDBOX_SCENARIOS`. A build that ships multiple specs **auto-switches at the scheduled cutover epoch with no coordinated redeploy**.

Pairs with web PR `spec-on-epoch-current` (which adds the field).

## Changes

- **`sandbox_harness.py`**: `SPEC_SCENARIOS` registry `{17: 11-set, 18: 12-set}` + `scenarios_for_spec()` + `_all_known_scenarios()`. `SANDBOX_SCENARIOS` kept as a back-compat alias = latest. `_pull_sync` pre-pulls the **union** so any schedulable spec's images are cached. `evaluate_miner`/`_run_eval_sync` take a `scenarios` param (default = latest).
- **`miner_eval.py`**: `evaluate_miner_s1` threads `scenarios` to the harness.
- **`validator.py`**: `_eval_loop_tick` reads `epoch.spec_number` (fallback: build max-known `LATEST_SPEC`), resolves the set, and **abstains** if the server's spec is newer than this build knows (a stale-spec submission is dropped by the web spec floor anyway). The resolved spec is stamped on the score submission + live progress posts.
- **`config.py`**: `SPEC_NUMBER` is now the build's max-known spec (`== max(SPEC_SCENARIOS)`, enforced by test), used only as the fallback when the server omits the field.
- **`tests/test_spec_registry.py`**: pins the registry to a snapshot that must stay in sync with the web `SCORING_BY_SPEC` (the divergence guard).

## Verification

`py_compile` clean; registry validated against the snapshot (17=11 w/ kv-store, 18=12 w/ git-multibranch+schemelike). The full harness suite needs the `docker` SDK (CI) — not runnable in this sandbox. Existing tests monkeypatch the module global / mock `_pull_sync`, so the `scenarios`-default + union changes stay compatible.

## ⚠️ Base / merge order

Based on **#287** (`spec-18-git-multibranch`) since the registry's spec-18 set is the set #287 introduces. **Merge #287 first**, then retarget this to `main`. Keep `SPEC_SCENARIOS[*]` in sync with the web `SCORING_BY_SPEC`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)