### PR TITLE
feat(spec): activate SPEC 20 — 14→17 scenarios (+pcap-to-netflow +3d-model-format-legacy +custom-memory-heap-crash)

### DIFF
--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 19
+SPEC_NUMBER = 20
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -57,7 +57,9 @@ logger = logging.getLogger(__name__)
 # bumps. Adding or removing a scenario must come with a SPEC_NUMBER bump
 # so cached scores invalidate. Sorted alphabetically for stability.
 SANDBOX_SCENARIOS: tuple[str, ...] = (
+    "3d-model-format-legacy",
     "configure-git-webserver",
+    "custom-memory-heap-crash",
     "db-wal-recovery",
     "deterministic-tarball",
     "git-leak-recovery",
@@ -65,6 +67,7 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
     "largest-eigenval",
     "nginx-request-logging",
     "path-tracing",
+    "pcap-to-netflow",
     "race-condition-fix",
     "regex-chess",
     "schemelike-metacircular-eval",
@@ -123,6 +126,18 @@ SANDBOX_SCENARIOS: tuple[str, ...] = (
 # and the score range becomes [0, 14]. The offset stays 0.0 (real scenarios,
 # not phantom refills). Requires the trajrl-bench release that ships the new
 # scenario images (>= 4.0.16); older bench images will report
+# "unknown scenario".
+#
+# SPEC 20 adds three real scenarios adapted from terminal-bench —
+# pcap-to-netflow (pcap capture → binary NetFlow v5 export, verified by
+# re-running the export script), 3d-model-format-legacy (reverse-engineer a
+# legacy binary 3D model format + modernize a win32-era C++ library, verified
+# by JSON field checks + a cmake rebuild), custom-memory-heap-crash (fix a
+# release-only custom-allocator lifetime bug behind a patched libstdc++,
+# verified by debug+release recompiles + Valgrind) — so N goes 14→17 and the
+# score range becomes [0, 17]. The offset stays 0.0 (real scenarios, not
+# phantom refills). Requires the trajrl-bench release that ships the new
+# scenario images (>= 4.0.18); older bench images will report
 # "unknown scenario".
 REMOVED_SCENARIO_BASE_SCORE: float = 0.0
 


### PR DESCRIPTION
Cuts the validator over to SPEC 20:

- `SPEC_NUMBER` 19 → 20 (`config.py`)
- `SANDBOX_SCENARIOS` 14 → 17 entries, inserted alphabetically (`sandbox_harness.py`): `3d-model-format-legacy` (sorts first — `3` < letters), `custom-memory-heap-crash` (after `configure-git-webserver`), `pcap-to-netflow` (after `path-tracing`)
- New SPEC 20 comment paragraph; score range becomes [0, 17], offset stays 0.0

Requires **trajrl-bench >= 4.0.18** (trajectoryRL/trajrl-bench#75), which ships the three scenario images — merge order: bench release first, then this.

Harness suite: `tests/test_sandbox_harness.py` 100 passed.

**DO NOT MERGE until the bench v4.0.18 tag CI has published the scenario images** — a validator running SPEC 20 before the images exist reports "unknown scenario".

🤖 Generated with [Claude Code](https://claude.com/claude-code)