### PR TITLE
fix(verifier): inject agent deliverable as 0o755 (deterministic-tarball would score ~0)

### DIFF
--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -1914,7 +1914,14 @@ class TrajectorySandboxHarness:
                 with tarfile.open(fileobj=buf3, mode="w") as tar:
                     info = tarfile.TarInfo(name=out_path.name)
                     info.size = len(agent_output_bytes)
-                    info.mode = 0o644
+                    # 0o755, not 0o644: the deliverable is often an executable
+                    # script the verifier runs directly (e.g. deterministic-tarball
+                    # runs /app/build.sh and asserts os.X_OK; several scenarios also
+                    # assert the deliverable is executable). Extraction only carries
+                    # the bytes, not the agent's mode, so a hardcoded 0o644 strips
+                    # the exec bit and those scenarios score ~0 (EACCES). +x is
+                    # harmless for non-script deliverables (data.comp, *.patch, …).
+                    info.mode = 0o755
                     info.mtime = int(time.time())
                     tar.addfile(info, io.BytesIO(agent_output_bytes))
                 buf3.seek(0)


### PR DESCRIPTION
Reviewer catch on #296. The verifier injects the agent's `agent_output_path` into the fresh verifier container with a hardcoded mode; extraction carries only the bytes, so `0o644` strips the exec bit.

- **deterministic-tarball** (new, SPEC 19) runs `/app/build.sh` **directly** and asserts `os.access(..., os.X_OK)` → with 0o644 every test hits EACCES → **~0**.
- Existing script scenarios (git-leak recovery.sh, nginx setup.sh, …) only survived because their `test.sh` runs the deliverable via `bash <path>` (no exec bit needed).
- tree-directory-parser mostly uses `bash /app/cmd.sh` but also asserts `os.X_OK` → loses that one test at 0o644.

Fix: inject at **0o755**. Harmless for non-script deliverables (data.comp, *.patch, *.json, *.py imported on PYTHONPATH).

**Proof**: `0o644` → `os.X_OK=False` + `PermissionError` on exec; `0o755` → runs. Harness unit tests: 99 pass (the 1 failure is the pre-existing `.env` `test_env_var_clamps` artifact on main).

Must land in **v0.6.26** — the release that activates deterministic-tarball. Not yet tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)