### PR TITLE
docs(miner): web-only submission + submission fee

### DIFF
--- a/docs/MINER_GUIDE.md
+++ b/docs/MINER_GUIDE.md
@@ -46,7 +46,7 @@ Season 1 requires `SKILL.md` only.
 
 - `SKILL.md` must not be empty.
 - Total pack JSON ≤ 32 KB.
-- Content-addressed: `sha256(json.dumps(pack, sort_keys=True))` matches the on-chain `pack_hash`.
+- Content-addressed: `sha256(json.dumps(pack, sort_keys=True))` matches the `pack_hash` carried in your submission.
 
 ---
 
@@ -229,17 +229,28 @@ cd trajectoryRL && pip install -e .
 
 trajectoryrl-miner build SKILL.md -o pack.json
 
-# Path B — managed web submit (recommended, no chain commit needed)
+# Pay the submission fee + submit. web-submit is the only channel: the
+# CLI recycles SUBMISSION_FEE_ALPHA (default 50) on chain via
+# recycle_alpha, then submits the pack referencing that receipt.
 trajectoryrl-miner web-submit pack.json
-
-# Path A — self-host + chain commit (alternative)
-# trajectoryrl-miner upload pack.json             # self-host on S3 / R2 / GCS
-# trajectoryrl-miner submit <pack_url>            # set_commitment on-chain
 
 trajectoryrl-miner status
 ```
 
-Path A writes the on-chain commitment `{pack_hash}|{pack_url}`; the platform's syncer ingests it into the challenger queue. Path B writes the queue entry directly via the web API and does not touch the chain. In both cases validators fetch your `pack.json`, verify the hash, extract `SKILL.md`, and run the full scenario session — pick one path, not both.
+`web-submit` is the sole submission channel: the platform stores your `pack.json`, verifies the recycle receipt, runs pre-eval, and writes the challenger-queue entry. Validators then fetch your pack, verify the hash, extract `SKILL.md`, and run the full scenario session. (On-chain `set_commitment` is no longer ingested as a submission.)
+
+---
+
+## Submission Fee
+
+Every submission is backed by an on-chain `recycle_alpha` burn, paid before the pack is accepted. Recycling is irreversible — it is the economic cost that deters spam and low-quality packs (it replaces the old owner-ban system).
+
+- **Amount** — `SUBMISSION_FEE_ALPHA` (default `50` α), signed by your **coldkey** via `recycle_alpha(hotkey, amount, netuid=11)`. Recycle at least the network fee; surplus is burned too, too little is rejected.
+- **Receipt** — the CLI passes the recycle's `(block, extrinsic_index)` with the submission; the server verifies it on chain (your hotkey, `amount ≥ fee`, within 24 h) before queuing the pack.
+- **Reuse** — the fee is consumed only once your pack enters the eval queue. A submission that fails a technical check (bad format, duplicate, similarity, …) does not consume the receipt, so the same recycle can back another submission within its 24 h window. Re-submitting the same `pack_hash` that already failed terminally does not re-evaluate it.
+- **Cooldown** — one submission per hotkey every ~20 min (server-enforced, `MINER_SUBMIT_COOLDOWN_SECONDS`), on top of the fee.
+
+Set the amount in `.env.miner` (`SUBMISSION_FEE_ALPHA=50`) or inline; full reference in [MINER_OPERATIONS.md](MINER_OPERATIONS.md).
 
 ---
 
@@ -297,4 +308,4 @@ A: The schema permits multiple files in `files`, but Season 1 only reads `SKILL.
 A: Pack rejected at schema validation.
 
 **Q: How often can I resubmit?**
-A: Self-hosted (`upload` + `submit`): chain-side rate limit (~100 blocks ≈ 20 min between commits). Managed (`web-submit`): one successful submission per hour per hotkey (server cooldown). Web-submitted packs do not require a follow-up on-chain `submit`, so the chain rate limit does not apply on this path.
+A: One submission per hotkey every ~20 min (server cooldown, `MINER_SUBMIT_COOLDOWN_SECONDS`). Each submission also costs the `recycle_alpha` fee — see [Submission Fee](#submission-fee).

--- a/docs/MINER_OPERATIONS.md
+++ b/docs/MINER_OPERATIONS.md
@@ -13,7 +13,7 @@ Mining means writing a **SKILL.md** — a scaffold that teaches a small open-sou
 
 For each scenario, validators run the testee LLM (default: `qwen/qwen3.5-35b-a3b`) in a fresh container with your `SKILL.md` and the scenario's `INSTRUCTION.md`. The agent produces a deliverable file. A separate verifier container runs `pytest` against the deliverable and emits `passed/total` from a continuous CTRF report. Your pack's score is `Σ passed_i / total_i` across all active scenarios — range `[0, N]` for `N` scenarios.
 
-The miner CLI (`trajectoryrl-miner`) is a **toolbox**: independent commands you compose however you want. Write your SKILL.md (manually, with an LLM, with your own automation), then use the CLI to build, host, and submit.
+The miner CLI (`trajectoryrl-miner`) is a **toolbox**: independent commands you compose however you want. Write your SKILL.md (manually, with an LLM, with your own automation), then use the CLI to build and submit via the web endpoint.
 
 ---
 
@@ -24,13 +24,13 @@ The miner CLI (`trajectoryrl-miner`) is a **toolbox**: independent commands you 
 | **Bittensor wallet** | `btcli wallet create --wallet.name miner --wallet.hotkey default` |
 | **Registration** | `btcli subnet register --netuid 11 --wallet.name miner` (dynamic cost) |
 | **Python** | 3.10+ |
-| **Pack hosting** | Either self-hosted (S3 / R2 / GCS / GitHub raw / etc.) **or** managed via `/api/v2/miners/submit` (no infra needed — see "Managed hosting" below) |
+| **Alpha balance** | Enough α to cover the submission fee (`SUBMISSION_FEE_ALPHA`, default **50 α**) paid via `recycle_alpha` before each submission. No pack hosting infra needed — the platform stores your pack. |
 
 ---
 
 ## Quick Start
 
-Submission has two paths. **Option A** is three steps (build, host, on-chain commit). **Option B** is two steps (build, web-submit) — the platform handles queue admission for you, no chain commit needed.
+Submission is web-only — two steps: build, then web-submit (the platform handles queue admission; no on-chain commit needed).
 
 ```bash
 git clone https://github.com/trajectoryRL/trajectoryRL.git
@@ -41,27 +41,12 @@ vim SKILL.md
 
 # 2. Build pack
 trajectoryrl-miner build SKILL.md -o pack.json
-```
 
-Then pick **one** route below.
-
-**Option A — Self-hosted + on-chain commit**
-
-```bash
-# 3a. Upload to your own S3-compatible bucket
-trajectoryrl-miner upload pack.json
-# → prints https://your-bucket.s3.amazonaws.com/pack.json
-
-# 4a. Commit on-chain
-trajectoryrl-miner submit https://your-bucket.s3.amazonaws.com/pack.json
-```
-
-**Option B — Managed web submit (no chain commit)**
-
-```bash
-# 3b. Submit pack content to trajrl.com (managed GCS).
-#     The platform stores the pack, runs pre-eval, and admits it to
-#     the challenger queue directly. No on-chain commit needed.
+# 3. Pay the submission fee and submit.
+#    The CLI recycles SUBMISSION_FEE_ALPHA (default 50 α) on-chain via
+#    recycle_alpha, then POSTs the pack + recycle receipt to the platform.
+#    The platform stores the pack, verifies the receipt, runs pre-eval,
+#    and admits it to the challenger queue directly. No on-chain commit needed.
 trajectoryrl-miner web-submit pack.json
 # → prints pack_url + cooldown info
 ```
@@ -78,40 +63,33 @@ That's it. Repeat whenever you improve your SKILL.md.
 
 ---
 
-## Two submission paths
+## Web Submit — the sole submission channel
 
-| Path | What you operate | Where the pack lives | Eligibility event | Reveal | Use this when |
-|------|-----------------|----------------------|-------------------|--------|---------------|
-| **A. Self-host + chain commit** | An HTTP host (S3 / GCS / GH / your own server) for `pack.json` | Your bucket | `set_commitment(pack_hash \| url)` on-chain | Public on chain immediately | You already have hosting and want full control |
-| **B. Web submit (recommended for new miners)** | Just the miner CLI, no hosting | Subnet's GCS at an unguessable random key | `miner_submissions` row created by the web-submit API | URL hidden 48 h | You want the easiest path; you don't want to run hosting |
-
-The two paths are **independent and equivalent** in how they feed the challenger queue — pick one, not both. Both produce a `pending_pre_eval` row in the platform's `miner_submissions` table (chain commits via the platform's metagraph syncer; web-submit directly). The picker reads from that table; chain-source and web-source rows compete on identical terms.
-
-### Path A — chain commit (classic)
+`web-submit` is the **only** way to enter the challenger queue. On-chain `set_commitment` is **no longer ingested as a submission** (`CHAIN_SUBMIT_INGEST_ENABLED=false`).
 
 ```bash
-trajectoryrl-miner build  SKILL.md -o pack.json
-trajectoryrl-miner upload pack.json                       # to your S3/GCS
-trajectoryrl-miner submit https://your-bucket/pack.json   # set_commitment on chain
-```
-
-### Path B — web submit (preferred)
-
-```bash
-# 1. Build pack locally (same as Path A)
 trajectoryrl-miner build SKILL.md -o pack.json
-
-# 2. POST pack to the subnet's hosted submit endpoint (signed with your hotkey).
-#    The endpoint stores the pack at an unguessable random GCS path,
-#    creates the miner_submissions row, and kicks off pre-eval.
-#    No on-chain commit step is required after this.
 trajectoryrl-miner web-submit pack.json
 # → Response: { pack_url: "https://storage.googleapis.com/.../pack.json", ... }
 ```
 
-The `web-submit` endpoint immediately validates your signature, hash and pack format, kicks off pre-eval asynchronously, and returns the `pack_url`. The platform queues the pack for the next eligible challenger epoch on its own — no follow-up `set_commitment` is needed. Web-source URLs are not exposed in any other API for **48 hours** (the "reveal gate"), so a competitor can't simply scrape the dashboard to harvest your fresh SKILL.md.
+The `web-submit` command:
+1. Recycles `SUBMISSION_FEE_ALPHA` α on-chain (coldkey-signed) and captures the `(block, extrinsic_index)` receipt.
+2. POSTs the pack content + receipt to `POST /api/v2/miners/submit`, signed with your hotkey.
+3. The server verifies the signature, pack format, hash, recycle receipt, and then kicks off pre-eval asynchronously — no follow-up `set_commitment` needed.
+
+The platform queues the pack for the next eligible challenger epoch on its own. Pack URLs are not exposed in any other API for **48 hours** (the "reveal gate"), so a competitor can't scrape the dashboard to harvest your fresh SKILL.md.
 
 Full request/response spec for `/api/v2/miners/submit` is in [`trajectoryrl.web/API.md`](https://github.com/trajectoryRL/trajectoryrl.web/blob/main/API.md).
+
+## Submission Fee
+
+Every submission must be backed by an on-chain `recycle_alpha` burn. Recycling is irreversible — it is the economic cost that deters spam and low-quality packs (replaces the old owner-ban / Coldban system).
+
+- **Amount** — `SUBMISSION_FEE_ALPHA` (default **50 α**), signed by your **coldkey** via `recycle_alpha(hotkey, amount, netuid=11)`. Recycling at least the required amount; surplus is also burned. Too little is rejected.
+- **Receipt** — the CLI passes the recycle's `(block, extrinsic_index)` with the submission; the server verifies it on-chain (your hotkey, `amount ≥ fee`, within **24 h**) before queuing the pack.
+- **Reuse** — the receipt is consumed **only when the pack enters the eval queue** (`pending_eval`). A submission that fails a technical check (bad format, duplicate hash, similarity, …) does **not** consume the receipt, so the same recycle can back another submission of a different pack within its 24 h window. Re-submitting the same `pack_hash` that already failed terminally does not re-evaluate it.
+- **Cooldown** — one submission per hotkey every **~20 min** (server-enforced via `MINER_SUBMIT_COOLDOWN_SECONDS`), on top of the fee.
 
 ---
 
@@ -120,10 +98,10 @@ Full request/response spec for `/api/v2/miners/submit` is in [`trajectoryrl.web/
 ```bash
 trajectoryrl-miner build       <skill_md_path> [-o pack.json]
 trajectoryrl-miner validate    <pack.json>
-trajectoryrl-miner upload      <pack.json> [--bucket ...] [--endpoint-url ...]
 trajectoryrl-miner web-submit  <pack.json> [--api-base-url ...]
-trajectoryrl-miner submit      <pack_url>
 trajectoryrl-miner status
+trajectoryrl-miner upload      <pack.json> [--bucket ...] [--endpoint-url ...]  # legacy — upload only, not ingested as submission
+trajectoryrl-miner submit      <pack_url>                                        # legacy — on-chain commit, no longer ingested as submission
 ```
 
 ### build
@@ -152,22 +130,11 @@ Validate an existing pack.json locally (without submitting).
 trajectoryrl-miner validate pack.json
 ```
 
-### upload
-
-Upload pack.json to S3-compatible storage. Prints the public URL.
-
-```bash
-trajectoryrl-miner upload pack.json
-trajectoryrl-miner upload pack.json --bucket my-bucket --endpoint-url https://storage.googleapis.com
-```
-
-Reads S3 config from environment or CLI flags. Returns the public URL for use with `submit`.
-
 ### web-submit
 
-Submit pack content directly to the managed web service (`POST /api/v2/miners/submit`). The server stores your pack at an unguessable random GCS path, creates the `miner_submissions` row, and kicks off pre-eval. No S3 / R2 / bucket config required — the request is signed with your hotkey, so the only credential you need is the wallet itself.
+The **sole submission channel**. Recycles `SUBMISSION_FEE_ALPHA` α on-chain (coldkey-signed), then POSTs the pack + recycle receipt to `POST /api/v2/miners/submit`. The server stores your pack at an unguessable random GCS path, verifies the receipt on-chain, creates the `miner_submissions` row, and kicks off pre-eval. No S3 / R2 / bucket config required — the request is signed with your hotkey, so the only credential you need is the wallet itself and enough alpha to cover the fee.
 
-This command is **self-contained** — it does not touch the chain, and you do **not** need to follow up with `submit <pack_url>`. The platform queues the pack for evaluation on its own.
+This command is **self-contained** — you do **not** need to follow up with anything. The platform queues the pack for evaluation on its own.
 
 ```bash
 trajectoryrl-miner web-submit pack.json
@@ -179,37 +146,49 @@ Output:
 ```
 Pack hash: a3f8c2...
 Endpoint: https://trajrl.com/api/v2/miners/submit
+Recycling 50 α (fee) on-chain...
+  recycle block: 3456789  extrinsic: 2
 Submitting pack content to web service...
 Submitted! pack_url = https://storage.googleapis.com/<bucket>/<prefix>/<uid>/<random_key>.json
   submission_id:    12345
-  cooldown_seconds: 3600
-  next_upload_at:   2026-05-04T15:00:00.000Z
+  cooldown_seconds: 1200
+  next_upload_at:   2026-05-04T14:20:00.000Z
   pre_eval_status:  pending
 
 Done — the platform will pre-eval and admit your pack to the
-challenger queue automatically. No on-chain commit required for
-web-submitted packs.
+challenger queue automatically. No on-chain commit required.
 ```
 
-**Cooldown**: The endpoint enforces a per-miner cooldown (default **1 hour**, set server-side via `MINER_SUBMIT_COOLDOWN_SECONDS`). Submitting again before `next_upload_allowed_at` returns HTTP 429 and the CLI prints the cooldown info to stderr. Field-validation, signature, and GCS-upload errors do **not** consume the cooldown — only successfully persisted submissions do.
+**Cooldown**: The endpoint enforces a per-miner cooldown (default **~20 min**, set server-side via `MINER_SUBMIT_COOLDOWN_SECONDS=1200`). Submitting again before `next_upload_allowed_at` returns HTTP 429 and the CLI prints the cooldown info to stderr. Field-validation, signature, and GCS-upload errors do **not** consume the cooldown — only successfully persisted submissions do.
+
+**Submission fee**: The fee (`recycle_alpha`, coldkey-signed) is consumed only when the pack reaches `pending_eval`. A submission that fails a technical check does not consume the receipt — the same recycle can back a new submission within its 24 h window.
 
 **Idempotency**: Resubmitting the **same** `(hotkey, pack_hash)` after the cooldown lifts is safe — the server reuses the existing `pack_url` (no re-upload), so the URL you got the first time stays valid.
 
 **Hash & signing**: The CLI canonicalises the pack as `json.dumps(pack, sort_keys=True)` (matches the validator's hash convention) and signs `trajectoryrl-miner-submit:{hotkey}:{timestamp}` with sr25519. The server recomputes the hash from `pack_content` and rejects on mismatch.
 
-> **`pack_url` is sensitive until the 48 h reveal gate.** The URL is intentionally unguessable so competitors can't enumerate packs by hotkey/uid/hash. Don't paste it into Discord, public dashboards, or shared logs — leaking the URL lets other miners hash-match and chain-commit a copy of your pack.
+> **`pack_url` is sensitive until the 48 h reveal gate.** The URL is intentionally unguessable so competitors can't enumerate packs by hotkey/uid/hash. Don't paste it into Discord, public dashboards, or shared logs — leaking the URL lets other miners hash-match and submit a copy of your pack.
 
-### submit
+### upload (legacy — no longer ingested as a submission)
 
-Submit an on-chain commitment pointing to your hosted pack.
+Upload pack.json to S3-compatible storage. Prints the public URL.
+
+```bash
+trajectoryrl-miner upload pack.json
+trajectoryrl-miner upload pack.json --bucket my-bucket --endpoint-url https://storage.googleapis.com
+```
+
+Reads S3 config from environment or CLI flags. Returns the public URL. **This command uploads only — it does not submit to the challenger queue.** Use `web-submit` instead.
+
+### submit (legacy — no longer ingested as a submission)
+
+Submit an on-chain commitment pointing to a hosted pack via `set_commitment`.
 
 ```bash
 trajectoryrl-miner submit https://your-bucket.s3.amazonaws.com/pack.json
 ```
 
-Fetches the pack from the URL, verifies the hash, and calls `set_commitment` on-chain. The on-chain block number establishes first-mover precedence and is the timestamp validators use for snapshot eligibility.
-
-> **Rate limit**: One commitment per ~100 blocks (~20 min) per hotkey.
+Fetches the pack from the URL, verifies the hash, and calls `set_commitment` on-chain. **On-chain commitments are no longer ingested as submissions** (`CHAIN_SUBMIT_INGEST_ENABLED=false`). This command still exists in the CLI but will not queue your pack for evaluation. Use `web-submit` instead.
 
 ### status
 
@@ -241,15 +220,18 @@ The CLI reads wallet and storage config from environment variables. Create a `.e
 | `NETUID` | yes | `11` | Subnet ID |
 | `NETWORK` | yes | `finney` | Bittensor network |
 
-### Managed hosting (for `web-submit` command)
+### Web Submit (for `web-submit` command)
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `TRAJECTORYRL_API_BASE_URL` | no | `https://trajrl.com` | Override the web service base URL (for staging / self-hosted). The CLI also accepts `--api-base-url` per-invocation. |
+| `SUBMISSION_FEE_ALPHA` | no | `50` | Minimum α recycled per submission via `recycle_alpha(hotkey, amount, netuid=11)`. Recycling is irreversible. |
 
-No HMAC keys / bucket credentials needed — the request is signed with the miner's bittensor hotkey.
+No HMAC keys / bucket credentials needed — the request is signed with the miner's bittensor hotkey. You do need enough alpha in your hotkey's balance to cover the fee.
 
-### S3-Compatible Storage (for `upload` command)
+### S3-Compatible Storage (for legacy `upload` command only)
+
+> **Legacy** — these variables are only used by the `upload` CLI command. The `upload` command uploads a pack to your own bucket but does **not** submit it to the challenger queue. Use `web-submit` instead.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
@@ -295,23 +277,18 @@ For SKILL.md authoring patterns and what makes a pack score well, the canonical 
 │                                                         │
 │  1. Write / iterate on SKILL.md                         │
 │  2. build → pack.json                                   │
-│  3. Pick ONE submission path:                           │
-│       Path A (self-host + chain commit)                 │
-│         • upload  → self-hosted public URL              │
-│         • submit  → on-chain commitment                 │
-│       Path B (managed web submit)                       │
-│         • web-submit → platform queues the pack         │
-│                        directly; no chain commit        │
+│  3. web-submit → recycles fee on-chain, then platform   │
+│                  stores pack + queues it directly       │
 │  4. Wait for validator evaluation (one epoch)           │
 │  5. Check results, iterate                              │
 └─────────────────────────────────────────────────────────┘
 ```
 
-Validators only re-evaluate when your `pack_hash` changes. No need to resubmit if your SKILL.md hasn't changed — once your pack is in the queue (via chain commitment or via web-submit), it carries forward into every future epoch's eval set automatically. Eligibility is driven by the latest `miner_submissions` row for your hotkey, not by an off-chain heartbeat.
+Validators only re-evaluate when your `pack_hash` changes. No need to resubmit if your SKILL.md hasn't changed — once your pack is in the queue via `web-submit`, it carries forward into every future epoch's eval set automatically. Eligibility is driven by the latest `miner_submissions` row for your hotkey, not by an off-chain heartbeat.
 
 ### Submission timing — the freeze gap
 
-The eval set for an epoch is **frozen ahead of the epoch's start block** at `cutoff_time`, after which a new commitment is no longer eligible for that epoch's snapshot. Commitments that land inside the freeze window get evaluated in the **next** epoch instead.
+The eval set for an epoch is **frozen ahead of the epoch's start block** at `cutoff_time`, after which a new web-submit is no longer eligible for that epoch's snapshot. Submissions that land inside the freeze window get evaluated in the **next** epoch instead.
 
 ```
 ... ← previous epoch ──┬───── freeze gap ─────┐ epoch N starts ... eval runs ...
@@ -322,30 +299,17 @@ The eval set for an epoch is **frozen ahead of the epoch's start block** at `cut
 
 Practical rules of thumb:
 
-- **Want to be evaluated this epoch?** Get your `set_commitment` (Path A) or `web-submit` (Path B) confirmed at least a few hours before the next epoch boundary. Anything later goes into the epoch after.
-- **Pack already on chain, no `pack_hash` change?** You don't need to do anything — your commitment carries forward automatically.
+- **Want to be evaluated this epoch?** Get your `web-submit` confirmed at least a few hours before the next epoch boundary. Anything later goes into the epoch after.
+- **Pack already queued, no `pack_hash` change?** You don't need to do anything — your submission carries forward automatically.
 - **Switched packs late?** Pack swaps that miss the cutoff don't dodge anything; they simply land in the next snapshot. Validators evaluate the pack you had at cutoff, not the one you swap in mid-epoch.
 
 For the full window math (`cutoff_time`, `window_start`, `commit_block` semantics), see [INCENTIVE_MECHANISM.md § Snapshot eligibility window](INCENTIVE_MECHANISM.md#snapshot-eligibility-window).
-
-### Picking a hosting option
-
-| | `upload` (self-hosted) | `web-submit` (managed) |
-|---|---|---|
-| Infra you run | S3 / R2 / GCS bucket + HMAC keys | none — request is signed with your hotkey |
-| URL you control | yes (your domain / bucket) | no (random GCS key under `trajrl.com`) |
-| Rate limit | bucket-side, not enforced by subnet | 1 successful submission / hour / hotkey |
-| Idempotent re-submit | always (same key = same URL) | yes — same `(hotkey, pack_hash)` reuses URL after cooldown |
-| Pre-eval feedback loop | none — wait for next epoch's snapshot | server runs pre-eval async; reflected in the next epoch_snapshot |
-| Best for | miners with existing infra / custom storage | new miners or anyone wanting one-command publishing |
-
-Discovery differs by path: Path A relies on the on-chain `<pack_hash>|<pack_url>` written via `set_commitment`, which the platform's syncer ingests into `miner_submissions`. Path B writes the `miner_submissions` row directly via the API. Once the row exists, the challenger picker treats both sources identically.
 
 ---
 
 ## Local Testing
 
-Before submitting on-chain, run the full evaluation harness against your SKILL.md locally. This is the same harness the production validator runs.
+Before submitting, run the full evaluation harness against your SKILL.md locally. This is the same harness the production validator runs.
 
 ```bash
 git clone https://github.com/trajectoryRL/trajectoryRL.git


### PR DESCRIPTION
## Summary

Updates the canonical miner docs in `docs/` for the shipped submission-fee feature: **web-submit is the sole submission channel** and each submission is backed by a **`recycle_alpha` fee**. Mirrors the web `/docs/miner-guide` page (trajectoryrl.web#157) and the INCENTIVE/API doc sync (#291).

## Changes

**`docs/MINER_GUIDE.md`**
- Submission section → web-only (removed the Path A self-host + on-chain-commit framing).
- New **Submission Fee** section: `recycle_alpha`, default 50 α coldkey-signed, receipt verified on-chain, consumed at queue entry, reusable on technical failure within 24 h.
- FAQ resubmit cadence + `pack_hash` wording.

**`docs/MINER_OPERATIONS.md`**
- Web-only Quick Start / Typical Workflow; A-vs-B framing removed (kept the epoch freeze-gap timing guidance).
- New **Submission Fee** section + `SUBMISSION_FEE_ALPHA` (default 50) in the config tables.
- `upload` / `submit` (on-chain) marked **legacy — no longer ingested as a submission**; S3 env vars marked legacy (`upload` only).
- Cooldown corrected to **~20 min** (`MINER_SUBMIT_COOLDOWN_SECONDS=1200`) — was incorrectly "1 hour".
- Request signature **unchanged** and explicitly not bound to the receipt (`trajectoryrl-miner-submit:{hotkey}:{timestamp}`).

Docs-only. The reveal-gate duration and eval/scoring sections are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
