### PR TITLE
Lock testee + judge model/endpoint in code (ignore operator env)

### DIFF
--- a/.env.validator.example
+++ b/.env.validator.example
@@ -2,44 +2,27 @@
 # Copy to .env.validator and fill in your values:  cp .env.validator.example .env.validator
 
 # =============================================================================
-# LLM API Configuration (OpenAI-compatible) — engy recommended (the default)
+# LLM API key — engy (https://engy.ai), the subnet's OpenAI-compatible API
 # =============================================================================
-# engy (https://engy.ai) is the subnet's own OpenAI-compatible inference API,
-# served on its GPU fleet. One key serves Qwen3.8-27B (the default
-# testee) and GLM-5.2, both with tool-calling. Get a key at https://engy.ai;
-# only LLM_API_KEY needs filling — base URL and model below are the defaults.
+# The models and endpoints are FIXED IN THE VALIDATOR CODE and identical for
+# every validator, because miners must be scored against the same model or
+# scores aren't comparable:
+#   - Testee (runs the miner's SKILL.md): Qwen3.8-27B on engy
+#   - Judge  (scores the testee):         GLM-5.2 on engy
+# A different family for the judge keeps its bias uncorrelated with the testee —
+# that split is what lets scoring separate real packs from no-skill baselines.
 #
-# Alternative — OpenRouter: get a key at https://openrouter.ai/keys, then set:
-#   LLM_API_KEY=sk-or-...
-#   LLM_BASE_URL=https://openrouter.ai/api/v1
-#   LLM_MODEL=qwen/qwen3.8-27b
-# Any OpenAI-compatible endpoint works — the harness routes a non-OpenRouter,
-# non-Anthropic base URL through a generic "custom" provider automatically, so
-# no extra config is needed beyond these three vars.
-
+# You therefore do NOT set the model or base URL here. Any LLM_MODEL /
+# LLM_BASE_URL / JUDGE_MODEL / JUDGE_BASE_URL you set is IGNORED (the validator
+# logs a warning). Changing the fleet's model is a code change + release, not an
+# operator setting.
+#
+# You supply only your engy API key. Get one at https://engy.ai.
 LLM_API_KEY=
-LLM_BASE_URL=https://api.engy.ai/v1
 
-# =============================================================================
-# Model selection — testee + independent judge
-# =============================================================================
-# As of v0.5.14, the recommended setup is Qwen3.8-27B as the testee
-# (the agent that solves the SKILL.md task) and GLM-5.1 as the judge (the
-# agent that scores the testee). The model split keeps judge bias
-# uncorrelated with testee bias — the v3.4.0 codebase_fix work showed this
-# pairing finally differentiates real packs from no-skill baselines.
-
-# Testee model — what the miner's SKILL.md is being executed by.
-# (On OpenRouter, use LLM_MODEL=qwen/qwen3.8-27b — see the block above.)
-LLM_MODEL=qwen3.8-27b
-
-# Judge model — independent family from the testee. If JUDGE_MODEL is empty,
-# judge falls back to LLM_MODEL (not recommended for production).
-JUDGE_MODEL=z-ai/glm-5.1
+# The judge shares the same engy endpoint, so JUDGE_API_KEY can stay empty to
+# reuse LLM_API_KEY. Set it only for a separate engy billing/quota lane.
 JUDGE_API_KEY=
-JUDGE_BASE_URL=https://openrouter.ai/api/v1
-# Tip: leaving JUDGE_API_KEY empty re-uses LLM_API_KEY when the base URL
-# matches; set it explicitly if you want a separate billing/quota lane.
 
 # =============================================================================
 # Bittensor

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ btcli stake add --wallet-name my-validator --hotkey default --netuid 11 --amount
 
 # 2. Configure
 cp .env.validator.example .env.validator
-# Edit: set WALLET_NAME, LLM_API_KEY, LLM_BASE_URL, LLM_MODEL (the model
-# the testee agent uses to solve scenarios).
+# Edit: set WALLET_NAME and LLM_API_KEY (your engy key). The testee/judge
+# models and endpoints are fixed in the validator code — not set here.
 
 # 3. Start
 docker compose -f docker/docker-compose.validator.yml --env-file .env.validator up -d

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,9 +30,7 @@ WALLET_NAME=validator
 WALLET_HOTKEY=default
 NETUID=11
 NETWORK=finney
-LLM_API_KEY=...
-LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
-LLM_MODEL=zhipu/glm-5.1
+LLM_API_KEY=...                   # your engy key; models/endpoints code-locked
 
 # Optional
 LOG_LEVEL=INFO                    # DEBUG for development

--- a/docker/docker-compose.validator.yml
+++ b/docker/docker-compose.validator.yml
@@ -13,9 +13,7 @@
 #   WALLET_HOTKEY=default
 #   NETUID=11
 #   NETWORK=finney
-#   LLM_API_KEY=...
-#   LLM_BASE_URL=https://open.bigmodel.cn/api/paas/v4
-#   LLM_MODEL=glm-5.1
+#   LLM_API_KEY=...        # your engy key (models/endpoints are code-locked)
 
 services:
   validator:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,70 @@
+"""Validator LLM config is code-locked, not operator-overridable.
+
+The testee model and inference endpoint that miners are scored against must
+be identical across the whole validator fleet, otherwise scores are not
+comparable. So ``ValidatorConfig.from_env`` pins the model + base URL (and the
+judge's model + base URL, which default to the primary) to the code constants
+and ignores any ``LLM_MODEL`` / ``LLM_BASE_URL`` / ``JUDGE_MODEL`` /
+``JUDGE_BASE_URL`` set in the operator environment. Only the secrets
+(``LLM_API_KEY`` / ``JUDGE_API_KEY``) remain env-driven — they cannot be
+committed to a public repo.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from trajectoryrl.utils.config import (
+    ValidatorConfig,
+    DEFAULT_LLM_MODEL,
+    DEFAULT_LLM_BASE_URL,
+    DEFAULT_JUDGE_MODEL,
+    DEFAULT_JUDGE_BASE_URL,
+)
+
+# A dotenv path that does not exist, so ``load_dotenv`` is a no-op and the test
+# is driven purely by ``monkeypatch.setenv`` — never the live .env.validator.
+_NO_DOTENV = Path("/nonexistent/.env.validator")
+
+
+def test_llm_model_override_is_ignored(monkeypatch):
+    monkeypatch.setenv("LLM_MODEL", "operator-picked-other-model")
+    cfg = ValidatorConfig.from_env(dotenv_path=_NO_DOTENV)
+    assert cfg.llm_model == DEFAULT_LLM_MODEL
+
+
+def test_llm_base_url_override_is_ignored(monkeypatch):
+    monkeypatch.setenv("LLM_BASE_URL", "https://openrouter.ai/api/v1")
+    cfg = ValidatorConfig.from_env(dotenv_path=_NO_DOTENV)
+    assert cfg.llm_base_url == DEFAULT_LLM_BASE_URL
+
+
+def test_judge_model_override_is_ignored(monkeypatch):
+    # The judge is locked to a fixed model distinct from the testee (keeps judge
+    # bias uncorrelated), so the env override is ignored — NOT collapsed onto
+    # the testee model.
+    monkeypatch.setenv("JUDGE_MODEL", "operator-picked-judge-model")
+    cfg = ValidatorConfig.from_env(dotenv_path=_NO_DOTENV)
+    assert cfg.judge_model == DEFAULT_JUDGE_MODEL
+    assert cfg.judge_model != cfg.llm_model  # judge stays decorrelated from testee
+
+
+def test_judge_base_url_override_is_ignored(monkeypatch):
+    monkeypatch.setenv("JUDGE_BASE_URL", "https://openrouter.ai/api/v1")
+    cfg = ValidatorConfig.from_env(dotenv_path=_NO_DOTENV)
+    assert cfg.judge_base_url == DEFAULT_JUDGE_BASE_URL
+
+
+def test_llm_api_key_still_read_from_env(monkeypatch):
+    # The one exception: the API key is a secret and stays operator-supplied.
+    monkeypatch.setenv("LLM_API_KEY", "sk-operator-secret")
+    cfg = ValidatorConfig.from_env(dotenv_path=_NO_DOTENV)
+    assert cfg.llm_api_key == "sk-operator-secret"
+
+
+def test_warns_when_a_locked_var_is_overridden(monkeypatch, caplog):
+    monkeypatch.setenv("LLM_MODEL", "operator-picked-other-model")
+    with caplog.at_level(logging.WARNING, logger="trajectoryrl.utils.config"):
+        ValidatorConfig.from_env(dotenv_path=_NO_DOTENV)
+    assert any("LLM_MODEL" in r.getMessage() and "ignored" in r.getMessage().lower()
+               for r in caplog.records)

--- a/trajectoryrl/utils/config.py
+++ b/trajectoryrl/utils/config.py
@@ -8,12 +8,41 @@ from typing import List, Optional
 
 logger = logging.getLogger(__name__)
 
-# Default eval LLM: Qwen3.8-27B via engy (https://engy.ai) — the
-# subnet's own OpenAI-compatible inference API, served on its GPU fleet
-# with tool-calling enabled. See .env.validator.example. Override
-# per-validator with LLM_BASE_URL / LLM_MODEL.
+# Eval LLM: Qwen3.8-27B via engy (https://engy.ai) — the subnet's own
+# OpenAI-compatible inference API, served on its GPU fleet with tool-calling
+# enabled. The testee model and endpoint are CODE-LOCKED: every validator must
+# score miners against the identical model/endpoint or scores are not
+# comparable, so these are not operator-overridable (see from_env). Changing
+# the fleet's testee model = editing these constants and cutting a release; the
+# new image rolls out fleet-wide via watchtower. Operators supply only their
+# secret LLM_API_KEY / JUDGE_API_KEY.
 DEFAULT_LLM_BASE_URL = "https://api.engy.ai/v1"
 DEFAULT_LLM_MODEL = "qwen3.8-27b"
+
+# Judge LLM — also code-locked, and deliberately a DIFFERENT model family from
+# the testee (GLM vs Qwen) so judge bias stays uncorrelated with testee bias;
+# that decorrelation is what lets scoring separate real packs from no-skill
+# baselines. Served by the same engy endpoint, so one operator key covers both
+# (JUDGE_API_KEY may stay empty to reuse LLM_API_KEY). Not operator-overridable.
+DEFAULT_JUDGE_MODEL = "glm-5.2"
+DEFAULT_JUDGE_BASE_URL = "https://api.engy.ai/v1"
+
+# LLM env vars that are intentionally ignored (the model/endpoint are locked
+# above). Set-but-ignored values are surfaced as a warning so operators aren't
+# confused about why their override had no effect.
+_LOCKED_LLM_ENV_VARS = ("LLM_MODEL", "LLM_BASE_URL", "JUDGE_MODEL", "JUDGE_BASE_URL")
+
+
+def _warn_ignored_llm_env() -> None:
+    """Warn when an operator sets a locked LLM env var; it has no effect."""
+    overridden = [v for v in _LOCKED_LLM_ENV_VARS if os.getenv(v)]
+    if overridden:
+        logger.warning(
+            "Ignored operator env %s: the testee model and inference endpoint "
+            "are fixed by the validator for scoring consistency across the "
+            "fleet (only LLM_API_KEY / JUDGE_API_KEY are operator-supplied).",
+            ", ".join(overridden),
+        )
 
 # Image channel drives the tag of the sandbox-agent image pulled by the
 # validator at runtime. Compose files set this per-channel (latest,
@@ -266,6 +295,8 @@ class ValidatorConfig:
             dotenv_path = Path(__file__).parent.parent.parent / ".env.validator"
         load_dotenv(dotenv_path)
 
+        _warn_ignored_llm_env()
+
         return cls(
             # --- Bittensor ---
             wallet_name=os.getenv("WALLET_NAME", "validator"),
@@ -280,13 +311,21 @@ class ValidatorConfig:
             pack_cache_dir=Path(os.getenv("PACK_CACHE_DIR", "/var/lib/trajectoryrl/packs")),
             log_dir=Path(os.getenv("LOG_DIR", "./logs")),
             # --- LLM ---
-            llm_model=os.getenv("LLM_MODEL", DEFAULT_LLM_MODEL),
+            # Model + endpoint are code-locked (NOT operator-overridable) so the
+            # whole validator fleet scores miners against an identical testee —
+            # LLM_MODEL / LLM_BASE_URL in the operator env are ignored (see
+            # _warn_ignored_llm_env). Only the API key stays env-driven: it is a
+            # secret and must never be committed to this public repo.
+            llm_model=DEFAULT_LLM_MODEL,
             llm_api_key=os.getenv("LLM_API_KEY", ""),
-            llm_base_url=os.getenv("LLM_BASE_URL", DEFAULT_LLM_BASE_URL),
-            # --- LLM Judge (optional, falls back to primary LLM if empty) ---
-            judge_model=os.getenv("JUDGE_MODEL", ""),
+            llm_base_url=DEFAULT_LLM_BASE_URL,
+            # --- LLM Judge: model + base URL are code-locked to a fixed model
+            # distinct from the testee (see DEFAULT_JUDGE_MODEL); JUDGE_MODEL /
+            # JUDGE_BASE_URL are ignored. Only JUDGE_API_KEY stays env-driven
+            # (empty ⇒ reuse LLM_API_KEY, since the judge shares engy).
+            judge_model=DEFAULT_JUDGE_MODEL,
             judge_api_key=os.getenv("JUDGE_API_KEY", ""),
-            judge_base_url=os.getenv("JUDGE_BASE_URL", ""),
+            judge_base_url=DEFAULT_JUDGE_BASE_URL,
             # --- Operational ---
             log_level=os.getenv("LOG_LEVEL", "INFO"),
             # --- Consensus CAS ---


### PR DESCRIPTION
## Why

The testee model/endpoint and judge model/endpoint must be **identical across the whole validator fleet** — otherwise miner scores aren't comparable. Today they come from operator env (`LLM_MODEL` / `LLM_BASE_URL` / `JUDGE_MODEL` / `JUDGE_BASE_URL`), so a central release **cannot** move the fleet's model: operators pinning the old value silently override the code default. That's exactly the symptom we hit — validators upgraded to the new image (v0.6.33) but kept **reporting the old model** (`qwen3.6-35b-a3b`) because their `.env.validator` still pinned it and watchtower preserves the baked env on image swap.

## What

Lock the values to code constants in `ValidatorConfig.from_env`:

| role | model | endpoint |
|------|-------|----------|
| testee | `qwen3.8-27b` | engy (`https://api.engy.ai/v1`) |
| judge | `glm-5.2` | engy |

- Judge is a **different family** (GLM vs Qwen) so its bias stays decorrelated from the testee — the split is what lets scoring separate real packs from no-skill baselines. Both served by engy, so one operator key covers both.
- `LLM_MODEL` / `LLM_BASE_URL` / `JUDGE_MODEL` / `JUDGE_BASE_URL` are **ignored**; a `WARNING` is logged if an operator still sets one.
- **Only `LLM_API_KEY` / `JUDGE_API_KEY` stay env-driven** (secrets — can't be committed to a public repo). `JUDGE_API_KEY` empty ⇒ reuses `LLM_API_KEY` (judge shares engy).

## Rollout effect

Changing the fleet's model is now **code change + release**: the new image rolls out via watchtower and every validator adopts the locked model on restart — **no per-operator `.env` edit required**. Fixes the "runs new image, reports old model" gap fleet-wide.

## Tests

New `tests/test_config.py` (6 tests, all green): each locked var's env override is ignored, the judge stays distinct from the testee, the API-key exception still reads from env, and the warning fires. Full suite: 244 passed (the 5 pre-existing `TestSleepUntilNextEpoch` failures are unrelated — a stale test referencing a since-removed `_sleep_until_next_epoch`, confirmed failing on a clean tree).

## Docs

`.env.validator.example`, `README.md`, `docker/README.md`, and the compose comment updated to show only the API key is operator-supplied. `docs/legacy/` left untouched.

## Follow-up (not in this PR)

After merge: bump `VERSION` → tag `v0.6.34` → watchtower rolls it out → fleet auto-adopts `qwen3.8-27b` + `glm-5.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)