### PR TITLE
feat(spec23): SCENARIOS_BY_SPEC[23] + SPEC_NUMBER=23

### DIFF
--- a/tests/test_spec_resolution.py
+++ b/tests/test_spec_resolution.py
@@ -34,6 +34,7 @@ from trajectoryrl.utils.commitments import MinerCommitment
 
 SPEC21_ADDITIONS = {"audio-synth-stft-peaks", "puzzle-solver", "query-optimize"}
 SPEC22_ADDITIONS = {"crack-7z-hash", "parallel-particle-simulator", "regex-engine-from-scratch"}
+SPEC23_ADDITIONS = {"attention-mil", "llm-inference-batching-scheduler", "torch-tensor-parallelism"}
 
 
 # ---------------------------------------------------------------------------
@@ -68,6 +69,15 @@ class TestSpec22Set:
         assert spec22 - spec21 == SPEC22_ADDITIONS
         assert spec21 < spec22
         assert len(spec21) == 20 and len(spec22) == 23
+
+
+class TestSpec23Set:
+    def test_spec23_is_spec22_plus_additions(self):
+        spec22 = set(sh.SCENARIOS_BY_SPEC[22])
+        spec23 = set(sh.SCENARIOS_BY_SPEC[23])
+        assert spec23 - spec22 == SPEC23_ADDITIONS
+        assert spec22 < spec23
+        assert len(spec22) == 23 and len(spec23) == 26
 
 
 # ---------------------------------------------------------------------------

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 22
+SPEC_NUMBER = 23
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -135,6 +135,37 @@ SCENARIOS_BY_SPEC: Dict[int, tuple[str, ...]] = {
         "tree-directory-parser",
         "write-compressor",
     ),
+    # SPEC 23: +attention-mil +llm-inference-batching-scheduler
+    # +torch-tensor-parallelism. Requires trajrl-bench >= 4.0.21 (ships the
+    # three new scenario images and the shared sandbox-agent-torch base).
+    23: (
+        "3d-model-format-legacy",
+        "attention-mil",
+        "audio-synth-stft-peaks",
+        "configure-git-webserver",
+        "crack-7z-hash",
+        "custom-memory-heap-crash",
+        "db-wal-recovery",
+        "deterministic-tarball",
+        "git-leak-recovery",
+        "git-multibranch",
+        "largest-eigenval",
+        "llm-inference-batching-scheduler",
+        "nginx-request-logging",
+        "parallel-particle-simulator",
+        "path-tracing",
+        "pcap-to-netflow",
+        "puzzle-solver",
+        "query-optimize",
+        "race-condition-fix",
+        "regex-chess",
+        "regex-engine-from-scratch",
+        "schemelike-metacircular-eval",
+        "swe-bench-astropy-2",
+        "torch-tensor-parallelism",
+        "tree-directory-parser",
+        "write-compressor",
+    ),
 }
 
 # Default scenario set: the local binary's spec. A SPEC_NUMBER bump


### PR DESCRIPTION
The eval scenario set grows 23 → 26 with `attention-mil`, `llm-inference-batching-scheduler`, and `torch-tensor-parallelism`.

This requires trajrl-bench >= 4.0.21 (already tagged and published), which ships the three new scenario images and the shared sandbox-agent-torch base.

The `22:` entry in `SCENARIOS_BY_SPEC` is deliberately retained for the transition window. `resolve_eval_spec` matches on registry membership only, so removing it would make validators evaluate the 26-scenario set while labelling results `spec_number=22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)