### PR TITLE
docs(validator): add engy as an LLM provider option next to OpenRouter

### DIFF
--- a/.env.validator.example
+++ b/.env.validator.example
@@ -7,6 +7,17 @@
 # OpenRouter is the recommended provider: one API key covers both the testee
 # (Qwen3.5-35B-A3B) and the judge (GLM-5.1) without juggling vendors. Get a
 # key at https://openrouter.ai/keys.
+#
+# Alternative — engy (https://engy.ai): the subnet's own OpenAI-compatible
+# inference API, served on its GPU fleet. One key serves Qwen3.6-35B-A3B (a
+# strong testee) and GLM-5.2, both with tool-calling. Get a key at
+# https://engy.ai, then set:
+#   LLM_API_KEY=sk-engy-...
+#   LLM_BASE_URL=https://api.engy.ai/v1
+#   LLM_MODEL=qwen3.6-35b-a3b
+# Any OpenAI-compatible endpoint works — the harness routes a non-OpenRouter,
+# non-Anthropic base URL through a generic "custom" provider automatically, so
+# no extra config is needed beyond these three vars.
 
 LLM_API_KEY=
 LLM_BASE_URL=https://openrouter.ai/api/v1
@@ -21,6 +32,7 @@ LLM_BASE_URL=https://openrouter.ai/api/v1
 # pairing finally differentiates real packs from no-skill baselines.
 
 # Testee model — what the miner's SKILL.md is being executed by.
+# (On engy, use LLM_MODEL=qwen3.6-35b-a3b — see the engy block above.)
 LLM_MODEL=qwen/qwen3.5-35b-a3b
 
 # Judge model — independent family from the testee. If JUDGE_MODEL is empty,

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ See [MINER_OPERATIONS.md](docs/MINER_OPERATIONS.md) for full CLI reference (`bui
 
 #### 3. Test locally (optional)
 
-Prereqs: Docker, an LLM API key (e.g. OpenRouter), ~10 GB free disk for the per-scenario images on first run.
+Prereqs: Docker, an LLM API key (e.g. OpenRouter or [engy](https://engy.ai)), ~10 GB free disk for the per-scenario images on first run.
 
 The validator and miner share the same harness — `scripts/eval_pack.py` runs your SKILL.md through every scenario in `SANDBOX_SCENARIOS` end-to-end, no chain interaction needed. It auto-pulls the sandbox-agent + scenario images on first invocation.
 


### PR DESCRIPTION
## What
Documents **engy** (https://engy.ai) — the subnet's own OpenAI-compatible inference API — as an LLM-provider option for the validator testee, placed right next to the existing OpenRouter guidance in `.env.validator.example`.

## Why
engy serves **Qwen3.6-35B-A3B** and **GLM-5.2** (both with tool-calling) on the subnet's GPU fleet, giving operators an alternative to OpenRouter for the testee LLM. The harness already routes any non-OpenRouter / non-Anthropic base URL through a generic `"custom"` provider (`sandbox-agent-entrypoint.sh`), so only three env vars change:

```
LLM_API_KEY=sk-engy-...
LLM_BASE_URL=https://api.engy.ai/v1
LLM_MODEL=qwen3.6-35b-a3b
```

## Changes
- `.env.validator.example`: engy provider block next to OpenRouter + an engy model-id note by `LLM_MODEL`.
- `README.md`: mention engy in the local-test prereqs.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
