### PR TITLE
feat(spec): activate deterministic-tarball + tree-directory-parser (SPEC 18→19)

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 18
+SPEC_NUMBER = 19
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -59,6 +59,7 @@ logger = logging.getLogger(__name__)
 SANDBOX_SCENARIOS: tuple[str, ...] = (
     "configure-git-webserver",
     "db-wal-recovery",
+    "deterministic-tarball",
     "git-leak-recovery",
     "git-multibranch",
     "largest-eigenval",
@@ -68,6 +69,7 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
     "regex-chess",
     "schemelike-metacircular-eval",
     "swe-bench-astropy-2",
+    "tree-directory-parser",
     "write-compressor",
 )
 
@@ -114,6 +116,14 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
 # git-multibranch + schemelike-metacircular-eval, so N goes 11→12 and the
 # score range becomes [0, 12]. The offset stays 0.0. Requires trajrl-bench
 # >= 4.0.14, which ships the new scenario images.
+#
+# SPEC 19 adds two real scenarios adapted from terminal-bench —
+# deterministic-tarball (reproducible-build archiving) + tree-directory-parser
+# (reconstruct a directory tree from a `tree -F` snapshot) — so N goes 12→14
+# and the score range becomes [0, 14]. The offset stays 0.0 (real scenarios,
+# not phantom refills). Requires the trajrl-bench release that ships the new
+# scenario images (>= 4.0.16); older bench images will report
+# "unknown scenario".
 REMOVED_SCENARIO_BASE_SCORE: float = 0.0
 
 


### PR DESCRIPTION
Companion to **trajrl-bench#71** (ships the two new scenario assets). This activates them on the validator.

## Change
- append `deterministic-tarball` + `tree-directory-parser` to `SANDBOX_SCENARIOS` (alphabetical) → **N 12 → 14**
- bump `SPEC_NUMBER` **18 → 19** (invalidates cached pack scores; seat re-competes on the new surface)
- `REMOVED_SCENARIO_BASE_SCORE` stays `0.0` (real scenarios, not phantom refills) → headline range **[0, 14]**

## ⚠️ Release ordering (do not merge/tag out of order)
The validator resolves each scenario image as `image_repo:<sandbox_tag>` (i.e. `scenario-<name>:latest` for the `:latest` channel), and the bench CI publishes those tags **only on a `v*` release**, not on merge-to-main. So:

1. Merge **trajrl-bench#71** to main.
2. Cut a **trajrl-bench release tag** (`v4.0.16`) → CI builds+pushes `scenario-deterministic-tarball` / `scenario-tree-directory-parser` under `:latest` (+ version tags). This is a bench release; it does **not** activate anything (still SPEC 18) — safe.
3. Merge **this PR**.
4. Cut the **validator release tag** → validators roll, pull the (now-published) images, and start running 14 scenarios at SPEC 19. **This is the step that changes live behavior.**

If this PR's release is tagged before the bench images exist, validators 404 on the image pull.

## Verification
- `SPEC_NUMBER == 19`, `len(SANDBOX_SCENARIOS) == 14`, list sorted, range [0,14].
- `tests/test_sandbox_harness.py`: 99 passed (the 1 failure, `test_env_var_clamps_to_at_least_one`, is pre-existing on `main` — a workstation `.env` artifact, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)