### PR TITLE
feat(fee): seated winner takes 100% — drop standing 75% emission burn

### DIFF
--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -74,7 +74,6 @@ def _spec_number() -> int:
 logger = logging.getLogger(__name__)
 
 OWNER_UID = 74
-BURN_FRACTION = 0.75  # 75% of miner emissions burned via owner UID
 
 _METAGRAPH_SYNC_RETRIES = 3
 _METAGRAPH_SYNC_DELAY = 10  # seconds between retries
@@ -1290,12 +1289,12 @@ class TrajectoryValidator:
             await self._set_fallback_weights(reason="No winner in cache")
             return
 
-        if winner_uid == OWNER_UID:
-            uids = [OWNER_UID]
-            weights = [1.0]
-        else:
-            uids = [winner_uid, OWNER_UID]
-            weights = [1.0 - BURN_FRACTION, BURN_FRACTION]
+        # Seated winner takes 100% of miner alpha. There is no standing burn —
+        # the submission fee (recycle_alpha) is now the economic mechanism.
+        # (The no-winner path still burns to the owner UID via
+        # _set_fallback_weights / _set_burn_weights.)
+        uids = [winner_uid]
+        weights = [1.0]
 
         await self._do_set_weights(
             uids, weights,


### PR DESCRIPTION
## Summary

Removes the standing **75% emission burn** so a seated winner takes **100%** of miner alpha. Previously `_set_winner_weights` assigned `[winner: 25%, owner: 75%]` (`BURN_FRACTION = 0.75`) on every tempo — even with a valid winner, 75% of the miner emission was burned to the owner UID.

This aligns the code with `INCENTIVE_MECHANISM.md`, which already states *"the seated winner takes 100% of miner alpha"* — the code and doc were in conflict.

## Change

`trajectoryrl/base/validator.py`:
- Drop the `BURN_FRACTION = 0.75` constant.
- `_set_winner_weights`: when a winner is seated, set `weights = [1.0]` on the winner UID (no owner split).

The **no-winner** path is unchanged: `_set_fallback_weights` / `_set_burn_weights` still burn 100% to the owner UID when no seat exists (cold start, stale cache, deregistered/banned winner) — validators must always `set_weights`.

## Rationale

With the submission fee (`recycle_alpha`) now the economic mechanism / alpha sink (see the submission-fee PR), the standing winner-emission burn is no longer needed.

## Impact

⚠️ Emission-distribution change: a seated winner's share of miner alpha goes from 25% → 100% per tempo; the owner UID no longer skims 75% while a winner is seated.

## Verification

- `BURN_FRACTION` has no remaining references; no test asserted the old 0.25/0.75 split.
- Weight/winner unit tests pass (the async weight tests require `pytest-asyncio`, which the repo doesn't install — pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
