### PR TITLE
feat(spec24): SCENARIOS_BY_SPEC[24] + SPEC_NUMBER=24 (first replacement bump)

### DIFF
--- a/tests/test_spec_resolution.py
+++ b/tests/test_spec_resolution.py
@@ -35,6 +35,10 @@ from trajectoryrl.utils.commitments import MinerCommitment
 SPEC21_ADDITIONS = {"audio-synth-stft-peaks", "puzzle-solver", "query-optimize"}
 SPEC22_ADDITIONS = {"crack-7z-hash", "parallel-particle-simulator", "regex-engine-from-scratch"}
 SPEC23_ADDITIONS = {"attention-mil", "llm-inference-batching-scheduler", "torch-tensor-parallelism"}
+# SPEC 24 is the first *replacement* bump: it removes AND adds (net size unchanged),
+# so it is asserted as a swap, not a subset like the additive specs above.
+SPEC24_ADDITIONS = {"fix-code-vulnerability", "large-scale-text-editing", "postgres-csv-clean"}
+SPEC24_REMOVALS = {"schemelike-metacircular-eval", "3d-model-format-legacy", "pcap-to-netflow"}
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +82,22 @@ class TestSpec23Set:
         assert spec23 - spec22 == SPEC23_ADDITIONS
         assert spec22 < spec23
         assert len(spec22) == 23 and len(spec23) == 26
+
+
+class TestSpec24Set:
+    def test_spec24_swaps_three_scenarios(self):
+        spec23 = set(sh.SCENARIOS_BY_SPEC[23])
+        spec24 = set(sh.SCENARIOS_BY_SPEC[24])
+        assert spec24 - spec23 == SPEC24_ADDITIONS
+        assert spec23 - spec24 == SPEC24_REMOVALS
+        # Replacement, not a superset: net size stays 26.
+        assert not (spec23 < spec24)
+        assert len(spec23) == len(spec24) == 26
+
+    def test_spec23_still_resolves_during_transition(self):
+        # resolve_eval_spec must still serve SPEC 23 while validators roll forward.
+        assert sh.SCENARIOS_BY_SPEC[23]
+        assert sh.resolve_eval_spec(23) == (23, sh.SCENARIOS_BY_SPEC[23])
 
 
 # ---------------------------------------------------------------------------

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -41,7 +41,7 @@ SANDBOX_IMAGE_REPO = "ghcr.io/trajectoryrl/sandbox-agent"
 # consulted only as the fallback target when no on-chain spec_number group
 # reaches >50% stake, and as the value written into outgoing commitments /
 # payloads.
-SPEC_NUMBER = 23
+SPEC_NUMBER = 24
 
 # Backwards-compatible alias for legacy callers / persisted state. Will be
 # removed after one validator release cycle.

--- a/trajectoryrl/utils/sandbox_harness.py
+++ b/trajectoryrl/utils/sandbox_harness.py
@@ -166,6 +166,39 @@ SCENARIOS_BY_SPEC: Dict[int, tuple[str, ...]] = {
         "tree-directory-parser",
         "write-compressor",
     ),
+    # SPEC 24 — first replacement bump: swaps scenarios rather than growing N.
+    # Retires schemelike-metacircular-eval, 3d-model-format-legacy, pcap-to-netflow
+    # (dead signal); adds fix-code-vulnerability, large-scale-text-editing,
+    # postgres-csv-clean. Net size stays 26. Keep the 23 entry for the transition
+    # window (resolve_eval_spec serves it while validators roll forward).
+    24: (
+        "attention-mil",
+        "audio-synth-stft-peaks",
+        "configure-git-webserver",
+        "crack-7z-hash",
+        "custom-memory-heap-crash",
+        "db-wal-recovery",
+        "deterministic-tarball",
+        "fix-code-vulnerability",
+        "git-leak-recovery",
+        "git-multibranch",
+        "large-scale-text-editing",
+        "largest-eigenval",
+        "llm-inference-batching-scheduler",
+        "nginx-request-logging",
+        "parallel-particle-simulator",
+        "path-tracing",
+        "postgres-csv-clean",
+        "puzzle-solver",
+        "query-optimize",
+        "race-condition-fix",
+        "regex-chess",
+        "regex-engine-from-scratch",
+        "swe-bench-astropy-2",
+        "torch-tensor-parallelism",
+        "tree-directory-parser",
+        "write-compressor",
+    ),
 }
 
 # Default scenario set: the local binary's spec. A SPEC_NUMBER bump


### PR DESCRIPTION
## Summary

Validator side of **SPEC 24** — the first *replacement* scenario bump. Swaps three dead-signal scenarios for three replacements; the active set stays at 26.

- **Removed** (dead signal on prod `eval_log_scenario_summaries`): `schemelike-metacircular-eval` (1 nonzero result in 2600 lifetime evals), `3d-model-format-legacy`, `pcap-to-netflow`.
- **Added** (shipped in trajrl-bench **v4.0.22**): `fix-code-vulnerability`, `large-scale-text-editing`, `postgres-csv-clean`.

## Changes

- `trajectoryrl/utils/config.py` — `SPEC_NUMBER` 23 → 24.
- `trajectoryrl/utils/sandbox_harness.py` — `SCENARIOS_BY_SPEC[24]` (26 names, alphabetical). The `23` entry is kept for the transition window (`resolve_eval_spec` serves it while validators roll forward; `SANDBOX_SCENARIOS = SCENARIOS_BY_SPEC[SPEC_NUMBER]` would KeyError at import without the current spec's entry).
- `tests/test_spec_resolution.py` — `TestSpec24Set`: the first **removals + additions** swap assertion (net size 26, `not spec23 < spec24`), plus SPEC 23 still resolving during the transition.

`test_spec_resolution.py` — 20 passed.

## Rollout

Companion web `SCORING_BY_SPEC[24]` is merged + deployed; bench v4.0.22 is released. The VERSION bump to **0.6.32** follows in a separate `chore/bump-version-0.6.32` PR (house rule). Deployed-but-unscheduled specs stay dormant — the `spec_schedule (24, effective_epoch)` INSERT is the last step and is what actually flips eval behavior, gated on this being deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)