### PR TITLE
feat(spec): schedule-driven eval spec — follow /epoch/current spec_number

### DIFF
--- a/tests/test_spec_resolution.py
+++ b/tests/test_spec_resolution.py
@@ -1,0 +1,320 @@
+"""Schedule-driven spec resolution (web /epoch/current → eval scenario set).
+
+Covers the three layers of the cutover-sync feature:
+  1. ``SCENARIOS_BY_SPEC`` registry + ``resolve_eval_spec`` clamp/fallback
+     in ``sandbox_harness``.
+  2. Per-eval scenario threading through ``evaluate_miner_s1`` /
+     ``harness.evaluate_miner``.
+  3. ``TrajectoryValidator`` eval loop adopting the server-reported
+     ``epoch.spec_number`` for scenario selection and outgoing payloads.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Mock bittensor so importing trajectoryrl.* doesn't pull in the SDK.
+_mock_bt = MagicMock()
+
+
+class _MockSynapse:
+    pass
+
+
+_mock_bt.Synapse = _MockSynapse
+sys.modules["bittensor"] = _mock_bt
+
+from trajectoryrl.utils.config import SPEC_NUMBER
+from trajectoryrl.utils import sandbox_harness as sh
+from trajectoryrl.utils.commitments import MinerCommitment
+
+
+SPEC21_ADDITIONS = {"audio-synth-stft-peaks", "puzzle-solver", "query-optimize"}
+
+
+# ---------------------------------------------------------------------------
+# 1. Registry
+# ---------------------------------------------------------------------------
+
+
+class TestScenarioRegistry:
+    def test_registry_covers_current_and_previous_spec(self):
+        assert SPEC_NUMBER in sh.SCENARIOS_BY_SPEC
+        assert SPEC_NUMBER - 1 in sh.SCENARIOS_BY_SPEC
+
+    def test_sandbox_scenarios_is_local_spec_set(self):
+        assert sh.SANDBOX_SCENARIOS == sh.SCENARIOS_BY_SPEC[SPEC_NUMBER]
+
+    def test_spec20_is_spec21_minus_additions(self):
+        spec21 = set(sh.SCENARIOS_BY_SPEC[21])
+        spec20 = set(sh.SCENARIOS_BY_SPEC[20])
+        assert spec21 - spec20 == SPEC21_ADDITIONS
+        assert spec20 < spec21
+        assert len(spec20) == 17 and len(spec21) == 20
+
+    def test_scenario_sets_sorted_and_unique(self):
+        for spec, scenarios in sh.SCENARIOS_BY_SPEC.items():
+            assert list(scenarios) == sorted(set(scenarios)), spec
+
+
+# ---------------------------------------------------------------------------
+# 2. resolve_eval_spec
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEvalSpec:
+    def test_known_spec_exact_match(self):
+        spec, scenarios = sh.resolve_eval_spec(20)
+        assert spec == 20
+        assert scenarios == sh.SCENARIOS_BY_SPEC[20]
+
+    def test_local_spec_exact_match(self):
+        spec, scenarios = sh.resolve_eval_spec(SPEC_NUMBER)
+        assert spec == SPEC_NUMBER
+        assert scenarios == sh.SCENARIOS_BY_SPEC[SPEC_NUMBER]
+
+    def test_numeric_string_coerced(self):
+        spec, _ = sh.resolve_eval_spec("20")
+        assert spec == 20
+
+    def test_none_falls_back_to_local(self):
+        spec, scenarios = sh.resolve_eval_spec(None)
+        assert spec == SPEC_NUMBER
+        assert scenarios == sh.SCENARIOS_BY_SPEC[SPEC_NUMBER]
+
+    def test_unknown_newer_spec_falls_back_to_local(self, caplog):
+        with caplog.at_level("WARNING"):
+            spec, _ = sh.resolve_eval_spec(99)
+        assert spec == SPEC_NUMBER
+        assert any("99" in r.message for r in caplog.records)
+
+    def test_unknown_older_spec_falls_back_to_local(self):
+        spec, _ = sh.resolve_eval_spec(3)
+        assert spec == SPEC_NUMBER
+
+    def test_garbage_falls_back_to_local(self):
+        spec, _ = sh.resolve_eval_spec("not-a-spec")
+        assert spec == SPEC_NUMBER
+
+
+# ---------------------------------------------------------------------------
+# 3. Validator threading
+# ---------------------------------------------------------------------------
+
+
+def _bare_validator():
+    """A TrajectoryValidator shell with just the attrs the tick path uses."""
+    from trajectoryrl.base.validator import TrajectoryValidator
+
+    v = TrajectoryValidator.__new__(TrajectoryValidator)
+    v.config = MagicMock()
+    v.wallet = MagicMock()
+    v.subtensor = MagicMock()
+    v.subtensor.get_current_block.return_value = 123
+    v.pack_fetcher = MagicMock()
+    v._sandbox_harness = MagicMock()
+    v._sandbox_harness.harness_name = "trajrl-bench"
+    v._sandbox_harness.harness_version = "0.0.0"
+    v._sandbox_harness.bench_image_hash = "unknown"
+    v._sandbox_harness.scenario_image_hash = "unknown"
+    v._sandbox_harness.sandbox_version = "unknown"
+    v._last_scored_challenge_epoch_id = None
+    v._last_set_weights_at = None
+    v._last_eval_at = None
+    v._last_set_weights_block = 0
+    v._save_eval_state = lambda: None
+    return v
+
+
+def _epoch_block(spec_number, epoch_id=777):
+    return {
+        "challenge_epoch_id": epoch_id,
+        "challenger_hotkey": "hk-challenger",
+        "challenger_pack_hash": "ab" * 32,
+        "challenger_pack_url": "https://example.com/pack.json",
+        "start_block": 100,
+        "end_block": 200,
+        "epoch_length_blocks": 100,
+        "status": "in_progress",
+        "spec_number": spec_number,
+    }
+
+
+class TestEvalLoopSpecThreading:
+    def test_tick_passes_api_spec_to_score_challenger(self, monkeypatch):
+        from trajectoryrl.base import validator as vmod
+
+        v = _bare_validator()
+        seen = {}
+
+        async def fake_refresh():
+            pass
+
+        async def fake_fetch(*a, **k):
+            return {"epoch": _epoch_block(20), "elapsed_blocks": 0}
+
+        async def fake_score(epoch_id, commitment, eval_spec, eval_scenarios):
+            seen["spec"] = eval_spec
+            seen["scenarios"] = eval_scenarios
+
+        v._refresh_winner_cache = fake_refresh
+        v._score_challenger = fake_score
+        monkeypatch.setattr(vmod, "fetch_current_epoch", fake_fetch)
+
+        asyncio.run(v._eval_loop_tick())
+        assert seen["spec"] == 20
+        assert seen["scenarios"] == sh.SCENARIOS_BY_SPEC[20]
+
+    def test_tick_unknown_api_spec_falls_back_to_local(self, monkeypatch):
+        from trajectoryrl.base import validator as vmod
+
+        v = _bare_validator()
+        seen = {}
+
+        async def fake_refresh():
+            pass
+
+        async def fake_fetch(*a, **k):
+            return {"epoch": _epoch_block(99), "elapsed_blocks": 0}
+
+        async def fake_score(epoch_id, commitment, eval_spec, eval_scenarios):
+            seen["spec"] = eval_spec
+
+        v._refresh_winner_cache = fake_refresh
+        v._score_challenger = fake_score
+        monkeypatch.setattr(vmod, "fetch_current_epoch", fake_fetch)
+
+        asyncio.run(v._eval_loop_tick())
+        assert seen["spec"] == SPEC_NUMBER
+
+
+class TestScoreChallengerSpecThreading:
+    def _run_score(self, monkeypatch, eval_spec, eval_scenarios):
+        from trajectoryrl.base import validator as vmod
+
+        v = _bare_validator()
+        submitted = {}
+
+        v._get_validator_log_offset = lambda: 0
+        v._prepare_eval_log_capture = lambda *a, **k: (MagicMock(), 0, 0)
+
+        async def fake_eval(commitment, epoch_id, spec, scenarios):
+            submitted["eval_spec"] = spec
+            submitted["eval_scenarios"] = scenarios
+            return {
+                "success": True,
+                "qualified": {"regex-chess": True},
+                "judge_details": {"regex-chess": {"overall_score": 1.0}},
+            }
+
+        async def fake_submit(wallet, **kwargs):
+            submitted["payload_spec"] = kwargs.get("spec_number")
+            return True
+
+        async def fake_upload(*a, **k):
+            pass
+
+        v._evaluate_challenger = fake_eval
+        v._fire_upload_eval_logs = fake_upload
+        v._fire_upload_cycle_logs = fake_upload
+        monkeypatch.setattr(vmod, "submit_challenge_score", fake_submit)
+
+        commitment = MinerCommitment(
+            uid=1, hotkey="hk", pack_hash="ab" * 32,
+            pack_url="https://example.com/p.json", block_number=100,
+            raw="r",
+        )
+        asyncio.run(
+            v._score_challenger(777, commitment, eval_spec, eval_scenarios)
+        )
+        return submitted
+
+    def test_submits_resolved_spec_not_local_constant(self, monkeypatch):
+        scenarios = sh.SCENARIOS_BY_SPEC[20]
+        submitted = self._run_score(monkeypatch, 20, scenarios)
+        assert submitted["payload_spec"] == 20
+        assert submitted["eval_spec"] == 20
+        assert submitted["eval_scenarios"] == scenarios
+
+
+# ---------------------------------------------------------------------------
+# 4. Harness / miner_eval scenario threading
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessScenarioParam:
+    def test_run_eval_sync_accepts_scenario_subset(self, monkeypatch):
+        """_run_eval_sync must iterate the passed-in scenario set, not the
+        module global."""
+        harness = sh.TrajectorySandboxHarness.__new__(sh.TrajectorySandboxHarness)
+        loaded = []
+
+        def fake_load(name):
+            loaded.append(name)
+            raise RuntimeError("stop after recording")
+
+        harness._pull_sync = lambda: None
+        harness._load_scenario_info = fake_load
+        harness._scenario_info = None
+
+        with pytest.raises(RuntimeError):
+            harness._run_eval_sync(
+                "skill", 1, "salt", "ph",
+                scenarios=("db-wal-recovery",),
+            )
+        assert loaded == ["db-wal-recovery"]
+
+    def test_evaluate_miner_s1_threads_scenarios(self, monkeypatch):
+        from trajectoryrl.utils import miner_eval as me
+
+        seen = {}
+
+        class _FakeResult:
+            error = None
+            aborted_mid_session = False
+            scenarios = ["db-wal-recovery"]
+            scenario_qualities = {"db-wal-recovery": 1.0}
+            scenario_costs_usd = {}
+            score = 1.0
+            mean_quality = 1.0
+
+            class session_result:
+                episodes = []
+
+        class _FakeHarness:
+            sandbox_scenarios = ["db-wal-recovery"]
+            sandbox_version = "test"
+
+            async def evaluate_miner(self, **kwargs):
+                seen["scenarios"] = kwargs.get("scenarios")
+                return _FakeResult()
+
+        class _FakeVerification:
+            valid = True
+            error = None
+            pack_content = {"files": {"SKILL.md": "# s"}}
+
+        class _FakeFetcher:
+            async def verify_submission(self, pack_url, pack_hash):
+                return _FakeVerification()
+
+        commitment = MinerCommitment(
+            uid=1, hotkey="hk", pack_hash="ab" * 32,
+            pack_url="https://example.com/p.json", block_number=100,
+            raw="r",
+        )
+        outcome = asyncio.run(
+            me.evaluate_miner_s1(
+                harness=_FakeHarness(),
+                pack_fetcher=_FakeFetcher(),
+                commitment=commitment,
+                epoch_seed=1,
+                validator_salt="salt",
+                scenarios=("db-wal-recovery",),
+            )
+        )
+        assert seen["scenarios"] == ("db-wal-recovery",)
+        assert outcome.success

--- a/trajectoryrl/base/validator.py
+++ b/trajectoryrl/base/validator.py
@@ -34,7 +34,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import bittensor as bt
 
 from ..utils.config import ValidatorConfig
-from ..utils.sandbox_harness import TrajectorySandboxHarness
+from ..utils.sandbox_harness import TrajectorySandboxHarness, resolve_eval_spec
 from ..utils.github import PackFetcher
 from ..utils import config as _config_mod
 from ..utils.commitments import MinerCommitment
@@ -490,8 +490,11 @@ class TrajectoryValidator:
         miner_log_offset: int,
         block_height: int,
         challenge_epoch_id: int,
+        eval_spec: Optional[int] = None,
     ) -> None:
         """Collect and upload eval logs. Fire-and-forget."""
+        if eval_spec is None:
+            eval_spec = _spec_number()
         s1_result = eval_result.get("_s1_sandbox_result") if eval_result else None
         if s1_result is not None:
             try:
@@ -511,7 +514,7 @@ class TrajectoryValidator:
                 "miner_uid": uid,
                 "block_height": block_height,
                 "pack_hash": commitment.pack_hash,
-                "spec_number": _spec_number(),
+                "spec_number": eval_spec,
                 "type": "eval",
             }
             try:
@@ -531,7 +534,7 @@ class TrajectoryValidator:
                 pack_hash=commitment.pack_hash,
                 log_archive=log_archive,
                 epoch_number=challenge_epoch_id,
-                spec_number=_spec_number(),
+                spec_number=eval_spec,
             )
             if ok:
                 try:
@@ -545,8 +548,11 @@ class TrajectoryValidator:
         cycle_log_offset: int,
         block_height: int,
         challenge_epoch_id: int,
+        eval_spec: Optional[int] = None,
     ) -> None:
         """Upload the validator log segment for one challenger cycle."""
+        if eval_spec is None:
+            eval_spec = _spec_number()
         import io
         import tarfile
 
@@ -581,7 +587,7 @@ class TrajectoryValidator:
                 "eval_id": eval_id,
                 "challenge_epoch_id": challenge_epoch_id,
                 "block_height": block_height,
-                "spec_number": _spec_number(),
+                "spec_number": eval_spec,
                 "type": "cycle",
             }
             try:
@@ -598,7 +604,7 @@ class TrajectoryValidator:
                 block_height=block_height,
                 log_archive=archive,
                 epoch_number=challenge_epoch_id,
-                spec_number=_spec_number(),
+                spec_number=eval_spec,
             )
             if ok:
                 try:
@@ -800,6 +806,8 @@ class TrajectoryValidator:
         self,
         commitment: MinerCommitment,
         challenge_epoch_id: int,
+        eval_spec: int,
+        eval_scenarios: Tuple[str, ...],
     ) -> Optional[Dict[str, Any]]:
         """Run a single trajrl-bench evaluation on the active challenger."""
         mlog = self._get_miner_logger(commitment.hotkey)
@@ -839,7 +847,7 @@ class TrajectoryValidator:
                 cost_usd=cost_usd,
                 duration_s=duration_s,
                 timed_out=timed_out,
-                spec_number=_spec_number(),
+                spec_number=eval_spec,
                 harness_name=self._sandbox_harness.harness_name,
                 harness_version=self._sandbox_harness.harness_version,
                 llm_model=self.config.llm_model,
@@ -896,6 +904,7 @@ class TrajectoryValidator:
             on_episode_verifying=on_episode_verifying,
             on_episode_done=on_episode_done,
             is_epoch_still_current=is_epoch_still_current,
+            scenarios=eval_scenarios,
         )
 
         if not outcome.success:
@@ -1035,7 +1044,23 @@ class TrajectoryValidator:
             )
             return
 
-        await self._score_challenger(challenge_epoch_id, commitment)
+        # The scoring spec for this epoch comes from the server's
+        # spec_schedule (docs/API.md /epoch/current `spec_number`), not
+        # from the local SPEC_NUMBER constant — a deployed-but-not-yet-
+        # effective spec stays dormant until its scheduled cutover
+        # epoch. resolve_eval_spec falls back to the local constant on
+        # a missing/unknown value.
+        eval_spec, eval_scenarios = resolve_eval_spec(epoch.get("spec_number"))
+        if eval_spec != _spec_number():
+            logger.info(
+                "Epoch %s evaluates under SPEC %d per server schedule "
+                "(local binary default: SPEC %d)",
+                challenge_epoch_id, eval_spec, _spec_number(),
+            )
+
+        await self._score_challenger(
+            challenge_epoch_id, commitment, eval_spec, eval_scenarios,
+        )
 
     async def _refresh_winner_cache(self):
         """Pull /api/v2/winner/current, run local derivation, persist cache."""
@@ -1051,8 +1076,16 @@ class TrajectoryValidator:
             logger.warning("Failed to persist winner cache: %s", e)
 
     async def _score_challenger(
-        self, challenge_epoch_id: int, commitment: MinerCommitment,
+        self,
+        challenge_epoch_id: int,
+        commitment: MinerCommitment,
+        eval_spec: Optional[int] = None,
+        eval_scenarios: Optional[Tuple[str, ...]] = None,
     ):
+        # Callers normally pass the schedule-resolved spec; None (e.g.
+        # legacy call sites) falls back to the local binary default.
+        if eval_spec is None or eval_scenarios is None:
+            eval_spec, eval_scenarios = resolve_eval_spec(eval_spec)
         eval_id = (
             datetime.datetime.utcnow().strftime("%Y%m%d_%H%M%S")
             + f"_e{challenge_epoch_id}"
@@ -1073,7 +1106,9 @@ class TrajectoryValidator:
             eval_id, commitment.hotkey,
         )
 
-        eval_result = await self._evaluate_challenger(commitment, challenge_epoch_id)
+        eval_result = await self._evaluate_challenger(
+            commitment, challenge_epoch_id, eval_spec, eval_scenarios,
+        )
 
         # Harness aborted mid-session because the epoch had moved on.
         # Drop the eval entirely — POSTing the partial sum would punish
@@ -1137,7 +1172,7 @@ class TrajectoryValidator:
             rejected=rejected if rejected else None,
             rejection_detail=rejection_detail if rejected else None,
             scenario_results=scenario_results or None,
-            spec_number=_spec_number(),
+            spec_number=eval_spec,
             llm_base_url=self.config.llm_base_url,
             llm_model=self.config.llm_model,
             judge_model=self.config.judge_model or None,
@@ -1150,12 +1185,12 @@ class TrajectoryValidator:
             self._save_eval_state()
 
         # Fire-and-forget log uploads
-        eval_scenarios = list(scenario_results.keys()) if scenario_results else []
+        ran_scenarios = list(scenario_results.keys()) if scenario_results else []
         try:
             await self._fire_upload_eval_logs(
-                eval_id, commitment.uid, commitment, eval_scenarios,
+                eval_id, commitment.uid, commitment, ran_scenarios,
                 eval_result, eval_dir, vlog_offset, mlog_offset,
-                block_height, challenge_epoch_id,
+                block_height, challenge_epoch_id, eval_spec,
             )
         except Exception as e:
             logger.warning("Eval log upload failed: %s", e)
@@ -1163,7 +1198,7 @@ class TrajectoryValidator:
         try:
             await self._fire_upload_cycle_logs(
                 eval_id, self._cycle_log_offset, self._cycle_log_block,
-                challenge_epoch_id,
+                challenge_epoch_id, eval_spec,
             )
         except Exception as e:
             logger.warning("Cycle log upload failed: %s", e)

--- a/trajectoryrl/utils/miner_eval.py
+++ b/trajectoryrl/utils/miner_eval.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Optional, Sequence
 
 from .commitments import MinerCommitment
 from .github import PackFetcher
@@ -82,6 +82,7 @@ async def evaluate_miner_s1(
     on_episode_verifying: Optional[Callable[[str, int, int], None]] = None,
     on_episode_done: Optional[Callable[[_EpisodeResult, int, int], None]] = None,
     is_epoch_still_current: Optional[Callable[[str], bool]] = None,
+    scenarios: Optional[Sequence[str]] = None,
 ) -> MinerEvalOutcome:
     """Evaluate a single miner's pack via trajrl-bench (Season 1).
 
@@ -102,6 +103,9 @@ async def evaluate_miner_s1(
             string lets the harness fall back to its built-in default.
         mlog: Optional per-miner logger for transcript tails. Falls back
             to module logger when omitted.
+        scenarios: Scenario set for this eval (a ``SCENARIOS_BY_SPEC``
+            entry picked from the server's spec schedule). Defaults to
+            the harness's ``SANDBOX_SCENARIOS`` (local binary's spec).
 
     Returns:
         ``MinerEvalOutcome`` describing success or skip reason. On
@@ -189,6 +193,7 @@ async def evaluate_miner_s1(
             on_episode_verifying=on_episode_verifying,
             on_episode_done=on_episode_done,
             is_epoch_still_current=is_epoch_still_current,
+            scenarios=scenarios,
         )
     except Exception as e:
         log.error("S1 evaluation failed: %s", e, exc_info=True)

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -41,43 +41,105 @@ import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
 import docker
 from docker.models.containers import Container
 from docker.types import LogConfig
 
-from ..utils.config import ValidatorConfig
+from ..utils.config import SPEC_NUMBER, ValidatorConfig
 
 logger = logging.getLogger(__name__)
 
 
-# Scenarios run per session, in order. Every validator runs the full set
-# so scores are comparable across validators / windows / SPEC_NUMBER
-# bumps. Adding or removing a scenario must come with a SPEC_NUMBER bump
-# so cached scores invalidate. Sorted alphabetically for stability.
-SANDBOX_SCENARIOS: tuple[str, ...] = (
-    "3d-model-format-legacy",
-    "audio-synth-stft-peaks",
-    "configure-git-webserver",
-    "custom-memory-heap-crash",
-    "db-wal-recovery",
-    "deterministic-tarball",
-    "git-leak-recovery",
-    "git-multibranch",
-    "largest-eigenval",
-    "nginx-request-logging",
-    "path-tracing",
-    "pcap-to-netflow",
-    "puzzle-solver",
-    "query-optimize",
-    "race-condition-fix",
-    "regex-chess",
-    "schemelike-metacircular-eval",
-    "swe-bench-astropy-2",
-    "tree-directory-parser",
-    "write-compressor",
-)
+# Scenario sets keyed by scoring spec (SPEC_NUMBER). The set to run for
+# a given epoch is chosen from the server-reported ``epoch.spec_number``
+# (web's ``spec_schedule``) via ``resolve_eval_spec`` — validators can
+# deploy a new release ahead of a scheduled cutover and auto-switch
+# scenario sets at the cutover epoch, with no coordinated redeploy.
+# Every validator runs the full set for a spec so scores are comparable
+# across validators / windows. Keep the previous spec's set during the
+# transition window; retire entries once their cutover is long past.
+# Adding or removing a scenario must come with a SPEC_NUMBER bump so
+# cached scores invalidate. Each set sorted alphabetically for
+# stability.
+SCENARIOS_BY_SPEC: Dict[int, tuple[str, ...]] = {
+    # SPEC 20 (activated 2026-07-08, challenge_epochs.id 2815).
+    20: (
+        "3d-model-format-legacy",
+        "configure-git-webserver",
+        "custom-memory-heap-crash",
+        "db-wal-recovery",
+        "deterministic-tarball",
+        "git-leak-recovery",
+        "git-multibranch",
+        "largest-eigenval",
+        "nginx-request-logging",
+        "path-tracing",
+        "pcap-to-netflow",
+        "race-condition-fix",
+        "regex-chess",
+        "schemelike-metacircular-eval",
+        "swe-bench-astropy-2",
+        "tree-directory-parser",
+        "write-compressor",
+    ),
+    # SPEC 21: +audio-synth-stft-peaks +puzzle-solver +query-optimize.
+    21: (
+        "3d-model-format-legacy",
+        "audio-synth-stft-peaks",
+        "configure-git-webserver",
+        "custom-memory-heap-crash",
+        "db-wal-recovery",
+        "deterministic-tarball",
+        "git-leak-recovery",
+        "git-multibranch",
+        "largest-eigenval",
+        "nginx-request-logging",
+        "path-tracing",
+        "pcap-to-netflow",
+        "puzzle-solver",
+        "query-optimize",
+        "race-condition-fix",
+        "regex-chess",
+        "schemelike-metacircular-eval",
+        "swe-bench-astropy-2",
+        "tree-directory-parser",
+        "write-compressor",
+    ),
+}
+
+# Default scenario set: the local binary's spec. A SPEC_NUMBER bump
+# without a matching registry entry fails loudly at import time.
+SANDBOX_SCENARIOS: tuple[str, ...] = SCENARIOS_BY_SPEC[SPEC_NUMBER]
+
+
+def resolve_eval_spec(api_spec: Any) -> tuple[int, tuple[str, ...]]:
+    """Resolve (spec, scenario set) for an eval from the server-reported
+    ``epoch.spec_number``.
+
+    Exact registry match wins; anything else (missing field, garbage,
+    or a spec this binary doesn't ship — older-than-registry or
+    newer-than-binary) falls back to the local ``SPEC_NUMBER`` so the
+    validator keeps evaluating instead of going silent. A fallback
+    under a too-new required spec means this binary is outdated: its
+    scores will be dropped by the web consensus floor until upgraded,
+    which is the correct pressure.
+    """
+    try:
+        spec = int(api_spec)
+    except (TypeError, ValueError):
+        spec = None
+    if spec is not None and spec in SCENARIOS_BY_SPEC:
+        return spec, SCENARIOS_BY_SPEC[spec]
+    if spec is not None:
+        logger.warning(
+            "Server requires SPEC %d but this binary only ships %s; "
+            "falling back to local SPEC %d (upgrade the validator if "
+            "the required spec is newer)",
+            spec, sorted(SCENARIOS_BY_SPEC), SPEC_NUMBER,
+        )
+    return SPEC_NUMBER, SCENARIOS_BY_SPEC[SPEC_NUMBER]
 
 # Headline-score offset for scenarios that have been retired from the
 # rotation. When we drop saturated scenarios (mean score ≥ ~0.8 in the
@@ -1068,10 +1130,15 @@ class TrajectorySandboxHarness:
             logger.warning("Failed to query sandbox version: %s", e)
 
         # Pull the per-scenario environment images for every scenario
-        # this validator runs. ``scenario_image_hashes`` keys each one
-        # for audit / submit-payload metadata.
+        # this validator may run — the union across SCENARIOS_BY_SPEC,
+        # so a schedule-driven fallback to the previous spec finds its
+        # images warm. ``scenario_image_hashes`` keys each one for
+        # audit / submit-payload metadata.
+        all_spec_scenarios = sorted(
+            {name for names in SCENARIOS_BY_SPEC.values() for name in names}
+        )
         self.scenario_image_hashes = {}
-        for scenario_name in SANDBOX_SCENARIOS:
+        for scenario_name in all_spec_scenarios:
             try:
                 self._scenario_info = None  # force re-fetch per scenario
                 self._load_scenario_info(scenario_name)
@@ -1172,8 +1239,14 @@ class TrajectorySandboxHarness:
         on_episode_verifying: Optional[Callable[[str, int, int], None]] = None,
         on_episode_done: Optional[Callable[[_EpisodeResult, int, int], None]] = None,
         is_epoch_still_current: Optional[Callable[[str], bool]] = None,
+        scenarios: Optional[Sequence[str]] = None,
     ) -> SandboxEvaluationResult:
         """Run the multi-scenario session.
+
+        ``scenarios`` selects the scenario set for this eval (a
+        ``SCENARIOS_BY_SPEC`` entry picked per epoch from the server's
+        spec schedule). Defaults to ``SANDBOX_SCENARIOS`` — the local
+        binary's spec.
 
         Callbacks (all optional, all invoked from the executor thread,
         all best-effort — exceptions are caught and logged):
@@ -1203,10 +1276,11 @@ class TrajectorySandboxHarness:
             f"{self.config.wallet_hotkey}:{self.config.netuid}".encode()
         ).hexdigest()[:16]
 
+        eval_scenarios = tuple(scenarios) if scenarios else tuple(SANDBOX_SCENARIOS)
         logger.info(
             "eval starting: pack_hash=%s, seed=%d, scenarios=%s",
             pack_hash[:12] if pack_hash else "?",
-            epoch_seed, list(SANDBOX_SCENARIOS),
+            epoch_seed, list(eval_scenarios),
         )
 
         loop = asyncio.get_event_loop()
@@ -1218,6 +1292,7 @@ class TrajectorySandboxHarness:
                     on_episode_verifying=on_episode_verifying,
                     on_episode_done=on_episode_done,
                     is_epoch_still_current=is_epoch_still_current,
+                    scenarios=eval_scenarios,
                 ),
             )
         except Exception as e:
@@ -1240,6 +1315,7 @@ class TrajectorySandboxHarness:
         on_episode_verifying: Optional[Callable[[str, int, int], None]] = None,
         on_episode_done: Optional[Callable[[_EpisodeResult, int, int], None]] = None,
         is_epoch_still_current: Optional[Callable[[str], bool]] = None,
+        scenarios: Optional[Sequence[str]] = None,
     ) -> _SessionResult:
         """One container per scenario, one episode each.
 
@@ -1277,8 +1353,9 @@ class TrajectorySandboxHarness:
         # Pre-load metadata for every scenario so we fail early on a
         # missing one. Each ``_load_scenario_info`` call also primes the
         # per-scenario image ref + tests payload.
+        eval_scenarios = tuple(scenarios) if scenarios else tuple(SANDBOX_SCENARIOS)
         scenario_specs: list[dict] = []
-        for name in SANDBOX_SCENARIOS:
+        for name in eval_scenarios:
             self._scenario_info = None  # bust cache; loop reads each
             info = self._load_scenario_info(name)
             scenario_image = self._scenario_image_ref()


### PR DESCRIPTION
## Summary

Makes the validator's eval spec **schedule-driven**: the scenario set for each epoch is picked from the server-reported `epoch.spec_number` (`GET /api/v2/epoch/current`, backed by web's `spec_schedule`) instead of the hardcoded local `SPEC_NUMBER` constant. Both sides can now deploy a new SPEC ahead of time and the cutover flips atomically at the scheduled `effective_epoch` — no coordinated redeploy, no stake-majority soft-transition window.

## Changes

**`sandbox_harness.py`**
- `SCENARIOS_BY_SPEC` registry keyed by spec (currently 20 + 21); `SANDBOX_SCENARIOS` now derives from the local `SPEC_NUMBER` — a future SPEC bump without a registry entry fails loudly at import.
- `resolve_eval_spec(api_spec)`: exact registry match wins; missing/garbage/unknown values (including a required spec newer than this binary) fall back to the local `SPEC_NUMBER` with a warning, so the validator keeps evaluating instead of going silent. A too-new required spec means the binary is outdated and its scores get dropped by the web consensus floor — the correct upgrade pressure.
- Scenario image pull covers the **union** across the registry, so a schedule fallback to the previous spec finds its images warm. `scenario_image_hash` ordering (audit string) is unchanged.
- `evaluate_miner` / `_run_eval_sync` accept a per-eval `scenarios` parameter.

**`miner_eval.py`** — `evaluate_miner_s1(..., scenarios=)` pass-through.

**`validator.py`**
- `_eval_loop_tick` resolves the epoch's spec and threads `(eval_spec, eval_scenarios)` through `_score_challenger` → `_evaluate_challenger`.
- Score submission, per-scenario progress posts, and eval/cycle log upload metadata all report the spec **actually evaluated** rather than the local constant. Heartbeat and persisted eval-state keep the local constant.

## Behavior at the SPEC 21 cutover

With this deployed and the `spec_schedule` row for 21 not yet inserted/effective, validators eval under SPEC 20 (17 scenarios) and report `spec_number=20`; the tick logs when the schedule spec differs from the binary default. When the SPEC 21 row's `effective_epoch` arrives, all upgraded validators switch to the 20-scenario set on the same epoch — aligned with web's consensus floor and the winner-rescore trigger.

## Testing

- New `tests/test_spec_resolution.py` (16 tests): registry shape (spec 20 = spec 21 minus the 3 additions), resolver clamp/fallback semantics, eval-loop → `_score_challenger` threading, submitted-payload spec, harness scenario-subset plumbing.
- Full suite: **234 passed** (incl. the 16 new), 5 failed — the failures are the pre-existing `TestSleepUntilNextEpoch` stale tests on `main` (method removed in the poll-interval rework), untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
