### PR TITLE
feat(spec22): register 23-scenario set, SPEC_NUMBER=22

### DIFF
--- a/tests/test_spec_resolution.py
+++ b/tests/test_spec_resolution.py
@@ -33,6 +33,7 @@ from trajectoryrl.utils.commitments import MinerCommitment
 
 
 SPEC21_ADDITIONS = {"audio-synth-stft-peaks", "puzzle-solver", "query-optimize"}
+SPEC22_ADDITIONS = {"crack-7z-hash", "parallel-particle-simulator", "regex-engine-from-scratch"}
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +59,15 @@ class TestScenarioRegistry:
     def test_scenario_sets_sorted_and_unique(self):
         for spec, scenarios in sh.SCENARIOS_BY_SPEC.items():
             assert list(scenarios) == sorted(set(scenarios)), spec
+
+
+class TestSpec22Set:
+    def test_spec22_is_spec21_plus_additions(self):
+        spec21 = set(sh.SCENARIOS_BY_SPEC[21])
+        spec22 = set(sh.SCENARIOS_BY_SPEC[22])
+        assert spec22 - spec21 == SPEC22_ADDITIONS
+        assert spec21 < spec22
+        assert len(spec21) == 20 and len(spec22) == 23
 
 
 # ---------------------------------------------------------------------------

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 21
+SPEC_NUMBER = 22
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -107,6 +107,34 @@ SCENARIOS_BY_SPEC: Dict[int, tuple[str, ...]] = {
         "tree-directory-parser",
         "write-compressor",
     ),
+    # SPEC 22: +crack-7z-hash +parallel-particle-simulator
+    # +regex-engine-from-scratch. Requires trajrl-bench >= 4.0.20
+    # (v4.0.19 predates the particle-sim + regex-engine images).
+    22: (
+        "3d-model-format-legacy",
+        "audio-synth-stft-peaks",
+        "configure-git-webserver",
+        "crack-7z-hash",
+        "custom-memory-heap-crash",
+        "db-wal-recovery",
+        "deterministic-tarball",
+        "git-leak-recovery",
+        "git-multibranch",
+        "largest-eigenval",
+        "nginx-request-logging",
+        "parallel-particle-simulator",
+        "path-tracing",
+        "pcap-to-netflow",
+        "puzzle-solver",
+        "query-optimize",
+        "race-condition-fix",
+        "regex-chess",
+        "regex-engine-from-scratch",
+        "schemelike-metacircular-eval",
+        "swe-bench-astropy-2",
+        "tree-directory-parser",
+        "write-compressor",
+    ),
 }
 
 # Default scenario set: the local binary's spec. A SPEC_NUMBER bump


### PR DESCRIPTION
Registers `SCENARIOS_BY_SPEC[22]` (23 names) + `SPEC_NUMBER=22`. Mirrors trajectoryrl.web SCORING_BY_SPEC[22] and trajrl-bench v4.0.20 images. Keeps SPEC 21 entry for the transition window. 17 spec-resolution tests pass (incl. sorted/unique + registry-coverage).

Requires bench >= 4.0.20 (v4.0.19 predates particle-sim + regex-engine images). Version bump is a separate PR per house rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)